### PR TITLE
revamp the shell scripts in the build directory

### DIFF
--- a/build/TruncateAuditTrail.sql
+++ b/build/TruncateAuditTrail.sql
@@ -1,2 +1,2 @@
-USE weberpdemo;
+-- USE weberpdemo;
 TRUNCATE TABLE audittrail;

--- a/build/check_syntax.sh
+++ b/build/check_syntax.sh
@@ -1,17 +1,17 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-#ROOT_DIR=$PWD
-#cd $ROOT_DIR/..
-for f in `find . -name "*.php" -o -name "*.inc"`
-do
-    newname=`echo $f | cut -c3-`
-    filename="$newname"
-    echo $filename
-    output=$((php -l $filename ) 2>&1)
+BASE_DIR="$(dirname -- "$(dirname -- "$(realpath "${BASH_SOURCE[0]}")")")";
 
-    if [ $? != 0 ]
-    then
-		echo '**Error** '$output >> ~/weberp$(date +%Y%m%d).log
-		echo '' >> ~/weberp$(date +%Y%m%d).log
+cd "$BASE_DIR";
+
+date_suffix="$(date +%Y%m%d)"
+# NB: this will break if some developer starts using spaces in file names...
+files="$(find . -name '*.php' -o -name '*.inc' | grep -v './vendor/' | sort | tr '\n' ' ')"
+
+for filename in $files; do
+	echo "Checking $filename ..."
+	output="$(php -l "$filename" 2>&1)"
+    if [ $? != 0 ]; then
+    	echo "**ERROR** $output" >&2
     fi
 done

--- a/build/create_tarball.sh
+++ b/build/create_tarball.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASE_DIR="$(dirname -- "$(dirname -- "$(realpath "${BASH_SOURCE[0]}")")")";
+
+# @todo grab this from a cli option (use getopts for parsing those)
+OUTPUT_DIR="$HOME";
+
+cd "$BASE_DIR";
+current_dir="${PWD##*/}"
+cd ..
+
+if [ -f "$OUTPUT_DIR/webERP.zip" ]; then rm "$OUTPUT_DIR/webERP.zip"; fi
+
+zip -r "$OUTPUT_DIR/webERP" "$current_dir" -x \*.git* \*/config.php \*build*

