### PR TITLE
Add login_data.sql for fresh installs, as suggested by @pakricard. Fixes #311.

### DIFF
--- a/install/tables/login_data.sql
+++ b/install/tables/login_data.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `login_data` (
+  `sessionid` char(32) DEFAULT NULL,
+  `userid` varchar(20) DEFAULT NULL,
+  `login` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `script` varchar(100) NOT NULL DEFAULT '',
+  KEY `sessionid` (`sessionid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3

--- a/sql/updates/11.php
+++ b/sql/updates/11.php
@@ -1,7 +1,7 @@
 <?php
 
 CreateTable('login_data', 'CREATE TABLE `login_data` (
-  `sessionid` char(26),
+  `sessionid` char(32),
   `userid` varchar(20),
   `login` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `script` varchar(100) NOT NULL DEFAULT "",


### PR DESCRIPTION
Also corrected datatype char length in 11.php. sessionid length is 32 characters.