### PR TITLE
Add NetBeans IDE project metadata to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 config.php
 # NetBeans project metadata
-/nbproject/private/
+nbproject/

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 config.php
+# NetBeans project metadata
+/nbproject/private/


### PR DESCRIPTION
OK to add IDE meta data to .gitignore? If no one disagrees in a day or two I will merge this PR (unless someone else does it first).

Fwiw, I think companies/ subdirectories _except_ for weberpdemo should also be ignored as a convenient safety precaution, but perhaps first "weberpdemo" should be renamed "default" for clarity. I'll post this to Discussions  and if there is support for the proposal I'll investigate doing the work.