--- a/build/dump_database.sh
+++ b/build/dump_database.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -e
+
+# @todo grab these from env vars. Also, add support for mysql host and port, as well as a variable for the db schema name
+MYSQL_USER=root;
+MYSQL_PWD=a;
+
+BASE_DIR="$(dirname -- "$(dirname -- "$(realpath "${BASH_SOURCE[0]}")")")";
+
+mysql -u"$MYSQL_USER"  -p"$MYSQL_PWD" weberpdemo < "$BASE_DIR/build/TruncateAuditTrail.sql"
+
+echo "SET FOREIGN_KEY_CHECKS = 0;" > "$BASE_DIR/sql/mysql/country_sql/default.sql"
+
+mysqldump -u"$MYSQL_USER"  -p"$MYSQL_PWD"  --skip-opt --create-options --skip-set-charset --ignore-table=weberpdemo.mrpsupplies \
+	--ignore-table=weberpdemo.mrpplanedorders --ignore-table=weberpdemo.mrpparameters --ignore-table=weberpdemo.levels \
+	--ignore-table=weberpdemo.mrprequirements --ignore-table=weberpdemo.buckets --no-data weberpdemo | \
+	sed 's/ AUTO_INCREMENT=[0-9]*//g' >> "$BASE_DIR/sql/mysql/country_sql/default.sql"
+
+mysqldump -u"$MYSQL_USER"  -p"$MYSQL_PWD" --skip-opt --skip-set-charset --quick --no-create-info weberpdemo \
+       accountgroups \
+       bankaccounts \
+       chartmaster \
+       companies \
+       cogsglpostings \
+       currencies \
+       holdreasons \
+       locations \
+       paymentterms \
+       reportlinks \
+       salesglpostings \
+       systypes \
+       taxauthorities \
+       taxgroups \
+       taxauthrates \
+       taxcategories \
+       taxprovinces \
+       www_users \
+       edi_orders_segs \
+       edi_orders_seg_groups \
+       config \
+       unitsofmeasure \
+       paymentmethods \
+       scripts \
+       securitygroups \
+       securitytokens \
+       securityroles \
+       accountsection \
+       > "$BASE_DIR/sql/mysql/country_sql/weberp-base.sql"
+
+mysqldump -u$MYSQL_USER  -p$MYSQL_PWD --skip-opt --skip-set-charset --quick --ignore-table=weberpdemo.mrpsupplies \
+	--ignore-table=weberpdemo.mrpplanedorders --ignore-table=weberpdemo.mrpparameters --ignore-table=weberpdemo.levels \
+	--ignore-table=weberpdemo.mrprequirements --no-create-info weberpdemo \
+	> "$BASE_DIR/sql/mysql/country_sql/weberp-demo_data.sql"
+
+if [ -f "$BASE_DIR/sql/mysql/country_sql/demo.sql" ]; then rm  "$BASE_DIR/sql/mysql/country_sql/demo.sql"; fi
+echo "CREATE DATABASE IF NOT EXISTS weberpdemo;" > "$BASE_DIR/sql/mysql/country_sql/demo.sql"
+# @todo add default collation to be utf8mb4
+echo "USE weberpdemo;" >> "$BASE_DIR/sql/mysql/country_sql/demo.sql"
+
+cat "$BASE_DIR/sql/mysql/country_sql/default.sql" >> "$BASE_DIR/sql/mysql/country_sql/demo.sql"
+
+cat "$BASE_DIR/sql/mysql/country_sql/weberp-base.sql" >> "$BASE_DIR/sql/mysql/country_sql/default.sql"
+rm  "$BASE_DIR/sql/mysql/country_sql/weberp-base.sql"
+cat "$BASE_DIR/sql/mysql/country_sql/weberp-demo_data.sql" >> "$BASE_DIR/sql/mysql/country_sql/demo.sql"
+rm  "$BASE_DIR/sql/mysql/country_sql/weberp-demo_data.sql"
+
+echo "SET FOREIGN_KEY_CHECKS = 1;" >> "$BASE_DIR/sql/mysql/country_sql/default.sql"
+echo "UPDATE systypes SET typeno=0;" >> "$BASE_DIR/sql/mysql/country_sql/default.sql"
+echo "INSERT INTO shippers VALUES (1,'Default Shipper',0);" >> "$BASE_DIR/sql/mysql/country_sql/default.sql"
+echo "UPDATE config SET confvalue='1' WHERE confname='Default_Shipper';" >> "$BASE_DIR/sql/mysql/country_sql/default.sql"
+
+echo "SET FOREIGN_KEY_CHECKS = 1;" >> "$BASE_DIR/sql/mysql/country_sql/demo.sql"

--- a/build/make_release.sh
+++ b/build/make_release.sh
@@ -1,152 +1,17 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
-BASE_DIR=/var/www/html/webERP;
-OUTPUT_DIR=/home/Documents/webERP;
-MYSQL_USER=root;
-MYSQL_PWD=a;
+set -e
 
-cd $BASE_DIR;
+BASE_DIR="$(dirname -- "$(dirname -- "$(realpath "${BASH_SOURCE[0]}")")")";
 
-# xgettext: Extracts translatable strings from given input file paths
+echo "Updating translation files..."
 
-xgettext --no-wrap --from-code=utf-8 -L php -o locale/en_GB.utf8/LC_MESSAGES/messages.pot *.php api/*.php includes/*.inc includes/*.php install/*.php reportwriter/*.inc reportwriter/*.php reportwriter/admin/*.inc reportwriter/admin/*.php reportwriter/admin/forms/*.html reportwriter/forms/*.html reportwriter/languages/en_US/*.php ../webSHOP/*.php ../webSHOP/includes/*.php
+"$BASE_DIR/build/update_translations.sh"
 
-# msgmerge: Merges two Uniforum style .po files together
+echo "Cleaning up and dumping the database..."
 
-msgmerge -U -N --backup=off --no-wrap locale/ar_EG.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/ar_SY.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/cs_CZ.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/de_DE.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/el_GR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/en_US.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/es_ES.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/et_EE.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/fa_IR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/fi_FI.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/fr_CA.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/fr_FR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/he_IL.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/hi_IN.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/hr_HR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/hu_HU.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/id_ID.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/it_IT.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/ja_JP.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/ko_KR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/lv_LV.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/mr_IN.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/nl_NL.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/pl_PL.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/pt_BR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/pt_PT.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/ro_RO.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/ru_RU.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/sq_AL.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/sv_SE.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/sw_KE.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/tr_TR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/vi_VN.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/zh_CN.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/zh_HK.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
-msgmerge -U -N --backup=off --no-wrap locale/zh_TW.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+"$BASE_DIR/build/dump_database.sh"
 
-# msgfmt: Generates a binary message catalog from a textual translation description
+echo "Creating the final tarball..."
 
-msgfmt -o locale/ar_EG.utf8/LC_MESSAGES/messages.mo locale/ar_EG.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/ar_SY.utf8/LC_MESSAGES/messages.mo locale/ar_SY.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/cs_CZ.utf8/LC_MESSAGES/messages.mo locale/cs_CZ.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/de_DE.utf8/LC_MESSAGES/messages.mo locale/de_DE.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/el_GR.utf8/LC_MESSAGES/messages.mo locale/el_GR.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/en_US.utf8/LC_MESSAGES/messages.mo locale/en_US.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/es_ES.utf8/LC_MESSAGES/messages.mo locale/es_ES.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/et_EE.utf8/LC_MESSAGES/messages.mo locale/et_EE.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/fa_IR.utf8/LC_MESSAGES/messages.mo locale/fa_IR.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/fi_FI.utf8/LC_MESSAGES/messages.mo locale/fi_FI.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/fr_CA.utf8/LC_MESSAGES/messages.mo locale/fr_CA.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/fr_FR.utf8/LC_MESSAGES/messages.mo locale/fr_FR.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/he_IL.utf8/LC_MESSAGES/messages.mo locale/he_IL.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/hi_IN.utf8/LC_MESSAGES/messages.mo locale/hi_IN.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/hr_HR.utf8/LC_MESSAGES/messages.mo locale/hr_HR.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/hu_HU.utf8/LC_MESSAGES/messages.mo locale/hu_HU.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/id_ID.utf8/LC_MESSAGES/messages.mo locale/id_ID.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/it_IT.utf8/LC_MESSAGES/messages.mo locale/it_IT.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/ja_JP.utf8/LC_MESSAGES/messages.mo locale/ja_JP.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/ko_KR.utf8/LC_MESSAGES/messages.mo locale/ko_KR.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/lv_LV.utf8/LC_MESSAGES/messages.mo locale/lv_LV.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/mr_IN.utf8/LC_MESSAGES/messages.mo locale/mr_IN.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/nl_NL.utf8/LC_MESSAGES/messages.mo locale/nl_NL.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/pl_PL.utf8/LC_MESSAGES/messages.mo locale/pl_PL.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/pt_BR.utf8/LC_MESSAGES/messages.mo locale/pt_BR.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/pt_PT.utf8/LC_MESSAGES/messages.mo locale/pt_PT.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/ro_RO.utf8/LC_MESSAGES/messages.mo locale/ro_RO.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/ru_RU.utf8/LC_MESSAGES/messages.mo locale/ru_RU.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/sq_AL.utf8/LC_MESSAGES/messages.mo locale/sq_AL.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/sv_SE.utf8/LC_MESSAGES/messages.mo locale/sv_SE.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/sw_KE.utf8/LC_MESSAGES/messages.mo locale/sw_KE.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/tr_TR.utf8/LC_MESSAGES/messages.mo locale/tr_TR.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/vi_VN.utf8/LC_MESSAGES/messages.mo locale/vi_VN.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/zh_CN.utf8/LC_MESSAGES/messages.mo locale/zh_CN.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/zh_HK.utf8/LC_MESSAGES/messages.mo locale/zh_HK.utf8/LC_MESSAGES/messages.po
-msgfmt -o locale/zh_TW.utf8/LC_MESSAGES/messages.mo locale/zh_TW.utf8/LC_MESSAGES/messages.po
-
-mysql -u$MYSQL_USER  -p$MYSQL_PWD < $BASE_DIR/build/TruncateAuditTrail.sql
-
-echo "SET FOREIGN_KEY_CHECKS = 0;" > $BASE_DIR/sql/mysql/country_sql/default.sql
-
-mysqldump -u$MYSQL_USER  -p$MYSQL_PWD  --skip-opt --create-options --skip-set-charset --ignore-table=weberpdemo.mrpsupplies  --ignore-table=weberpdemo.mrpplanedorders --ignore-table=weberpdemo.mrpparameters --ignore-table=weberpdemo.levels --ignore-table=weberpdemo.mrprequirements --ignore-table=weberpdemo.buckets --no-data weberpdemo | sed 's/ AUTO_INCREMENT=[0-9]*//g' >> $BASE_DIR/sql/mysql/country_sql/default.sql
-
-mysqldump -u$MYSQL_USER  -p$MYSQL_PWD --skip-opt --skip-set-charset --quick --no-create-info weberpdemo  \
-       accountgroups \
-       bankaccounts \
-       chartmaster \
-       companies \
-       cogsglpostings \
-       currencies \
-       holdreasons \
-       locations \
-       paymentterms \
-       reportlinks \
-       salesglpostings \
-       systypes \
-       taxauthorities \
-       taxgroups \
-       taxauthrates \
-       taxcategories \
-       taxprovinces \
-       www_users \
-       edi_orders_segs \
-       edi_orders_seg_groups \
-       config \
-       unitsofmeasure \
-       paymentmethods \
-       scripts \
-       securitygroups \
-       securitytokens \
-       securityroles \
-       accountsection \
-       > $BASE_DIR/sql/mysql/country_sql/weberp-base.sql
-
-mysqldump -u$MYSQL_USER  -p$MYSQL_PWD --skip-opt --skip-set-charset --quick --ignore-table=weberpdemo.mrpsupplies  --ignore-table=weberpdemo.mrpplanedorders --ignore-table=weberpdemo.mrpparameters --ignore-table=weberpdemo.levels --ignore-table=weberpdemo.mrprequirements --no-create-info weberpdemo  > $BASE_DIR/sql/mysql/country_sql/weberp-demo_data.sql
-
-rm  $BASE_DIR/sql/mysql/country_sql/demo.sql
-echo "CREATE DATABASE IF NOT EXISTS weberpdemo;" > $BASE_DIR/sql/mysql/country_sql/demo.sql
-echo "USE weberpdemo;" >> $BASE_DIR/sql/mysql/country_sql/demo.sql
-
-cat $BASE_DIR/sql/mysql/country_sql/default.sql >> $BASE_DIR/sql/mysql/country_sql/demo.sql
-
-cat $BASE_DIR/sql/mysql/country_sql/weberp-base.sql >> $BASE_DIR/sql/mysql/country_sql/default.sql
-cat $BASE_DIR/sql/mysql/country_sql/weberp-demo_data.sql >> $BASE_DIR/sql/mysql/country_sql/demo.sql
-rm  $BASE_DIR/sql/mysql/country_sql/weberp-demo_data.sql
-rm  $BASE_DIR/sql/mysql/country_sql/weberp-base.sql
-
-echo "SET FOREIGN_KEY_CHECKS = 1;" >> $BASE_DIR/sql/mysql/country_sql/default.sql
-echo "UPDATE systypes SET typeno=0;" >> $BASE_DIR/sql/mysql/country_sql/default.sql
-echo "INSERT INTO shippers VALUES (1,'Default Shipper',0);" >> $BASE_DIR/sql/mysql/country_sql/default.sql
-echo "UPDATE config SET confvalue='1' WHERE confname='Default_Shipper';" >> $BASE_DIR/sql/mysql/country_sql/default.sql
-echo "SET FOREIGN_KEY_CHECKS = 1;" >> $BASE_DIR/sql/mysql/country_sql/demo.sql
-
-rm $OUTPUT_DIR/webERP.zip
-
-cd ..
-
-zip -r $OUTPUT_DIR/webERP webERP webSHOP -x \*.git* \*/config.php \*build*
+"$BASE_DIR/build/make_tarball.sh"

--- a/build/update_translations.sh
+++ b/build/update_translations.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -e
+
+BASE_DIR="$(dirname -- "$(dirname -- "$(realpath "${BASH_SOURCE[0]}")")")";
+
+cd "$BASE_DIR";
+
+# xgettext: Extracts translatable strings from given input file paths
+
+# @todo use `find` to avoid having to specify all directories manually
+xgettext --no-wrap --from-code=utf-8 -L php -o locale/en_GB.utf8/LC_MESSAGES/messages.pot *.php api/*.php dashboard/*.php \
+	doc/Manual/*.php includes/*.php install/*.php reportwriter/*.inc reportwriter/*.php reportwriter/admin/*.php \
+	reportwriter/admin/forms/*.php reportwriter/forms/*.php reportwriter/languages/en_US/*.php
+
+# msgmerge: Merges two Uniforum style .po files together
+
+# @todo use a list with all the languages and a for loop
+msgmerge -U -N --backup=off --no-wrap locale/ar_EG.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/ar_SY.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/cs_CZ.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/de_DE.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/el_GR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/en_US.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/es_ES.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/et_EE.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/fa_IR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/fi_FI.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/fr_CA.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/fr_FR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/he_IL.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/hi_IN.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/hr_HR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/hu_HU.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/id_ID.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/it_IT.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/ja_JP.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/ko_KR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/lv_LV.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/mr_IN.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/nl_NL.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/pl_PL.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/pt_BR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/pt_PT.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/ro_RO.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/ru_RU.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/sq_AL.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/sv_SE.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/sw_KE.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/tr_TR.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/vi_VN.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/zh_CN.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/zh_HK.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+msgmerge -U -N --backup=off --no-wrap locale/zh_TW.utf8/LC_MESSAGES/messages.po locale/en_GB.utf8/LC_MESSAGES/messages.pot
+
+# msgfmt: Generates a binary message catalog from a textual translation description
+
+# @todo use a list with all the languages and a for loop
+msgfmt -o locale/ar_EG.utf8/LC_MESSAGES/messages.mo locale/ar_EG.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/ar_SY.utf8/LC_MESSAGES/messages.mo locale/ar_SY.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/cs_CZ.utf8/LC_MESSAGES/messages.mo locale/cs_CZ.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/de_DE.utf8/LC_MESSAGES/messages.mo locale/de_DE.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/el_GR.utf8/LC_MESSAGES/messages.mo locale/el_GR.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/en_US.utf8/LC_MESSAGES/messages.mo locale/en_US.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/es_ES.utf8/LC_MESSAGES/messages.mo locale/es_ES.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/et_EE.utf8/LC_MESSAGES/messages.mo locale/et_EE.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/fa_IR.utf8/LC_MESSAGES/messages.mo locale/fa_IR.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/fi_FI.utf8/LC_MESSAGES/messages.mo locale/fi_FI.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/fr_CA.utf8/LC_MESSAGES/messages.mo locale/fr_CA.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/fr_FR.utf8/LC_MESSAGES/messages.mo locale/fr_FR.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/he_IL.utf8/LC_MESSAGES/messages.mo locale/he_IL.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/hi_IN.utf8/LC_MESSAGES/messages.mo locale/hi_IN.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/hr_HR.utf8/LC_MESSAGES/messages.mo locale/hr_HR.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/hu_HU.utf8/LC_MESSAGES/messages.mo locale/hu_HU.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/id_ID.utf8/LC_MESSAGES/messages.mo locale/id_ID.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/it_IT.utf8/LC_MESSAGES/messages.mo locale/it_IT.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/ja_JP.utf8/LC_MESSAGES/messages.mo locale/ja_JP.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/ko_KR.utf8/LC_MESSAGES/messages.mo locale/ko_KR.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/lv_LV.utf8/LC_MESSAGES/messages.mo locale/lv_LV.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/mr_IN.utf8/LC_MESSAGES/messages.mo locale/mr_IN.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/nl_NL.utf8/LC_MESSAGES/messages.mo locale/nl_NL.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/pl_PL.utf8/LC_MESSAGES/messages.mo locale/pl_PL.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/pt_BR.utf8/LC_MESSAGES/messages.mo locale/pt_BR.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/pt_PT.utf8/LC_MESSAGES/messages.mo locale/pt_PT.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/ro_RO.utf8/LC_MESSAGES/messages.mo locale/ro_RO.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/ru_RU.utf8/LC_MESSAGES/messages.mo locale/ru_RU.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/sq_AL.utf8/LC_MESSAGES/messages.mo locale/sq_AL.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/sv_SE.utf8/LC_MESSAGES/messages.mo locale/sv_SE.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/sw_KE.utf8/LC_MESSAGES/messages.mo locale/sw_KE.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/tr_TR.utf8/LC_MESSAGES/messages.mo locale/tr_TR.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/vi_VN.utf8/LC_MESSAGES/messages.mo locale/vi_VN.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/zh_CN.utf8/LC_MESSAGES/messages.mo locale/zh_CN.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/zh_HK.utf8/LC_MESSAGES/messages.mo locale/zh_HK.utf8/LC_MESSAGES/messages.po
+msgfmt -o locale/zh_TW.utf8/LC_MESSAGES/messages.mo locale/zh_TW.utf8/LC_MESSAGES/messages.po


### PR DESCRIPTION
Even if those are not used much atm, better to have them in working condition than broken and unsafe...

Also, splitting them in multiple parts allows their usage outside of a full build, eg. we could run php correctness checks automatically on PRs, and update of po files automatically before a new tag or release is done, etc... 