### PR TITLE
Remove all occurrences of $DbgMsg

### DIFF
--- a/AccountGroups.php
+++ b/AccountGroups.php
@@ -17,13 +17,12 @@ function CheckForRecursiveGroup($ParentGroupName, $GroupName) {
 ie the parent group results in a recursive group structure otherwise false ie 0 */
 
 	$ErrMsg = _('An error occurred in retrieving the account groups of the parent account group during the check for recursion');
-	$DbgMsg = _('The SQL that was used to retrieve the account groups of the parent account group and that failed in the process was');
 	do {
 		$SQL = "SELECT parentgroupname
 				FROM accountgroups
 				WHERE groupname='" . $GroupName ."'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$MyRow = DB_fetch_row($Result);
 		if($ParentGroupName == $MyRow[0]) {
 			return true;
@@ -43,8 +42,7 @@ $Errors = array();
 if(isset($_POST['MoveGroup'])) {
 	$SQL="UPDATE chartmaster SET group_='" . $_POST['DestinyAccountGroup'] . "' WHERE group_='" . $_POST['OriginalAccountGroup'] . "'";
 	$ErrMsg = _('An error occurred in moving the account group');
-	$DbgMsg = _('The SQL that was used to move the account group was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	echo '<div class="centre"><a href="' . htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8') . '">' . _('Review Account Groups') . '</a></div>';
 	prnMsg( _('All accounts in the account group:') . ' ' . $_POST['OriginalAccountGroup'] . ' ' . _('have been changed to the account group:') . ' ' . $_POST['DestinyAccountGroup'],'success');
 }
@@ -65,10 +63,9 @@ if(isset($_POST['submit'])) {
 			FROM accountgroups
 			WHERE groupname='" . $_POST['GroupName'] . "'";
 
-	$DbgMsg = _('The SQL that was used to retrieve the information was');
 	$ErrMsg = _('Could not check whether the group exists because');
 
-	$Result=DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$MyRow=DB_fetch_row($Result);
 
 	if($MyRow[0] != 0 AND $_POST['SelectedAccountGroup'] == '') {
@@ -102,10 +99,9 @@ if(isset($_POST['submit'])) {
 					FROM accountgroups
 					WHERE groupname='" . $_POST['ParentGroupName'] . "'";
 
-			$DbgMsg = _('The SQL that was used to retrieve the information was');
 			$ErrMsg = _('Could not check whether the group is recursive because');
 
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			$ParentGroupRow = DB_fetch_array($Result);
 			$_POST['SequenceInTB'] = $ParentGroupRow['sequenceintb'];
@@ -145,15 +141,14 @@ if(isset($_POST['submit'])) {
 					SET group_='" . $_POST['GroupName'] . "'
 					WHERE group_='" . $_POST['SelectedAccountGroup'] . "'";
 			$ErrMsg = _('An error occurred in renaming the account group');
-			$DbgMsg = _('The SQL that was used to rename the account group was');
 
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			$SQL = "UPDATE accountgroups
 					SET parentgroupname='" . $_POST['GroupName'] . "'
 					WHERE parentgroupname='" . $_POST['SelectedAccountGroup'] . "'";
 
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			DB_ReinstateForeignKeys();
 		}
@@ -165,7 +160,6 @@ if(isset($_POST['submit'])) {
 										parentgroupname='" . $_POST['ParentGroupName'] . "'
 									WHERE groupname = '" . $_POST['SelectedAccountGroup'] . "'";
 		$ErrMsg = _('An error occurred in updating the account group');
-		$DbgMsg = _('The SQL that was used to update the account group was');
 
 		$Msg = _('Record Updated');
 	} elseif($InputError !=1) {
@@ -184,13 +178,12 @@ if(isset($_POST['submit'])) {
 											'" . $_POST['PandL'] . "',
 											'" . $_POST['ParentGroupName'] . "')";
 		$ErrMsg = _('An error occurred in inserting the account group');
-		$DbgMsg = _('The SQL that was used to insert the account group was');
 		$Msg = _('Record inserted');
 	}
 
 	if($InputError!=1) {
 		//run the SQL from either of the above possibilites
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg($Msg,'success');
 		unset ($_POST['SelectedAccountGroup']);
 		unset ($_POST['GroupName']);
@@ -204,8 +197,7 @@ if(isset($_POST['submit'])) {
 
 	$SQL= "SELECT COUNT(group_) AS total_groups FROM chartmaster WHERE chartmaster.group_='" . $_GET['SelectedAccountGroup'] . "'";
 	$ErrMsg = _('An error occurred in retrieving the group information from chartmaster');
-	$DbgMsg = _('The SQL that was used to retrieve the information was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$MyRow = DB_fetch_array($Result);
 	if($MyRow['total_groups']>0) {
 		prnMsg( _('Cannot delete this account group because general ledger accounts have been created using this group'),'warn');
@@ -220,7 +212,7 @@ if(isset($_POST['submit'])) {
 				<td><select tabindex="2" ' . (in_array('ParentGroupName',$Errors) ?  'class="selecterror"' : '' ) . '  name="DestinyAccountGroup">';
 
 		$SQL = "SELECT groupname FROM accountgroups";
-		$GroupResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$GroupResult = DB_query($SQL, $ErrMsg);
 		while($GroupRow = DB_fetch_array($GroupResult) ) {
 
 			if(isset($_POST['ParentGroupName']) AND $_POST['ParentGroupName']==$GroupRow['groupname']) {
@@ -239,8 +231,7 @@ if(isset($_POST['submit'])) {
 	} else {
 		$SQL = "SELECT COUNT(groupname) groupnames FROM accountgroups WHERE parentgroupname = '" . $_GET['SelectedAccountGroup'] . "'";
 		$ErrMsg = _('An error occurred in retrieving the parent group information');
-		$DbgMsg = _('The SQL that was used to retrieve the information was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$MyRow = DB_fetch_array($Result);
 		if($MyRow['groupnames']>0) {
 			prnMsg( _('Cannot delete this account group because it is a parent account group of other account group(s)'),'warn');
@@ -249,8 +240,7 @@ if(isset($_POST['submit'])) {
 		} else {
 			$SQL="DELETE FROM accountgroups WHERE groupname='" . $_GET['SelectedAccountGroup'] . "'";
 			$ErrMsg = _('An error occurred in deleting the account group');
-			$DbgMsg = _('The SQL that was used to delete the account group was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg( $_GET['SelectedAccountGroup'] . ' ' . _('group has been deleted') . '!','success');
 		}
 
@@ -275,9 +265,8 @@ if(!isset($_GET['SelectedAccountGroup']) AND !isset($_POST['SelectedAccountGroup
 			LEFT JOIN accountsection ON sectionid = sectioninaccounts
 			ORDER BY sequenceintb";
 
-	$DbgMsg = _('The sql that was used to retrieve the account group information was ');
 	$ErrMsg = _('Could not get account groups because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	echo '<p class="page_title_text"><img alt="" src="'.$RootPath.'/css/'.$Theme.'/images/maintenance.png" title="' . $Title . '" />' . ' ' . $Title . '</p><br />';
 
 	echo '<table class="selection">
@@ -342,9 +331,7 @@ if(!isset($_GET['delete'])) {
 				FROM accountgroups
 				WHERE groupname='" . $_GET['SelectedAccountGroup'] ."'";
 
-		$ErrMsg = _('An error occurred in retrieving the account group information');
-		$DbgMsg = _('The SQL that was used to retrieve the account group and that failed in the process was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		if(DB_num_rows($Result) == 0) {
 			prnMsg( _('The account group name does not exist in the database'),'error');
 			include('includes/footer.php');
@@ -399,7 +386,7 @@ if(!isset($_GET['delete'])) {
 		'value="">', _('Top Level Group'), '</option>';
 
 	$SQL = "SELECT groupname FROM accountgroups";
-	$GroupResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$GroupResult = DB_query($SQL, $ErrMsg);
 	while( $GroupRow = DB_fetch_array($GroupResult) ) {
 		if(isset($_POST['ParentGroupName']) AND $_POST['ParentGroupName']==$GroupRow['groupname']) {
 			echo '<option selected="selected" value="'.htmlspecialchars($GroupRow['groupname'], ENT_QUOTES,'UTF-8').'">' .htmlspecialchars($GroupRow['groupname'], ENT_QUOTES,'UTF-8') . '</option>';
@@ -418,7 +405,7 @@ if(!isset($_GET['delete'])) {
 				'name="SectionInAccounts" tabindex="3">';
 
 	$SQL = "SELECT sectionid, sectionname FROM accountsection ORDER BY sectionid";
-	$SecResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$SecResult = DB_query($SQL, $ErrMsg);
 	while( $SecRow = DB_fetch_array($SecResult) ) {
 		if($_POST['SectionInAccounts']==$SecRow['sectionid']) {
 			echo '<option selected="selected" value="'.$SecRow['sectionid'].'">' . $SecRow['sectionname'].' ('.$SecRow['sectionid'].')</option>';

--- a/AccountSections.php
+++ b/AccountSections.php
@@ -164,7 +164,7 @@ if(!isset($_GET['SelectedSectionID']) AND !isset($_POST['SelectedSectionID'])) {
 		ORDER BY sectionid";
 
 	$ErrMsg = _('Could not get account group sections because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<p class="page_title_text"><img alt="" class="noPrint" src="', $RootPath, '/css/', $Theme,
 		'/images/maintenance.png" title="', // Icon image.

--- a/AgedDebtors.php
+++ b/AgedDebtors.php
@@ -530,7 +530,7 @@ if(isset($_POST['PrintPDF']) or isset($_POST['View'])
 
 			$SQL = "SELECT salesmancode, salesmanname FROM salesman";
 
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 			echo '<option value="">' . _('All Salespeople') . '</option>';
 			while ($MyRow=DB_fetch_array($Result)) {
 					echo '<option value="' . $MyRow['salesmancode'] . '">' . $MyRow['salesmanname'] . '</option>';
@@ -546,7 +546,7 @@ if(isset($_POST['PrintPDF']) or isset($_POST['View'])
 
 		$SQL = "SELECT currency, currabrev FROM currencies";
 
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		while ($MyRow=DB_fetch_array($Result)) {
 			  if($MyRow['currabrev'] == $_SESSION['CompanyRecord']['currencydefault']) {
 				echo '<option selected="selected" value="' . $MyRow['currabrev'] . '">' . $MyRow['currency'] . '</option>';

--- a/AgedSuppliers.php
+++ b/AgedSuppliers.php
@@ -333,7 +333,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])
 				<select tabindex="4" name="Currency">';
 
 		$SQL = "SELECT currency, currabrev FROM currencies";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 
 		while ($MyRow=DB_fetch_array($Result)){
 			if ($MyRow['currabrev'] == $_SESSION['CompanyRecord']['currencydefault']){

--- a/Areas.php
+++ b/Areas.php
@@ -88,8 +88,7 @@ if (isset($_POST['submit'])) {
 	//run the SQL from either of the above possibilites
 	if ($InputError !=1) {
 		$ErrMsg = _('The area could not be added or updated because');
-		$DbgMsg = _('The SQL that failed was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		unset($SelectedArea);
 		unset($_POST['AreaCode']);
 		unset($_POST['AreaDescription']);

--- a/AutomaticTranslationDescriptions.php
+++ b/AutomaticTranslationDescriptions.php
@@ -54,7 +54,7 @@ if(DB_num_rows($Result) != 0) {
 					"SET descriptiontranslation='" . $TranslatedText . "', " .
 						"needsrevision= '1' " .
 					"WHERE stockid='" . $MyRow['stockid'] . "' AND (language_id='" . $MyRow['language_id'] . "')";
-			$Update = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Update = DB_query($SQL, $ErrMsg, '', true);
 
 			$i++;
 			echo '<tr class="striped_row">
@@ -74,7 +74,7 @@ if(DB_num_rows($Result) != 0) {
 						"needsrevision= '1' " .
 					"WHERE stockid='" . $MyRow['stockid'] . "' AND (language_id='" . $MyRow['language_id'] . "')";
 					echo $SQL;
-			$Update = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Update = DB_query($SQL, $ErrMsg, '', true);
 
 			$i++;
 			echo '<tr class="striped_row">

--- a/BOMExtendedQty.php
+++ b/BOMExtendedQty.php
@@ -19,7 +19,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				extendedqpa double,
 				sortpart text) DEFAULT CHARSET=utf8";
 	$ErrMsg = _('The SQL to create passbom failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$SQL = "CREATE TEMPORARY TABLE tempbom (
 				parent char(20),

--- a/BOMIndented.php
+++ b/BOMIndented.php
@@ -18,7 +18,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				part char(20),
 				sortpart text) DEFAULT CHARSET=utf8";
 	$ErrMsg = _('The SQL to create passbom failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$SQL = "CREATE TEMPORARY TABLE tempbom (
 				parent char(20),

--- a/BOMIndentedReverse.php
+++ b/BOMIndentedReverse.php
@@ -16,7 +16,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				sortpart text) DEFAULT CHARSET=utf8";
 
 	$ErrMsg = _('The SQL to create passbom failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$SQL = "CREATE TEMPORARY TABLE tempbom (
 				parent char(20),

--- a/BOMInquiry.php
+++ b/BOMInquiry.php
@@ -93,7 +93,7 @@ if (isset($_POST['Search'])){
 		}
 
 		$ErrMsg = _('The SQL to find the parts selected failed with the message');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 	} //one of keywords or StockCode was more than a zero length string
 } //end of if search
@@ -162,7 +162,7 @@ if (isset($StockID) and $StockID!=""){
             AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 	$ErrMsg = _('The bill of material could not be retrieved because');
-	$BOMResult = DB_query($SQL,$ErrMsg);
+	$BOMResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($BOMResult)==0){
 		prnMsg(_('The bill of material for this part is not set up') . ' - ' . _('there are no components defined for it'),'warn');

--- a/BOMs.php
+++ b/BOMs.php
@@ -56,8 +56,7 @@ function CheckForRecursiveBOM($UltimateParent, $ComponentToCheck) {
 
 	$SQL = "SELECT component FROM bom WHERE parent='" . $ComponentToCheck . "'";
 	$ErrMsg = _('An error occurred in retrieving the components of the BOM during the check for recursion');
-	$DbgMsg = _('The SQL that was used to retrieve the components of the BOM and that failed in the process was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result) != 0) {
 		while ($MyRow = DB_fetch_array($Result)) {
@@ -115,8 +114,7 @@ function DisplayBOMItems($UltimateParent, $Parent, $Component, $Level) {
 				ORDER BY bom.sequence ASC";
 
 	$ErrMsg = _('Could not retrieve the BOM components because');
-	$DbgMsg = _('The SQL used to retrieve the components was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$RowCounter = 0;
 
@@ -229,8 +227,7 @@ if (isset($_POST['ComponentSearch']) or isset($_POST['Next']) or isset($_POST['P
 			WHERE stockmaster.stockid='" . $SelectedParent . "'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_row($Result);
 
@@ -278,8 +275,7 @@ if (isset($_POST['ComponentSearch']) or isset($_POST['Next']) or isset($_POST['P
 	}
 
 	$ErrMsg = _('Could not retrieve the list of potential components because');
-	$DbgMsg = _('The SQL used to retrieve the list of potential components part was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<form method="post" action="', htmlspecialchars(basename(__FILE__) , ENT_QUOTES, 'UTF-8') , '?SelectedParent=', urlencode($SelectedParent) , '">';
 	echo '<input type="hidden" name="FormID" value="', $_SESSION['FormID'], '" />';
@@ -383,8 +379,7 @@ if (isset($_GET['Add']) or isset($_GET['Edit'])) {
 			WHERE stockmaster.stockid='" . $SelectedParent . "'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_row($Result);
 
@@ -709,9 +704,8 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 						AND loccode='" . $_POST['LocCode'] . "'";
 
 			$ErrMsg = _('Could not update this BOM component because');
-			$DbgMsg = _('The SQL used to update the component was');
 
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			$Msg = _('Details for') . ' - ' . $SelectedComponent . ' ' . _('have been updated') . '.';
 			UpdateCost($SelectedComponent);
 
@@ -732,9 +726,8 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 						AND loccode='" . $_POST['LocCode'] . "'";
 
 				$ErrMsg = _('An error occurred in checking the component is not already on the BOM');
-				$DbgMsg = _('The SQL that was used to check the component was not already on the BOM and that failed in the process was');
 
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 
 				if (DB_num_rows($Result) == 0) {
 
@@ -761,9 +754,8 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 								)";
 
 					$ErrMsg = _('Could not insert the BOM component because');
-					$DbgMsg = _('The SQL used to insert the component was');
 
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+					$Result = DB_query($SQL, $ErrMsg);
 
 					UpdateCost($_POST['SelectedComponent']);
 					$Msg = _('A new component part') . ' ' . $_POST['SelectedComponent'] . ' ' . _('has been added to the bill of material for part') . ' - ' . $SelectedParent . '.';
@@ -795,8 +787,7 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 				AND workcentreadded='" . $WorkCentre . "'";
 
 		$ErrMsg = _('Could not delete this BOM components because');
-		$DbgMsg = _('The SQL used to delete the BOM was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$ComponentSQL = "SELECT component
 							FROM bom
@@ -829,8 +820,7 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 			WHERE stockmaster.stockid='" . $SelectedParent . "'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_row($Result);
 
@@ -864,8 +854,7 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 			AND stockmaster.mbflag='M'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$i = 0;
 	if (DB_num_rows($Result) > 0) {
 		echo '<table class="selection noPrint">
@@ -889,8 +878,7 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 		AND stockmaster.mbflag='A'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result) > 0) {
 		echo '<table class="noPrint">
 				<tr>
@@ -919,8 +907,7 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 			AND stockmaster.mbflag='K'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result) > 0) {
 		echo '<table>
 				<tr>
@@ -949,8 +936,7 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 					AND stockmaster.mbflag='G'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result) > 0) {
 		echo '<table>
 				<tr>

--- a/BOMs_SingleLevel.php
+++ b/BOMs_SingleLevel.php
@@ -47,8 +47,7 @@ ie the BOM is recursive otherwise false ie 0 */
 
 	$SQL = "SELECT component FROM bom WHERE parent='".$ComponentToCheck."'";
 	$ErrMsg = _('An error occurred in retrieving the components of the BOM during the check for recursion');
-	$DbgMsg = _('The SQL that was used to retrieve the components of the BOM and that failed in the process was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result)!=0) {
 		while ($MyRow=DB_fetch_array($Result)){
@@ -98,8 +97,7 @@ function DisplayBOMItems($UltimateParent, $Parent, $Component,$Level) {
 				AND bom.parent = '".$Parent."'";
 
 		$ErrMsg = _('Could not retrieve the BOM components because');
-		$DbgMsg = _('The SQL used to retrieve the components was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		//echo $TableHeader;
 		$RowCounter =0;
@@ -298,9 +296,8 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 					AND bom.component='" . $SelectedComponent . "'";
 
 			$ErrMsg =  _('Could not update this BOM component because');
-			$DbgMsg =  _('The SQL used to update the component was');
 
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			$Msg = _('Details for') . ' - ' . $SelectedComponent . ' ' . _('have been updated') . '.';
 			UpdateCost($SelectedComponent);
 
@@ -321,9 +318,8 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 						AND loccode='" . $_POST['LocCode'] . "'" ;
 
 				$ErrMsg =  _('An error occurred in checking the component is not already on the BOM');
-				$DbgMsg =  _('The SQL that was used to check the component was not already on the BOM and that failed in the process was');
 
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 
 				if (DB_num_rows($Result)==0) {
 
@@ -347,9 +343,8 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 								" . $_POST['AutoIssue'] . ")";
 
 					$ErrMsg = _('Could not insert the BOM component because');
-					$DbgMsg = _('The SQL used to insert the component was');
 
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+					$Result = DB_query($SQL, $ErrMsg);
 
 					UpdateCost($_POST['Component']);
 					$Msg = _('A new component part') . ' ' . $_POST['Component'] . ' ' . _('has been added to the bill of material for part') . ' - ' . $SelectedParent . '.';
@@ -380,8 +375,7 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 				AND workcentreadded='".$WorkCentre."'";
 
 		$ErrMsg = _('Could not delete this BOM components because');
-		$DbgMsg = _('The SQL used to delete the BOM was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$ComponentSQL = "SELECT component
 							FROM bom
@@ -414,10 +408,9 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 			WHERE stockmaster.stockid='" . $SelectedParent . "'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result=DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
-	$MyRow=DB_fetch_row($Result);
+	$MyRow = DB_fetch_row($Result);
 
 	$ParentMBflag = $MyRow[1];
 
@@ -450,8 +443,7 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 			AND stockmaster.mbflag='M'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result=DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$ix = 0;
 	if( DB_num_rows($Result) > 0 ) {
      echo '<table class="selection">';
@@ -474,8 +466,7 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 		AND stockmaster.mbflag='A'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result=DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if( DB_num_rows($Result) > 0 ) {
         echo '<table class="selection">';
 		echo '<tr><td><div class="centre">' . _('Assembly parent items').' : ';
@@ -499,8 +490,7 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 			AND stockmaster.mbflag='K'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result=DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if( DB_num_rows($Result) > 0 ) {
         echo '<table class="selection">';
 		echo '<tr><td><div class="centre">' . _('Kit sets').' : ';
@@ -523,8 +513,7 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 			AND stockmaster.mbflag='G'";
 
 	$ErrMsg = _('Could not retrieve the description of the parent part because');
-	$DbgMsg = _('The SQL used to retrieve description of the parent part was');
-	$Result=DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if( DB_num_rows($Result) > 0 ) {
 		echo '<table class="selection">
 				<tr>
@@ -671,8 +660,7 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 			}
 
 			$ErrMsg = _('Could not retrieve the list of potential components because');
-			$DbgMsg = _('The SQL used to retrieve the list of potential components part was');
-			$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 
 			while ($MyRow = DB_fetch_array($Result)) {
@@ -864,7 +852,7 @@ if (isset($Select)) { //Parent Stock Item selected so display BOM or edit Compon
 		}
 
 		$ErrMsg = _('The SQL to find the parts selected failed with the message');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 	} //one of keywords or StockCode was more than a zero length string
 } //end of if search

--- a/BankAccountBalances.php
+++ b/BankAccountBalances.php
@@ -30,8 +30,7 @@ $SQL = "SELECT DISTINCT
 			AND userid='" . $_SESSION['UserID'] . "'
 		ORDER BY bankaccounts.accountcode";
 $ErrMsg = _('The bank accounts could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve the bank accounts was');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($Result) == 0) {
 	echo _('There are no bank accounts defined that you have authority to see');

--- a/BankAccountUsers.php
+++ b/BankAccountUsers.php
@@ -88,7 +88,7 @@ if (isset($_POST['submit'])) {
 		AND userid='".$SelectedUser."'";
 
 	$ErrMsg = _('The bank account user record could not be deleted because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	prnMsg(_('User').' '. $SelectedUser .' '. _('has been un-authorised to use').' '. $SelectedBankAccount .' '. _('bank account') ,'success');
 	unset($_GET['delete']);
 }
@@ -113,8 +113,7 @@ then none of the above are true. These will call the same page again and allow u
 			FROM bankaccounts
 			ORDER BY accountcode";
 	$ErrMsg = _('The bank accounts could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the bank accounts was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	echo '<option value="">' . _('Not Yet Selected') . '</option>';
 	while ($MyRow = DB_fetch_array($Result)) {
 		// Lists bank accounts order by accountcode

--- a/BankAccounts.php
+++ b/BankAccounts.php
@@ -39,7 +39,7 @@ if (isset($_POST['submit'])) {
 
 	$SQL="SELECT count(accountcode)
 			FROM bankaccounts WHERE accountcode='".$_POST['AccountCode']."'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_row($Result);
 
 	if ($MyRow[0]!=0 and !isset($SelectedBankAccount)) {
@@ -133,8 +133,7 @@ if (isset($_POST['submit'])) {
 	//run the SQL from either of the above possibilites
 	if( $InputError !=1 ) {
 		$ErrMsg = _('The bank account could not be inserted or modified because');
-		$DbgMsg = _('The SQL used to insert/modify the bank account details was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg($Msg,'success');
 		echo '<br />';
@@ -192,8 +191,7 @@ if (!isset($SelectedBankAccount)) {
 				ON bankaccounts.accountcode = chartmaster.accountcode
 			ORDER BY bankaccounts.accountcode";
 	$ErrMsg = _('The bank accounts could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the bank accounts was') . ':<br />' . $SQL;
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 			<tr>

--- a/BankMatching.php
+++ b/BankMatching.php
@@ -54,14 +54,14 @@ if (isset($_POST['Update']) AND $_POST['RowCounter']>1) {
 						FROM banktrans
 						WHERE banktransid='" . $_POST['BankTrans_' . $Counter]."'";
 			$ErrMsg =  _('Could not retrieve transaction information');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			$MyRow=DB_fetch_array($Result);
 			$AmountCleared = round($MyRow[0] / $MyRow[1],2);
 			/*Update the banktrans recoord to match it off */
 			$SQL = "UPDATE banktrans SET amountcleared= ". $AmountCleared . "
 									WHERE banktransid='" . $_POST['BankTrans_' . $Counter] . "'";
 			$ErrMsg =  _('Could not match off this payment because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 		} elseif ((isset($_POST['AmtClear_' . $Counter])
 					AND filter_number_format($_POST['AmtClear_' . $Counter])<0
@@ -75,7 +75,7 @@ if (isset($_POST['Update']) AND $_POST['RowCounter']>1) {
 					 WHERE banktransid='" . $_POST['BankTrans_' . $Counter]."'";
 
 			$ErrMsg = _('Could not update the amount matched off this bank transaction because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 		} elseif (isset($_POST['Unclear_' . $Counter])
 					AND $_POST['Unclear_' . $Counter]==True) {
@@ -83,7 +83,7 @@ if (isset($_POST['Update']) AND $_POST['RowCounter']>1) {
 			$SQL = "UPDATE banktrans SET amountcleared = 0
 					 WHERE banktransid='" . $_POST['BankTrans_' . $Counter]."'";
 			$ErrMsg =  _('Could not unclear this bank transaction because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 		}
 	}
 	/*Show the updated position with the same criteria as previously entered*/

--- a/BankReconciliation.php
+++ b/BankReconciliation.php
@@ -74,8 +74,7 @@ if (isset($_POST['PostExchangeDifference']) AND is_numeric(filter_number_format(
 									'" . $ExchangeDifference . "')";
 
 		$ErrMsg = _('Cannot insert a GL entry for the exchange difference because');
-		$DbgMsg = _('The SQL that failed to insert the exchange difference GL entry was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		$SQL = "INSERT INTO gltrans (type,
 									typeno,
 									trandate,
@@ -91,7 +90,7 @@ if (isset($_POST['PostExchangeDifference']) AND is_numeric(filter_number_format(
 									'" . mb_substr($CurrencyRow['bankaccountname'] . ' ' . _('reconciliation on') . ' ' . Date($_SESSION['DefaultDateFormat']), 0, 200) . "',
 									'" . (-$ExchangeDifference) . "')";
 
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		DB_Txn_Commit();
 		prnMsg(_('Exchange difference of') . ' ' . locale_number_format($ExchangeDifference, $_SESSION['CompanyRecord']['decimalplaces']) . ' ' . _('has been posted'), 'success');
@@ -114,8 +113,7 @@ $SQL = "SELECT
 			AND bankaccountusers.userid = '" . $_SESSION['UserID'] . "'
 		ORDER BY bankaccounts.bankaccountname";
 $ErrMsg = _('The bank accounts could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve the bank accounts was');
-$AccountsResults = DB_query($SQL, $ErrMsg, $DbgMsg);
+$AccountsResults = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($AccountsResults) == 0) {
 	echo '</select>

--- a/CollectiveWorkOrderCost.php
+++ b/CollectiveWorkOrderCost.php
@@ -195,8 +195,7 @@ if (isset($_POST['SearchParts'])){
 	 }
 
 	$ErrMsg =  _('No items were returned by the SQL because');
-	$DbgMsg = _('The SQL used to retrieve the searched parts was');
-	$StockItemsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$StockItemsResult = DB_query($SQL, $ErrMsg);
 }
 
 if (isset($_POST['StockID'])){
@@ -460,7 +459,7 @@ if (!isset($StockID)) {
 		} //end not order number selected
 
 		$ErrMsg = _('No works orders were returned by the SQL because');
-		$WorkOrdersResult = DB_query($SQL,$ErrMsg);
+		$WorkOrdersResult = DB_query($SQL, $ErrMsg);
 
 		/*show a table of the orders returned by the SQL */
 		if (DB_num_rows($WorkOrdersResult)>0) {

--- a/CompanyPreferences.php
+++ b/CompanyPreferences.php
@@ -82,7 +82,7 @@ if (isset($_POST['submit'])) {
 								WHERE coycode=1";
 
 			$ErrMsg =  _('The company preferences could not be updated because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg( _('Company preferences updated'),'success');
 
 			/* Alter the exchange rates in the currencies table */
@@ -96,7 +96,7 @@ if (isset($_POST['submit'])) {
 			/* Set new rates */
 			$SQL="UPDATE currencies SET rate=rate/" . $NewCurrencyRate;
 			$ErrMsg =  _('Could not update the currency rates');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			/* End of update currencies */
 
@@ -149,7 +149,7 @@ if ($InputError != 1) {
 				WHERE coycode=1";
 
 	$ErrMsg =  _('The company preferences could not be retrieved because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 
 	$MyRow = DB_fetch_array($Result);
@@ -250,7 +250,7 @@ echo '<field>
 	</field>';
 
 
-$Result=DB_query("SELECT currabrev, currency FROM currencies");
+$Result = DB_query("SELECT currabrev, currency FROM currencies");
 include('includes/CurrenciesArray.php'); // To get the currency name from the currency code.
 
 echo '<field>
@@ -270,7 +270,7 @@ DB_free_result($Result);
 echo '</select>
 	</field>';
 
-$Result=DB_query("SELECT accountcode,
+$Result = DB_query("SELECT accountcode,
 						accountname
 					FROM chartmaster INNER JOIN accountgroups
 					ON chartmaster.group_=accountgroups.groupname
@@ -384,7 +384,7 @@ echo '<field>
 		<label>' . _('Freight Re-charged GL Account') . ':</label>
 		<select tabindex="19" name="FreightAct">';
 
-$Result=DB_query("SELECT accountcode,
+$Result = DB_query("SELECT accountcode,
 						accountname
 					FROM chartmaster INNER JOIN accountgroups
 					ON chartmaster.group_=accountgroups.groupname

--- a/ConfirmDispatch_Invoice.php
+++ b/ConfirmDispatch_Invoice.php
@@ -99,8 +99,7 @@ if (!isset($_GET['OrderNumber']) and !isset($_SESSION['ProcessingOrder'])) {
 	}
 
 	$ErrMsg = _('The order cannot be retrieved because');
-	$DbgMsg = _('The SQL to get the order header was');
-	$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg, $DbgMsg);
+	$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg);
 
 	if (DB_num_rows($GetOrdHdrResult) == 1) {
 
@@ -180,8 +179,7 @@ if (!isset($_GET['OrderNumber']) and !isset($_SESSION['ProcessingOrder'])) {
 							ORDER BY salesorderdetails.orderlineno";
 
 		$ErrMsg = _('The line items of the order cannot be retrieved because');
-		$DbgMsg = _('The SQL that failed was');
-		$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg, $DbgMsg);
+		$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 
 		if (DB_num_rows($LineItemsResult) > 0) {
 
@@ -209,8 +207,7 @@ if (!isset($_GET['OrderNumber']) and !isset($_SESSION['ProcessingOrder'])) {
 										AND pickreqdetails.orderlineno='" . $MyRow['orderlineno'] . "'";
 
 				$ErrMsg = _('The serial items of the pick list cannot be retrieved because');
-				$DbgMsg = _('The SQL that failed was');
-				$SerialItemsResult = DB_query($SerialItemsSQL, $ErrMsg, $DbgMsg);
+				$SerialItemsResult = DB_query($SerialItemsSQL, $ErrMsg);
 
 				if (DB_num_rows($SerialItemsResult) > 0) {
 					$InOutModifier = 1;
@@ -784,8 +781,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 				WHERE debtorno='" . $_SESSION['Items' . $identifier]->DebtorNo . "'
 				AND branchcode='" . $_SESSION['Items' . $identifier]->Branch . "'";
 		$ErrMsg = _('Could not update the default shipping carrier for this branch because');
-		$DbgMsg = _('The SQL used to update the branch default carrier was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	}
 
 	$DefaultDispatchDate = FormatDateForSQL($DefaultDispatchDate);
@@ -798,8 +794,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 			WHERE orderno= '" . $_SESSION['ProcessingOrder'] . "'";
 
 	$ErrMsg = _('CRITICAL ERROR') . ' ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales order header could not be updated with the invoice number');
-	$DbgMsg = _('The following SQL to update the sales order was used');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	/*Now insert the DebtorTrans */
 
@@ -844,8 +839,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 									'" . $_SESSION['Items' . $identifier]->SalesPerson . "' )";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction record could not be inserted because');
-	$DbgMsg = _('The following SQL to insert the debtor transaction record was used');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	$DebtorTransID = DB_Last_Insert_ID('debtortrans', 'id');
 
 	/* Insert the tax totals for each tax authority where tax was charged on the invoice */
@@ -859,8 +853,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 									'" . $TaxAmount / $_SESSION['CurrencyRate'] . "')";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction taxes records could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the debtor transaction taxes record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	}
 
 	/* If balance of the order cancelled update sales order details quantity. Also insert log records for OrderDeliveryDifferencesLog */
@@ -890,8 +883,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 						AND orderlineno = '" . $OrderLine->LineNumber . "'";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales order detail record could not be updated because');
-			$DbgMsg = _('The following SQL to update the sales order detail record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			if (($OrderLine->Quantity - $OrderLine->QtyDispatched) > 0) {
 
@@ -912,8 +904,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 															'CAN')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The order delivery differences log record could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the order delivery differences record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 
 		} elseif (($OrderLine->Quantity - $OrderLine->QtyDispatched) > 0 and DateDiff(ConvertSQLDate($DefaultDispatchDate), $_SESSION['Items' . $identifier]->DeliveryDate, 'd') > 0) {
@@ -939,8 +930,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 												)";
 
 			$ErrMsg = '<br />' . _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The order delivery differences log record could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the order delivery differences record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		} /*end of order delivery differences log entries */
 
 		/*Now update SalesOrderDetails for the quantity invoiced and the actual dispatch dates. */
@@ -965,8 +955,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 			}
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales order detail record could not be updated because');
-			$DbgMsg = _('The following SQL to update the sales order detail record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/*update any open pickreqdetails*/
 			$LineItemsSQL = "SELECT pickreqdetails.detailno
@@ -979,8 +968,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 							AND salesorderdetails.orderlineno='" . $OrderLine->LineNumber . "'";
 
 			$ErrMsg = _('The line items of the pick list cannot be retrieved because');
-			$DbgMsg = _('The SQL that failed was');
-			$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg, $DbgMsg);
+			$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 
 			$MyLine = DB_fetch_array($LineItemsResult);
 			$DetailNo = $MyLine['detailno'];
@@ -989,8 +977,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 					WHERE detailno='" . $DetailNo . "'";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The pickreqdetail record could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the pickreqdetail records was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/* Update location stock records if not a dummy stock item
 			 need the MBFlag later too so save it to $MBFlag */
@@ -1027,8 +1014,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 						AND loccode = '" . $_SESSION['Items' . $identifier]->Location . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated because');
-				$DbgMsg = _('The following SQL to update the location stock record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			} elseif ($MBFlag == 'A') { /* its an assembly */
 				/*Need to get the BOM for this part and make
@@ -1045,8 +1031,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 								AND bom.effectiveafter <= CURRENT_DATE";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not retrieve assembly components from the database for') . ' ' . $OrderLine->StockID . _('because') . ' ';
-				$DbgMsg = _('The SQL that failed was');
-				$AssResult = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$AssResult = DB_query($SQL, $ErrMsg, '', true);
 
 				while ($AssParts = DB_fetch_array($AssResult)) {
 
@@ -1059,8 +1044,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 							AND loccode= '" . $_SESSION['Items' . $identifier]->Location . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Can not retrieve assembly components location stock quantities because ');
-					$DbgMsg = _('The SQL that failed was');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					if (DB_num_rows($Result) == 1) {
 						$LocQtyRow = DB_fetch_row($Result);
 						$QtyOnHandPrior = $LocQtyRow[0];
@@ -1101,8 +1085,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 												 '" . ($QtyOnHandPrior - $AssParts['quantity'] * $OrderLine->QtyDispatched) . "'	)";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records for the assembly components of') . ' ' . $OrderLine->StockID . ' ' . _('could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the assembly components stock movement records was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					$SQL = "UPDATE locstock
 							SET quantity = locstock.quantity - " . ($AssParts['quantity'] * $OrderLine->QtyDispatched) . "
@@ -1110,8 +1093,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 							AND loccode = '" . $_SESSION['Items' . $identifier]->Location . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated for an assembly component because');
-					$DbgMsg = _('The following SQL to update the locations stock record for the component was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} /* end of assembly explosion and updates */
 
 				/*Update the cart with the recalculated standard cost from the explosion of the assembly's components*/
@@ -1197,8 +1179,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 			}
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the stock movement records was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/*Get the ID of the StockMove... */
 			$StkMoveNo = DB_Last_Insert_ID('stockmoves', 'stkmoveno');
@@ -1228,8 +1209,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 													  '" . $_SESSION['CurrencyRate'] . "'
 													)";
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales commission accrual record could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the sales commission accrual record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SalesPersonSQL = "SELECT salesmanname, glaccount FROM salesman WHERE salesmancode='" . $_SESSION['Items' . $identifier]->SalesPerson . "'";
 				$SalesPersonResult = DB_query($SalesPersonSQL);
@@ -1252,8 +1232,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 										'" . round($Commission / $_SESSION['CurrencyRate'], $_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The expenses side of the sales commission posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the sales commission record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "INSERT INTO gltrans (type,
 											typeno,
@@ -1272,8 +1251,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 										'" . round(-$Commission / $_SESSION['CurrencyRate'], $_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The accruals side of the sales commission posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the sales commission record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 
 			/*Insert the taxes that applied to this line */
@@ -1291,8 +1269,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 											'" . $Tax->TaxOnTax . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Taxes and rates applicable to this invoice line item could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement tax detail records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 
 			/* Insert the StockSerialMovements and update the StockSerialItems  for controlled items*/
@@ -1307,8 +1284,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 							AND serialno='" . $Item->BundleRef . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-					$DbgMsg = _('The following SQL to update the serial stock item record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					/* now insert the serial stock movement */
 
@@ -1322,8 +1298,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 											'" . -$Item->BundleQty . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} /* foreach controlled item in the serialitems array */
 			} /*end if the orderline is a controlled item */
 
@@ -1368,8 +1343,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 						salesanalysis.budgetoractual";
 
 			$ErrMsg = _('The count of existing Sales analysis records could not run because');
-			$DbgMsg = '<br />' . _('SQL to count the no of sales analysis records');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$MyRow = DB_fetch_row($Result);
 
@@ -1424,8 +1398,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 			}
 
 			$ErrMsg = _('Sales analysis record could not be added or updated because');
-			$DbgMsg = _('The following SQL to insert the sales analysis record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/* If GLLink_Stock then insert GLTrans to credit stock and debit cost of sales at standard cost*/
 
@@ -1450,8 +1423,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 										'" . round(($OrderLine->StandardCost * $OrderLine->QtyDispatched), $_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The cost of sales GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/*now the stock entry - this is set to the cost act in the case of a fixed asset disposal */
 				$StockGLCode = GetStockGLCode($OrderLine->StockID);
@@ -1473,8 +1445,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 										'" . round((-$OrderLine->StandardCost * $OrderLine->QtyDispatched), $_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock side of the cost of sales GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			} /* end of if GL and stock integrated and standard cost !=0 and not an asset */
 
 			if ($_SESSION['CompanyRecord']['gllink_debtors'] == 1 and $OrderLine->Price != 0) {
@@ -1500,8 +1471,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 											'" . (-$OrderLine->Price * $OrderLine->QtyDispatched / $_SESSION['CurrencyRate']) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales GL posting could not be inserted because');
-					$DbgMsg = '<br />' . _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					if ($OrderLine->DiscountPercent != 0) {
 
@@ -1522,8 +1492,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 													'" . ($OrderLine->Price * $OrderLine->QtyDispatched * $OrderLine->DiscountPercent / $_SESSION['CurrencyRate']) . "')";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales discount GL posting could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 					} /*end of if discount !=0 */
 
 				} else {
@@ -1539,8 +1508,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 						ON fixedassetcategories.categoryid = fixedassets.assetcategoryid
 						WHERE assetid ='" . $AssetNumber . "'";
 					$ErrMsg = _('The asset disposal GL posting details could not be retrieved because');
-					$DbgMsg = _('The following SQL was used to get the asset posting details');
-					$DisposalResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+					$DisposalResult = DB_query($SQL, $ErrMsg);
 					$DisposalRow = DB_fetch_array($DisposalResult);
 
 					/* Need to :
@@ -1568,8 +1536,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 												'" . $DisposalRow['accumdepn'] . "')";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The reversal of accumulated depreciation GL posting on disposal could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 					}
 					// 2.) Credit the cost account:
 					if ($DisposalRow['cost'] != 0) {
@@ -1585,8 +1552,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 									10,'" . $InvoiceNo . "','" . $DefaultDispatchDate . "','" . $PeriodNo . "','" . $DisposalRow['costact'] . "','" . $_SESSION['Items' . $identifier]->DebtorNo . " - " . $OrderLine->StockID . ' ' . _('cost disposal') . "','" . -$DisposalRow['cost'] . "')";
 									mb_substr($_SESSION['Items' . $identifier]->DebtorNo . " - " . $OrderLine->StockID . ' ' . _('cost disposal'), 0, 200) . "','" .
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The reversal of asset cost on disposal GL posting could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 					}
 					// 3.) Debit the disposal account with the NBV:
 					if ($DisposalRow['cost'] - $DisposalRow['accumdepn'] != 0) {
@@ -1607,8 +1573,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 												'" . ($DisposalRow['cost'] - $DisposalRow['accumdepn']) . "')";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The disposal net book value GL posting could not be inserted because');
-						$DbgMsg = '<br />' . _('The following SQL to insert the GLTrans record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 					}
 					//4. Credit the disposal account with the proceeds
 					$SQL = "INSERT INTO gltrans (type,
@@ -1628,8 +1593,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 											'" . (-$OrderLine->Price * $OrderLine->QtyDispatched * (1 - $OrderLine->DiscountPercent) / $_SESSION['CurrencyRate']) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The disposal proceeds GL posting could not be inserted because');
-					$DbgMsg = '<br />' . _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} // End if the item being sold was an asset.
 
 			} /*end of if sales integrated with debtors */
@@ -1656,8 +1620,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 												'" . round(($OrderLine->Price * $OrderLine->QtyDispatched * (1 - $OrderLine->DiscountPercent) / $_SESSION['CurrencyRate']), $_SESSION['CompanyRecord']['decimalplaces']) . "',
 												'" . $DefaultDispatchDate . "')";
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The fixed asset transaction could not be inserted because');
-				$DbgMsg = '<br />' . _('The following SQL to insert the fixed asset transaction record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "UPDATE fixedassets
 						SET disposalproceeds ='" . round(($OrderLine->Price * $OrderLine->QtyDispatched * (1 - $OrderLine->DiscountPercent) / $_SESSION['CurrencyRate']), $_SESSION['CompanyRecord']['decimalplaces']) . "',
@@ -1665,8 +1628,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 						WHERE assetid ='" . $AssetNumber . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The fixed asset record could not be updated for the disposal because');
-				$DbgMsg = '<br />' . _('The following SQL to update the fixed asset record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			}
 		} /*Quantity dispatched is more than 0 */
@@ -1679,8 +1641,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 			WHERE orderno= '" . $_SESSION['ProcessingOrder'] . "'
 			AND closed=0";
 	$ErrMsg = _('CRITICAL ERROR') . ' ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The pick list header could not be updated');
-	$DbgMsg = _('The following SQL to update the pick list was used');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	if ($_SESSION['CompanyRecord']['gllink_debtors'] == 1) {
 
@@ -1703,8 +1664,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 										'" . (($_SESSION['Items' . $identifier]->total + $_SESSION['Items' . $identifier]->FreightCost + $TaxTotal) / $_SESSION['CurrencyRate']) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The total debtor GL posting could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the total debtors control GLTrans record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 
 		/*Could do with setting up a more flexible freight posting schema that looks at the sales type and area of the customer branch to determine where to post the freight recovery */
@@ -1728,8 +1688,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 					'" . (-$_SESSION['Items' . $identifier]->FreightCost / $_SESSION['CurrencyRate']) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The freight GL posting could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 		foreach ($TaxTotals as $TaxAuthID => $TaxAmount) {
 			if ($TaxAmount != 0) {
@@ -1750,8 +1709,7 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 											'" . (-$TaxAmount / $_SESSION['CurrencyRate']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The tax GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 		}
 	} /*end of if Sales and GL integrated */

--- a/ContractBOM.php
+++ b/ContractBOM.php
@@ -140,8 +140,7 @@ if (isset($_POST['Search'])){  /*ie seach for stock items */
 	}
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL statement that failed was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult)==0 AND $Debug==1){
 		prnMsg( _('There are no products to display matching the criteria provided'),'warn');
@@ -191,8 +190,7 @@ if (isset($_POST['NewItem'])){ /* NewItem is set from the part selection list as
 							WHERE stockmaster.stockid = '". trim($_POST['StockID'.$i]) . "'";
 
 				$ErrMsg = _('The item details could not be retrieved');
-				$DbgMsg = _('The SQL used to retrieve the item details but failed was');
-				$Result1 = DB_query($SQL, $ErrMsg, $DbgMsg);
+				$Result1 = DB_query($SQL, $ErrMsg);
 
 				if ($MyRow = DB_fetch_array($Result1)){
 
@@ -229,8 +227,7 @@ if (count($_SESSION['Contract'.$identifier]->ContractBOM)>0){
 			AND stocktype<>'D'
 			ORDER BY categorydescription";
 	$ErrMsg = _('The supplier category details could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the category details but failed was');
-	$Result1 = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result1 = DB_query($SQL, $ErrMsg);
 	echo '<p class="page_title_text">
 			<img src="'.$RootPath.'/css/'.$Theme.'/images/contract.png" title="' . _('Contract Bill of Material') . '" alt="" />  '.$_SESSION['Contract'.$identifier]->CustomerName . '
 		</p>';
@@ -286,8 +283,7 @@ if (!isset($_GET['Edit'])) {
 			AND stocktype<>'D'
 			ORDER BY categorydescription";
 	$ErrMsg = _('The supplier category details could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the category details but failed was');
-	$Result1 = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result1 = DB_query($SQL, $ErrMsg);
 	echo '<p class="page_title_text">
 			<img src="'.$RootPath.'/css/'.$Theme.'/images/magnifier.png" title="' . _('Print') . '" alt="" />' . ' ' . _('Search For Stock Items') .
 		'</p>';

--- a/ContractCosting.php
+++ b/ContractCosting.php
@@ -42,7 +42,7 @@ $SQL = "SELECT stockmoves.stockid,
 				stockmaster.units,
 				stockmaster.decimalplaces";
 $ErrMsg = _('Could not get the inventory issues for this contract because');
-$InventoryIssuesResult = DB_query($SQL,$ErrMsg);
+$InventoryIssuesResult = DB_query($SQL, $ErrMsg);
 $InventoryIssues = array();
 while ($InventoryIssuesRow = DB_fetch_array($InventoryIssuesResult)){
 	$InventoryIssues[$InventoryIssuesRow['stockid']]['StockID'] = $InventoryIssuesRow['stockid'];
@@ -194,7 +194,7 @@ $SQL = "SELECT supptrans.supplierno,
 		WHERE contractcharges.contractref='" . $ContractRef . "'
 		ORDER BY contractcharges.anticipated";
 $ErrMsg = _('Could not get the other charges to the contract because');
-$OtherChargesResult = DB_query($SQL,$ErrMsg);
+$OtherChargesResult = DB_query($SQL, $ErrMsg);
 $OtherReqtsActual =0;
 while ($OtherChargesRow=DB_fetch_array($OtherChargesResult)) {
 	if ($OtherChargesRow['anticipated']==0){
@@ -257,8 +257,7 @@ if (isset($_POST['CloseContract']) AND $_SESSION['Contract'.$identifier]->Status
 							'" . -$Variance . "')";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The gl entry of WIP for the variance on closing the contract could not be inserted because');
-	$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	$SQL = "INSERT INTO gltrans (type,
 								typeno,
 								trandate,
@@ -275,16 +274,14 @@ if (isset($_POST['CloseContract']) AND $_SESSION['Contract'.$identifier]->Status
 							'" . $Variance . "')";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The gl entry of WIP for the variance on closing the contract could not be inserted because');
-	$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 //Now update the status of the contract to closed
 	$SQL = "UPDATE contracts
 				SET status=3
 				WHERE contractref='" . $_SESSION['Contract'.$identifier]->ContractRef . "'";
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The status of the contract could not be updated to closed because');
-	$DbgMsg = _('The following SQL to change the status of the contract was used');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 /*Check if the contract work order is still open */
 	$CheckIfWOOpenResult = DB_query("SELECT closed
@@ -293,7 +290,7 @@ if (isset($_POST['CloseContract']) AND $_SESSION['Contract'.$identifier]->Status
 	$CheckWORow=DB_fetch_row($CheckIfWOOpenResult);
 	if ($CheckWORow[0]==0){
 		//then close the work order
-		$CloseWOResult =DB_query("UPDATE workorders
+		$CloseWOResult = DB_query("UPDATE workorders
 									SET closed=1
 									WHERE wo='" . $_SESSION['Contract'.$identifier]->WO . "'",
 									_('Could not update the work order to closed because:'),
@@ -306,7 +303,7 @@ if (isset($_POST['CloseContract']) AND $_SESSION['Contract'.$identifier]->Status
 	 *  If work done on the contract is a write off then the user must also write off the stock of the contract item as a separate job
 	 */
 
-		$Result =DB_query("SELECT qtyrecd FROM woitems
+		$Result = DB_query("SELECT qtyrecd FROM woitems
 							WHERE stockid='" . $_SESSION['Contract'.$identifier]->ContractRef . "'
 							AND wo='" . $_SESSION['Contract'.$identifier]->WO . "'");
 		if (DB_num_rows($Result)==1) {
@@ -336,8 +333,7 @@ if (isset($_POST['CloseContract']) AND $_SESSION['Contract'.$identifier]->Status
 						AND loccode= '" . $_SESSION['Contract'.$identifier]->LocCode . "'";
 
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-				$DbgMsg =  _('The following SQL to update the location stock record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					/*Insert stock movements - with unit cost */
 
@@ -367,8 +363,7 @@ if (isset($_POST['CloseContract']) AND $_SESSION['Contract'.$identifier]->Status
 									'" . ($QtyOnHandPrior + 1) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('stock movement records could not be inserted when processing the work order receipt because');
-				$DbgMsg =  _('The following SQL to insert the stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/*Get the ID of the StockMove... */
 				$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -396,8 +391,7 @@ if (isset($_POST['CloseContract']) AND $_SESSION['Contract'.$identifier]->Status
 											'" . ($OtherReqtsBudget+$ContractBOMBudget) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The receipt of contract work order finished stock GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the work order receipt of finished items GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					/*now the credit WIP entry*/
 					$SQL = "INSERT INTO gltrans (type,
@@ -416,20 +410,18 @@ if (isset($_POST['CloseContract']) AND $_SESSION['Contract'.$identifier]->Status
 											'" . -($OtherReqtsBudget+$ContractBOMBudget) . "')";
 
 					$ErrMsg =   _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The WIP credit on receipt of finished items from a work order GL posting could not be inserted because');
-					$DbgMsg =  _('The following SQL to insert the WIP GLTrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '',true);
 
 				} /* end of if GL and stock integrated and standard cost !=0 */
 
 				//update the wo with the new qtyrecd
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' ._('Could not update the work order item record with the total quantity received because');
-				$DbgMsg = _('The following SQL was used to update the work order');
-				$UpdateWOResult =DB_query("UPDATE woitems
+				$UpdateWOResult = DB_query("UPDATE woitems
 										SET qtyrecd=qtyrecd+1
 										WHERE wo='" . $_SESSION['Contract'.$identifier]->WO . "'
 										AND stockid='" . $_SESSION['Contract'.$identifier]->ContractRef . "'",
 										$ErrMsg,
-										$DbgMsg,
+										'',
 										true);
 			}//end if the contract wo was not received - work order item received/processed above if not
 		}//end if there was a row returned from the woitems query

--- a/Contracts.php
+++ b/Contracts.php
@@ -185,21 +185,21 @@ if (isset($_POST['CancelContract'])) {
 	if ($OK_to_delete==true){
 		$SQL = "DELETE FROM contractbom WHERE contractref='" . $_SESSION['Contract'.$identifier]->ContractRef . "'";
 		$ErrMsg = _('The contract bill of materials could not be deleted because');
-		$DelResult=DB_query($SQL,$ErrMsg);
+		$DelResult = DB_query($SQL, $ErrMsg);
 		$SQL = "DELETE FROM contractreqts WHERE contractref='" . $_SESSION['Contract'.$identifier]->ContractRef . "'";
 		$ErrMsg = _('The contract requirements could not be deleted because');
-		$DelResult=DB_query($SQL,$ErrMsg);
+		$DelResult = DB_query($SQL, $ErrMsg);
 		$SQL= "DELETE FROM contracts WHERE contractref='" . $_SESSION['Contract'.$identifier]->ContractRef . "'";
 		$ErrMsg = _('The contract could not be deleted because');
-		$DelResult=DB_query($SQL,$ErrMsg);
+		$DelResult = DB_query($SQL, $ErrMsg);
 
 		if ($_SESSION['Contract'.$identifier]->Status==1){
 			$SQL = "DELETE FROM salesorderdetails WHERE orderno='" . $_SESSION['Contract'.$identifier]->OrderNo . "'";
 			$ErrMsg = _('The quotation lines for the contract could not be deleted because');
-			$DelResult=DB_query($SQL,$ErrMsg);
+			$DelResult = DB_query($SQL, $ErrMsg);
 			$SQL = "DELETE FROM salesorders WHERE orderno='" . $_SESSION['Contract'.$identifier]->OrderNo . "'";
 			$ErrMsg = _('The quotation for the contract could not be deleted because');
-			$DelResult=DB_query($SQL,$ErrMsg);
+			$DelResult = DB_query($SQL, $ErrMsg);
 		}
 		prnMsg( _('Contract').' '.$_SESSION['Contract'.$identifier]->ContractRef.' '._('has been cancelled'), 'success');
 		unset($_SESSION['ExistingContract']);
@@ -326,7 +326,7 @@ if (isset($_POST['CommitContract']) OR isset($_POST['CreateQuotation'])){
 										exrate = '" . filter_number_format($_POST['ExRate']) . "'
 							WHERE contractref ='" . $_POST['ContractRef'] . "'";
 			$ErrMsg = _('Cannot update the contract because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			/* also need to update the items on the contract BOM  - delete the existing contract BOM then add these items*/
 			$Result = DB_query("DELETE FROM contractbom WHERE contractref='" .$_POST['ContractRef'] . "'");
 			$ErrMsg = _('Could not add a component to the contract bill of material');
@@ -339,7 +339,7 @@ if (isset($_POST['CommitContract']) OR isset($_POST['CreateQuotation'])){
 												'" . $Component->StockID . "',
 												'" . $WorkCentre . "',
 												'" . $Component->Quantity . "')";
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 			}
 
 			/*also need to update the items on the contract requirements  - delete the existing database entries then add these */
@@ -355,7 +355,7 @@ if (isset($_POST['CommitContract']) OR isset($_POST['CreateQuotation'])){
 													'" . $Requirement->Requirement . "',
 													'" . $Requirement->CostPerUnit . "',
 													'" . $Requirement->Quantity . "')";
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 			}
 
 			prnMsg(_('The changes to the contract have been committed to the database'),'success');
@@ -379,8 +379,7 @@ if (isset($_POST['CommitContract']) OR isset($_POST['CreateQuotation'])){
 											materialcost= '" . $ContractCost . "'
 										WHERE stockid ='" . $_SESSION['Contract'.$identifier]->ContractRef."'";
 			$ErrMsg =  _('The contract item could not be updated because');
-			$DbgMsg = _('The SQL that was used to update the contract item failed was');
-			$InsertNewItemResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$InsertNewItemResult = DB_query($SQL, $ErrMsg);
 
 			//update the quotation
 			$SQL = "UPDATE salesorderdetails
@@ -388,8 +387,7 @@ if (isset($_POST['CommitContract']) OR isset($_POST['CreateQuotation'])){
 						WHERE stkcode='" .  $_SESSION['Contract'.$identifier]->ContractRef . "'
 						AND orderno='" .  $_SESSION['Contract'.$identifier]->OrderNo . "'";
 			$ErrMsg = _('The contract quotation could not be updated because');
-			$DbgMsg = _('The SQL that failed to update the quotation was');
-			$UpdQuoteResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+			$UpdQuoteResult = DB_query($SQL, $ErrMsg);
 			prnMsg(_('The contract quotation has been updated based on the new contract cost and margin'),'success');
 			echo '<br /><a href="' .$RootPath . '/SelectSalesOrder.php?OrderNumber=' .  $_SESSION['Contract'.$identifier]->OrderNo . '&amp;Quotations=Quotes_Only">' . _('Go to Quotation') . ' ' .  $_SESSION['Contract'.$identifier]->OrderNo . '</a>';
 
@@ -426,7 +424,7 @@ if (isset($_POST['CommitContract']) OR isset($_POST['CreateQuotation'])){
 							'". filter_number_format($_POST['ExRate']) ."')";
 
 		$ErrMsg = _('The new contract could not be added because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		/*Also need to add the reqts and contracbom*/
 		$ErrMsg = _('Could not add a component to the contract bill of material');
@@ -439,7 +437,7 @@ if (isset($_POST['CommitContract']) OR isset($_POST['CreateQuotation'])){
 									'" . $Component->StockID . "',
 									'" . $WorkCentre . "',
 									'" . $Component->Quantity . "')";
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 		}
 
 		$ErrMsg = _('Could not add a requirement to the contract requirements');
@@ -452,7 +450,7 @@ if (isset($_POST['CommitContract']) OR isset($_POST['CreateQuotation'])){
 									'" . $Requirement->Requirement . "',
 									'" . $Requirement->CostPerUnit . "',
 									'" . $Requirement->Quantity . "')";
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 		}
 		prnMsg(_('The new contract has been added to the database'),'success');
 
@@ -478,8 +476,7 @@ if(isset($_POST['CreateQuotation']) AND !$InputError){
 //Check if the item exists already
 	$SQL = "SELECT stockid FROM stockmaster WHERE stockid='" . $_SESSION['Contract'.$identifier]->ContractRef."'";
 	$ErrMsg =  _('The item could not be retrieved because');
-	$DbgMsg = _('The SQL that was used to find the item failed was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result)==0) { //then the item doesn't currently exist so add it
 
 		$SQL = "INSERT INTO stockmaster (stockid,
@@ -497,8 +494,7 @@ if(isset($_POST['CreateQuotation']) AND !$InputError){
 									'" . $_SESSION['DefaultTaxCategory'] . "',
 									'" . $ContractCost . "')";
 		$ErrMsg =  _('The new contract item could not be added because');
-		$DbgMsg = _('The SQL that was used to insert the contract item failed was');
-		$InsertNewItemResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$InsertNewItemResult = DB_query($SQL, $ErrMsg);
 		$SQL = "INSERT INTO locstock (loccode,
 										stockid)
 						SELECT locations.loccode,
@@ -506,8 +502,7 @@ if(isset($_POST['CreateQuotation']) AND !$InputError){
 						FROM locations";
 
 		$ErrMsg =  _('The locations for the item') . ' ' . $_SESSION['Contract'.$identifier]->ContractRef . ' ' . _('could not be added because');
-		$DbgMsg = _('NB Locations records can be added by opening the utility page') . ' <i>Z_MakeStockLocns.php</i> ' . _('The SQL that was used to add the location records that failed was');
-		$InsLocnsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$InsLocnsResult = DB_query($SQL, $ErrMsg);
 	}
 	//now add the quotation for the item
 
@@ -529,8 +524,7 @@ if(isset($_POST['CreateQuotation']) AND !$InputError){
 				WHERE debtorsmaster.debtorno='" . $_SESSION['Contract'.$identifier]->DebtorNo  . "'
 				AND custbranch.branchcode='" . $_SESSION['Contract'.$identifier]->BranchCode . "'";
 	$ErrMsg =  _('The customer and branch details could not be retrieved because');
-	$DbgMsg = _('The SQL that was used to find the customer and branch details failed was');
-	$CustomerDetailsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$CustomerDetailsResult = DB_query($SQL, $ErrMsg);
 
 	$CustomerDetailsRow = DB_fetch_array($CustomerDetailsResult);
 
@@ -580,7 +574,7 @@ if(isset($_POST['CreateQuotation']) AND !$InputError){
 											'1' )";
 
 	$ErrMsg = _('The quotation cannot be added because');
-	$InsertQryResult = DB_query($HeaderSQL,$ErrMsg,true);
+	$InsertQryResult = DB_query($HeaderSQL, $ErrMsg,true);
 	$LineItemSQL = "INSERT INTO salesorderdetails ( orderlineno,
 													orderno,
 													stkcode,
@@ -595,9 +589,8 @@ if(isset($_POST['CreateQuotation']) AND !$InputError){
 												'1',
 												'" . $_SESSION['Contract'.$identifier]->CustomerRef . "',
 												'" . FormatDateForSQL($_SESSION['Contract'.$identifier]->RequiredDate) . "')";
-	$DbgMsg = _('The SQL that failed was');
 	$ErrMsg = _('Unable to add the quotation line');
-	$Ins_LineItemResult = DB_query($LineItemSQL,$ErrMsg,$DbgMsg,true);
+	$Ins_LineItemResult = DB_query($LineItemSQL, $ErrMsg, '', true);
 	 //end of adding the quotation to salesorders/details
 
 	//make the status of the contract 1 - to indicate that it is now quoted
@@ -605,7 +598,7 @@ if(isset($_POST['CreateQuotation']) AND !$InputError){
 								status='" . 1 . "'
 						WHERE contractref='" . DB_escape_string($_SESSION['Contract'.$identifier]->ContractRef) . "'";
 	$ErrMsg = _('Unable to update the contract status and order number because');
-	$UpdContractResult = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$UpdContractResult = DB_query($SQL, $ErrMsg, '', true);
 	DB_Txn_Commit();
 	$_SESSION['Contract'.$identifier]->Status=1;
 	$_SESSION['Contract'.$identifier]->OrderNo=$OrderNo;
@@ -689,7 +682,7 @@ if (isset($_POST['SearchCustomers'])){
 	}
 
 	$ErrMsg = _('The searched customer records requested cannot be retrieved because');
-	$Result_CustSelect = DB_query($SQL,$ErrMsg);
+	$Result_CustSelect = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result_CustSelect)==0){
 		prnMsg(_('No Customer Branch records contain the search criteria') . ' - ' . _('please try again') . ' - ' . _('Note a Customer Branch Name may be different to the Customer Name'),'info');
@@ -722,8 +715,7 @@ if (isset($_POST['SelectedCustomer'])) {
 			AND custbranch.branchcode='" . $_SESSION['Contract'.$identifier]->BranchCode . "'" ;
 
 	$ErrMsg = _('The customer record selected') . ': ' . $_SESSION['Contract'.$identifier]->DebtorNo . ' ' . _('cannot be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the customer details and failed was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$MyRow = DB_fetch_array($Result);
 	if (DB_num_rows($Result)==0){
 		prnMsg(_('The customer details were unable to be retrieved'),'error');
@@ -863,8 +855,7 @@ if (!isset($_SESSION['Contract'.$identifier]->DebtorNo)
 			<select name="CategoryID">';
 	$SQL = "SELECT categoryid, categorydescription FROM stockcategory";
 	$ErrMsg = _('The stock categories could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve stock categories and failed was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	while ($MyRow = DB_fetch_array($Result)) {
 		if (!isset($_SESSION['Contract' . $identifier]->CategoryID) or $MyRow['categoryid'] == $_SESSION['Contract' . $identifier]->CategoryID) {
 			echo '<option selected="selected" value="', $MyRow['categoryid'], '">', $MyRow['categorydescription'], '</option>';
@@ -884,8 +875,7 @@ if (!isset($_SESSION['Contract'.$identifier]->DebtorNo)
 					AND locationusers.userid='" . $_SESSION['UserID'] . "'
 					AND locationusers.canupd=1";
 	$ErrMsg = _('The stock locations could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve stock locations and failed was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<field>
 			<label for="LocCode">', _('Location'), ':</label>

--- a/CounterReturns.php
+++ b/CounterReturns.php
@@ -117,8 +117,7 @@ if (!isset($_SESSION['Items' . $identifier])) {
 				WHERE debtorsmaster.debtorno = '" . $_SESSION['Items' . $identifier]->DebtorNo . "'";
 
 		$ErrMsg = _('The details of the customer selected') . ': ' .  $_SESSION['Items' . $identifier]->DebtorNo . ' ' . _('cannot be retrieved because');
-		$DbgMsg = _('The SQL used to retrieve the customer details and failed was') . ':';
-		$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$MyRow = DB_fetch_array($Result);
 		$_SESSION['RequireCustomerSelection']=0;
@@ -145,8 +144,7 @@ if (!isset($_SESSION['Items' . $identifier])) {
 				WHERE custbranch.branchcode='" . $_SESSION['Items' . $identifier]->Branch . "'
 				AND custbranch.debtorno = '" . $_SESSION['Items' . $identifier]->DebtorNo . "'";
         $ErrMsg = _('The customer branch record of the customer selected') . ': ' . $_SESSION['Items' . $identifier]->Branch . ' ' . _('cannot be retrieved because');
-		$DbgMsg = _('SQL used to retrieve the branch details was') . ':';
-		$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($Result)==0) {
 
@@ -321,8 +319,7 @@ if (isset($_POST['search']) OR isset($_POST['Next']) OR isset($_POST['Prev'])) {
 	$SQL = $SQL . ' LIMIT ' . $_SESSION['DefaultDisplayRecordsMax'].' OFFSET '.strval($_SESSION['DefaultDisplayRecordsMax']*$Offset);
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL used to get the part selection was');
-	$SearchResult = DB_query($SQL,$ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult)==0 ) {
 		prnMsg (_('There are no products available meeting the criteria specified'),'info');
@@ -400,8 +397,7 @@ if ($_SESSION['Items' . $identifier]->DefaultCurrency != $_SESSION['CompanyRecor
 				WHERE stockmaster.stockid='". $NewItem ."'";
 
 		$ErrMsg = _('Could not determine if the part being ordered was a kitset or not because');
-		$DbgMsg = _('The sql that was used to determine if the part being ordered was a kitset or not was ');
-		$KitResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$KitResult = DB_query($SQL, $ErrMsg);
 
 
 		if (DB_num_rows($KitResult)==0) {
@@ -416,7 +412,7 @@ if ($_SESSION['Items' . $identifier]->DefaultCurrency != $_SESSION['CompanyRecor
                         AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 				$ErrMsg =  _('Could not retrieve kitset components from the database because') . ' ';
-				$KitResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$KitResult = DB_query($SQL, $ErrMsg);
 
 				$ParentQty = $NewItemQty;
 				while ($KitParts = DB_fetch_array($KitResult)) {
@@ -517,8 +513,7 @@ if (isset($_POST['Recalculate'])) {
 				WHERE stockmaster.stockid='". $ReturnItemLine->StockID."'";
 
 		$ErrMsg = _('Could not determine if the part being ordered was a kitset or not because');
-		$DbgMsg = _('The sql that was used to determine if the part being ordered was a kitset or not was ');
-		$KitResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$KitResult = DB_query($SQL, $ErrMsg);
 		if ($MyRow=DB_fetch_array($KitResult)) {
 			if ($MyRow['mbflag']=='K') {	/*It is a kit set item */
 				$SQL = "SELECT bom.component,
@@ -529,7 +524,7 @@ if (isset($_POST['Recalculate'])) {
                             AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 				$ErrMsg = _('Could not retrieve kitset components from the database because');
-				$KitResult = DB_query($SQL,$ErrMsg);
+				$KitResult = DB_query($SQL, $ErrMsg);
 
 				$ParentQty = $NewItemQty;
 				while ($KitParts = DB_fetch_array($KitResult)) {
@@ -563,7 +558,7 @@ Now figure out if the item is a kit set - the field MBFlag='K'
 
 	$ErrMsg =  _('Could not determine if the part being ordered was a kitset or not because');
 
-	$KitResult = DB_query($SQL,$ErrMsg);
+	$KitResult = DB_query($SQL, $ErrMsg);
 
 	$NewItemQty = 1; /*By Default */
 	$Discount = 0; /*By default - can change later or discount category override */
@@ -578,7 +573,7 @@ Now figure out if the item is a kit set - the field MBFlag='K'
                     AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 			$ErrMsg = _('Could not retrieve kitset components from the database because');
-			$KitResult = DB_query($SQL,$ErrMsg);
+			$KitResult = DB_query($SQL, $ErrMsg);
 
 			$ParentQty = $NewItemQty;
 			while ($KitParts = DB_fetch_array($KitResult)) {
@@ -614,7 +609,7 @@ if (isset($NewItemArray) AND isset($_POST['SelectingReturnItems'])) {
 
 			$ErrMsg =  _('Could not determine if the part being returned was a kitset or not because');
 
-			$KitResult = DB_query($SQL,$ErrMsg);
+			$KitResult = DB_query($SQL, $ErrMsg);
 
 			//$NewItemQty = 1; /*By Default */
 			$Discount = 0; /*By default - can change later or discount category override */
@@ -629,7 +624,7 @@ if (isset($NewItemArray) AND isset($_POST['SelectingReturnItems'])) {
                             AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 					$ErrMsg = _('Could not retrieve kitset components from the database because');
-					$KitResult = DB_query($SQL,$ErrMsg);
+					$KitResult = DB_query($SQL, $ErrMsg);
 
 					$ParentQty = $NewItemQty;
 					while ($KitParts = DB_fetch_array($KitResult)) {
@@ -952,8 +947,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 					'" . $_SESSION['Items' . $identifier]->SalesPerson . "' )";
 
 		$ErrMsg =_('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction record could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the debtor transaction record was used');
-	 	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$DebtorTransID = DB_Last_Insert_ID('debtortrans','id');
 
@@ -968,8 +962,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 											'" . -$TaxAmount/$ExRate . "')";
 
 			$ErrMsg =_('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction taxes records could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the debtor transaction taxes record was used');
-	 		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 
 		//Loop around each item on the sale and process each in turn
@@ -1005,8 +998,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 						AND loccode = '" . $_SESSION['Items' . $identifier]->Location . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated because');
-				$DbgMsg = _('The following SQL to update the location stock record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			} else if ($MBFlag=='A') { /* its an assembly */
 				/*Need to get the BOM for this part and make
@@ -1024,8 +1016,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
                         AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not retrieve assembly components from the database for'). ' '. $ReturnItemLine->StockID . _('because').' ';
-				$DbgMsg = _('The SQL that failed was');
-				$AssResult = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$AssResult = DB_query($SQL, $ErrMsg, '', true);
 
 				while ($AssParts = DB_fetch_array($AssResult)) {
 
@@ -1038,8 +1029,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 									AND loccode= '" . $_SESSION['Items' . $identifier]->Location . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Can not retrieve assembly components location stock quantities because ');
-					$DbgMsg = _('The SQL that failed was');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					if (DB_num_rows($Result)==1) {
 						$LocQtyRow = DB_fetch_row($Result);
 						$QtyOnHandPrior = $LocQtyRow[0];
@@ -1081,8 +1071,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 													newqoh + " . ($AssParts['quantity'] * $ReturnItemLine->Quantity) . " )";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records for the assembly components of'). ' '. $ReturnItemLine->StockID . ' ' . _('could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the assembly components stock movement records was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 					$SQL = "UPDATE locstock
@@ -1091,8 +1080,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 							AND loccode = '" . $_SESSION['Items' . $identifier]->Location . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated for an assembly component because');
-					$DbgMsg = _('The following SQL to update the locations stock record for the component was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} /* end of assembly explosion and updates */
 
 				/*Update the cart with the recalculated standard cost from the explosion of the assembly's components*/
@@ -1175,8 +1163,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 			}
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the stock movement records was used');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*Get the ID of the StockMove... */
 			$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -1196,8 +1183,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 								'" . $Tax->TaxOnTax . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Taxes and rates applicable to this invoice line item could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement tax detail records was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			} //end for each tax for the line
 
 
@@ -1241,8 +1227,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 						salesanalysis.salesperson";
 
 			$ErrMsg = _('The count of existing Sales analysis records could not run because');
-			$DbgMsg = _('SQL to count the no of sales analysis records');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$MyRow = DB_fetch_row($Result);
 
@@ -1299,8 +1284,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 			}
 
 			$ErrMsg = _('Sales analysis record could not be added or updated because');
-			$DbgMsg = _('The following SQL to insert the sales analysis record was used');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/* If GLLink_Stock then insert GLTrans to credit stock and debit cost of sales at standard cost*/
 
@@ -1324,8 +1308,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 												'" . $ReturnItemLine->StandardCost * -$ReturnItemLine->Quantity . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The cost of sales GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*now the stock entry*/
 				$StockGLCode = GetStockGLCode($ReturnItemLine->StockID);
@@ -1346,8 +1329,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 											'" . ($ReturnItemLine->StandardCost * $ReturnItemLine->Quantity) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock side of the cost of sales GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			} /* end of if GL and stock integrated and standard cost !=0 */
 
 			if ($_SESSION['CompanyRecord']['gllink_debtors']==1 AND $ReturnItemLine->Price !=0) {
@@ -1371,8 +1353,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 											'" . ($ReturnItemLine->Price * $ReturnItemLine->Quantity/$ExRate) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales GL posting could not be inserted because');
-				$DbgMsg = '<br />' ._('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				if ($ReturnItemLine->DiscountPercent !=0) {
 
@@ -1392,8 +1373,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 													'" . -($ReturnItemLine->Price * $ReturnItemLine->Quantity * $ReturnItemLine->DiscountPercent/$ExRate) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales discount GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} /*end of if discount !=0 */
 			} /*end of if sales integrated with debtors */
 		} /*end of OrderLine loop */
@@ -1418,8 +1398,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 												'" . -(($_SESSION['Items' . $identifier]->total + filter_number_format($_POST['TaxTotal']))/$ExRate) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The total debtor GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the total debtors control GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 
 
@@ -1441,8 +1420,7 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 													'" . ($TaxAmount/$ExRate) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The tax GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 			}
 
@@ -1467,9 +1445,8 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 							'" . $_POST['BankAccount'] . "',
 							'" . $_SESSION['Items' . $identifier]->LocationName . ' ' . _('Counter Return') . ' ' . $CreditNoteNo . "',
 							'" . -(filter_number_format($_POST['AmountPaid'])/$ExRate) . "')";
-				$DbgMsg = _('The SQL that failed to insert the GL transaction for the bank account debit was');
 				$ErrMsg = _('Cannot insert a GL transaction for the bank account debit');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/* Now Debit Debtors account with negative receipt/payment to customer */
 				$SQL="INSERT INTO gltrans ( type,
@@ -1486,9 +1463,8 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 							'" . $_SESSION['CompanyRecord']['debtorsact'] . "',
 							'" . $_SESSION['Items' . $identifier]->LocationName . ' ' . _('Counter Return') . ' ' . $CreditNoteNo . "',
 							'" . (filter_number_format($_POST['AmountPaid'])/$ExRate) . "')";
-				$DbgMsg = _('The SQL that failed to insert the GL transaction for the debtors account credit was');
 				$ErrMsg = _('Cannot insert a GL transaction for the debtors account credit');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}//amount paid was not zero
 
 			EnsureGLEntriesBalance(12,$PaymentNumber);
@@ -1543,9 +1519,8 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 						'" . -filter_number_format($_POST['AmountPaid']) * $BankAccountExRate . "',
 						'" . $_SESSION['Items' . $identifier]->DefaultCurrency . "')";
 
-			$DbgMsg = _('The SQL that failed to insert the bank account transaction was');
 			$ErrMsg = _('Cannot insert a bank transaction');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			//insert a new debtortrans for the receipt
 
@@ -1572,9 +1547,8 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 						'" . filter_number_format($_POST['AmountPaid']) . "',
 						'" . $_SESSION['Items' . $identifier]->LocationName . ' ' . _('Counter Sale') ."')";
 
-			$DbgMsg = _('The SQL that failed to insert the customer receipt transaction was');
 			$ErrMsg = _('Cannot insert a receipt transaction against the customer because') ;
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$ReceiptDebtorTransID = DB_Last_Insert_ID('debtortrans','id');
 
@@ -1589,9 +1563,8 @@ if (isset($_POST['ProcessReturn']) AND $_POST['ProcessReturn'] != '') {
 											'" . $ReturnDate . "',
 											 '" . $DebtorTransID . "',
 											 '" . $ReceiptDebtorTransID . "')";
-			$DbgMsg = _('The SQL that failed to insert the allocation of the receipt to the credit note was');
 			$ErrMsg = _('Cannot insert the customer allocation of the receipt to the invoice because');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		} //end if $_POST['AmountPaid']!= 0
 
 		DB_Txn_Commit();

--- a/CounterSales.php
+++ b/CounterSales.php
@@ -123,8 +123,7 @@ if (!isset($_SESSION['Items'.$identifier])) {
 				WHERE debtorsmaster.debtorno = '" . $_SESSION['Items'.$identifier]->DebtorNo . "'";
 
 		$ErrMsg = _('The details of the customer selected') . ': ' .  $_SESSION['Items'.$identifier]->DebtorNo . ' ' . _('cannot be retrieved because');
-		$DbgMsg = _('The SQL used to retrieve the customer details and failed was') . ':';
-		$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$MyRow = DB_fetch_array($Result);
 		if ($MyRow['dissallowinvoices'] != 1) {
@@ -156,8 +155,7 @@ if (!isset($_SESSION['Items'.$identifier])) {
 				WHERE custbranch.branchcode='" . $_SESSION['Items'.$identifier]->Branch . "'
 				AND custbranch.debtorno = '" . $_SESSION['Items'.$identifier]->DebtorNo . "'";
             $ErrMsg = _('The customer branch record of the customer selected') . ': ' . $_SESSION['Items'.$identifier]->Branch . ' ' . _('cannot be retrieved because');
-			$DbgMsg = _('SQL used to retrieve the branch details was') . ':';
-			$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			if (DB_num_rows($Result)==0) {
 
@@ -346,8 +344,7 @@ if (isset($_POST['Search']) or isset($_POST['Next']) or isset($_POST['Previous']
 	$SQL = $SQL . ' LIMIT ' . $_SESSION['DefaultDisplayRecordsMax'].' OFFSET ' . strval($_SESSION['DefaultDisplayRecordsMax']*$Offset);
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL used to get the part selection was');
-	$SearchResult = DB_query($SQL,$ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult)==0 ) {
 		prnMsg (_('There are no products available meeting the criteria specified'),'info');
@@ -443,8 +440,7 @@ if ($_SESSION['Items'.$identifier]->DefaultCurrency != $_SESSION['CompanyRecord'
 				WHERE stockmaster.stockid='". $NewItem ."'";
 
 		$ErrMsg = _('Could not determine if the part being ordered was a kitset or not because');
-		$DbgMsg = _('The sql that was used to determine if the part being ordered was a kitset or not was ');
-		$KitResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$KitResult = DB_query($SQL, $ErrMsg);
 
 
 		if (DB_num_rows($KitResult)==0) {
@@ -459,7 +455,7 @@ if ($_SESSION['Items'.$identifier]->DefaultCurrency != $_SESSION['CompanyRecord'
                         AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 				$ErrMsg =  _('Could not retrieve kitset components from the database because') . ' ';
-				$KitResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$KitResult = DB_query($SQL, $ErrMsg);
 
 				$ParentQty = $NewItemQty;
 				while ($KitParts = DB_fetch_array($KitResult)) {
@@ -558,8 +554,7 @@ if (isset($_POST['Recalculate'])) {
 				WHERE stockmaster.stockid='". $OrderLine->StockID."'";
 
 		$ErrMsg = _('Could not determine if the part being ordered was a kitset or not because');
-		$DbgMsg = _('The sql that was used to determine if the part being ordered was a kitset or not was ');
-		$KitResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$KitResult = DB_query($SQL, $ErrMsg);
 		if ($MyRow=DB_fetch_array($KitResult)) {
 			if ($MyRow['mbflag']=='K') {	/*It is a kit set item */
 				$SQL = "SELECT bom.component,
@@ -570,7 +565,7 @@ if (isset($_POST['Recalculate'])) {
                             AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 				$ErrMsg = _('Could not retrieve kitset components from the database because');
-				$KitResult = DB_query($SQL,$ErrMsg);
+				$KitResult = DB_query($SQL, $ErrMsg);
 
 				$ParentQty = $NewItemQty;
 				while ($KitParts = DB_fetch_array($KitResult)) {
@@ -605,7 +600,7 @@ Now figure out if the item is a kit set - the field MBFlag='K'
 
 	$ErrMsg =  _('Could not determine if the part being ordered was a kitset or not because');
 
-	$KitResult = DB_query($SQL,$ErrMsg);
+	$KitResult = DB_query($SQL, $ErrMsg);
 
 	$NewItemQty = 1; /*By Default */
 	$Discount = 0; /*By default - can change later or discount category override */
@@ -620,7 +615,7 @@ Now figure out if the item is a kit set - the field MBFlag='K'
                     AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 			$ErrMsg = _('Could not retrieve kitset components from the database because');
-			$KitResult = DB_query($SQL,$ErrMsg);
+			$KitResult = DB_query($SQL, $ErrMsg);
 
 			$ParentQty = $NewItemQty;
 			while ($KitParts = DB_fetch_array($KitResult)) {
@@ -657,7 +652,7 @@ if (isset($NewItemArray) AND isset($_POST['SelectingOrderItems'])) {
 
 			$ErrMsg =  _('Could not determine if the part being ordered was a kitset or not because');
 
-			$KitResult = DB_query($SQL,$ErrMsg);
+			$KitResult = DB_query($SQL, $ErrMsg);
 
 			//$NewItemQty = 1; /*By Default */
 			$Discount = 0; /*By default - can change later or discount category override */
@@ -672,7 +667,7 @@ if (isset($NewItemArray) AND isset($_POST['SelectingOrderItems'])) {
                             AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 					$ErrMsg = _('Could not retrieve kitset components from the database because');
-					$KitResult = DB_query($SQL,$ErrMsg);
+					$KitResult = DB_query($SQL, $ErrMsg);
 
 					$ParentQty = $NewItemQty;
 					while ($KitParts = DB_fetch_array($KitResult)) {
@@ -1011,7 +1006,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 					AND locstock.loccode='" . $_SESSION['Items'.$identifier]->Location . "'";
 
 			$ErrMsg = _('Could not retrieve the quantity left at the location once this order is invoiced (for the purposes of checking that stock will not go negative because)');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			$CheckNegRow = DB_fetch_array($Result);
 			if ($CheckNegRow['mbflag']=='B' OR $CheckNegRow['mbflag']=='M') {
 				if ($CheckNegRow['quantity'] < $OrderLine->Quantity) {
@@ -1035,7 +1030,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
                         AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 				$ErrMsg = _('Could not retrieve the component quantity left at the location once the assembly item on this order is invoiced (for the purposes of checking that stock will not go negative because)');
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 				while ($NegRow = DB_fetch_array($Result)) {
 					if ($NegRow['qtyleft']<0) {
 						prnMsg(_('Invoicing the selected order would result in negative stock for a component of an assembly item on the order. The system parameters are set to prohibit negative stocks from occurring. This invoice cannot be created until the stock on hand is corrected.'),'error',$NegRow['component'] . ' ' . $NegRow['description'] . ' - ' . _('Negative Stock Prohibited'));
@@ -1130,9 +1125,8 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 												'" . Date('Y-m-d') . "',
 												0,
 												'" . $_SESSION['Items'.$identifier]->SalesPerson . "')";
-		$DbgMsg = _('Trouble inserting the sales order header. The SQL that failed was');
 		$ErrMsg = _('The order cannot be added because');
-		$InsertQryResult = DB_query($HeaderSQL,$ErrMsg,$DbgMsg,true);
+		$InsertQryResult = DB_query($HeaderSQL, $ErrMsg, '', true);
 
 		$StartOf_LineItemsSQL = "INSERT INTO salesorderdetails (orderlineno,
 																orderno,
@@ -1147,7 +1141,6 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 																completed)
 															VALUES (";
 
-		$DbgMsg = _('Trouble inserting a line of a sales order. The SQL that failed was');
 		foreach ($_SESSION['Items'.$identifier]->LineItems as $StockItem) {
 
 			$LineItemsSQL = $StartOf_LineItemsSQL .
@@ -1164,7 +1157,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 					1)";
 
 			$ErrMsg = _('Unable to add the sales order line');
-			$Ins_LineItemResult = DB_query($LineItemsSQL,$ErrMsg,$DbgMsg,true);
+			$Ins_LineItemResult = DB_query($LineItemsSQL, $ErrMsg, '', true);
 
 			/*Now check to see if the item is manufactured
 			 * 			and AutoCreateWOs is on
@@ -1200,7 +1193,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 											'" . Date('Y-m-d') . "',
 											'" . Date('Y-m-d'). "')",
 											$ErrMsg,
-											$DbgMsg,
+											'',
 											true);
 					//Need to get the latest BOM to roll up cost
 					$CostResult = DB_query("SELECT SUM((materialcost+labourcost+overheadcost)*bom.quantity) AS cost
@@ -1226,7 +1219,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 											 '" . $WOQuantity . "',
 											 '" . $Cost . "')";
 					$ErrMsg = _('The work order item could not be added');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					//Recursively insert real component requirements - see includes/SQL_CommonFunctions.in for function WoRealRequirements
 					WoRealRequirements($WONo, $_SESSION['DefaultFactoryLocation'], $StockItem->StockID);
@@ -1255,14 +1248,14 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 																'" . $StockItem->StockID . "',
 																'" . ($StockItem->NextSerialNo + $i)	 . "')";
 								$ErrMsg = _('The serial number for the work order item could not be added');
-								$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+								$Result = DB_query($SQL, $ErrMsg, '', true);
 								$FactoryManagerEmail .= "\n" . ($StockItem->NextSerialNo + $i);
 							}
 						} //end loop around creation of woserialnos
 						$NewNextSerialNo = ($StockItem->NextSerialNo + $WOQuantity +1);
 						$ErrMsg = _('Could not update the new next serial number for the item');
 						$UpdateSQL="UPDATE stockmaster SET nextserialno='" . $NewNextSerialNo . "' WHERE stockid='" . $StockItem->StockID . "'";
-						$UpdateNextSerialNoResult = DB_query($UpdateSQL,$ErrMsg,$DbgMsg,true);
+						$UpdateNextSerialNoResult = DB_query($UpdateSQL, $ErrMsg, '', true);
 					} // end if the item is serialised and nextserialno is set
 					// Send email to the Factory Manager
 					$EmailSubject = _('New Work Order Number') . ' ' . $WONo . ' ' . _('for') . ' ' . $StockItem->StockID . ' x ' . $WOQuantity;
@@ -1290,8 +1283,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 		$SQL = "UPDATE salesorders SET comments = CONCAT(comments,'" . ' ' . _('Invoice') . ': ' . "','" . $InvoiceNo . "') WHERE orderno= '" . $OrderNo."'";
 
 		$ErrMsg = _('CRITICAL ERROR') . ' ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales order header could not be updated with the invoice number');
-		$DbgMsg = _('The following SQL to update the sales order was used');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	/*Now insert the DebtorTrans */
 
@@ -1334,8 +1326,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 				'" . $_SESSION['Items'.$identifier]->SalesPerson . "')";
 
 		$ErrMsg =_('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction record could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the debtor transaction record was used');
-	 	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$DebtorTransID = DB_Last_Insert_ID('debtortrans','id');
 
@@ -1350,8 +1341,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 											'" . $TaxAmount/$ExRate . "')";
 
 			$ErrMsg =_('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction taxes records could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the debtor transaction taxes record was used');
-	 		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 
 		//Loop around each item on the sale and process each in turn
@@ -1387,8 +1377,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 							AND loccode = '" . $_SESSION['Items'.$identifier]->Location . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated because');
-				$DbgMsg = _('The following SQL to update the location stock record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			} else if ($MBFlag=='A') { /* its an assembly */
 				/*Need to get the BOM for this part and make
@@ -1406,8 +1395,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
                         AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not retrieve assembly components from the database for'). ' '. $OrderLine->StockID . _('because').' ';
-				$DbgMsg = _('The SQL that failed was');
-				$AssResult = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$AssResult = DB_query($SQL, $ErrMsg, '', true);
 
 				while ($AssParts = DB_fetch_array($AssResult)) {
 
@@ -1420,8 +1408,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 									AND loccode= '" . $_SESSION['Items'.$identifier]->Location . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Can not retrieve assembly components location stock quantities because ');
-					$DbgMsg = _('The SQL that failed was');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					if (DB_num_rows($Result)==1) {
 						$LocQtyRow = DB_fetch_row($Result);
 						$QtyOnHandPrior = $LocQtyRow[0];
@@ -1462,9 +1449,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 												newqoh-" . ($AssParts['quantity'] * $OrderLine->Quantity) . " )";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records for the assembly components of'). ' '. $OrderLine->StockID . ' ' . _('could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the assembly components stock movement records was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
-
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					$SQL = "UPDATE locstock
 							SET quantity = locstock.quantity - " . $AssParts['quantity'] * $OrderLine->Quantity . "
@@ -1472,8 +1457,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 							AND loccode = '" . $_SESSION['Items'.$identifier]->Location . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated for an assembly component because');
-					$DbgMsg = _('The following SQL to update the locations stock record for the component was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} /* end of assembly explosion and updates */
 
 				/*Update the cart with the recalculated standard cost from the explosion of the assembly's components*/
@@ -1558,8 +1542,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 			}
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the stock movement records was used');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*Get the ID of the StockMove... */
 			$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -1579,8 +1562,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 							'" . $Tax->TaxOnTax . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Taxes and rates applicable to this invoice line item could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement tax detail records was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			} //end for each tax for the line
 
 			/* Controlled stuff not currently handled by counter orders
@@ -1598,8 +1580,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 							AND serialno='" . $Item->BundleRef . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-					$DbgMsg = _('The following SQL to update the serial stock item record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					// now insert the serial stock movement
 
@@ -1613,8 +1594,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 							" . -$Item->BundleQty . ")";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}// foreach controlled item in the serialitems array
 			} //end if the orderline is a controlled item
 
@@ -1661,8 +1641,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 					salesanalysis.salesperson";
 
 			$ErrMsg = _('The count of existing Sales analysis records could not run because');
-			$DbgMsg = _('SQL to count the no of sales analysis records');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$MyRow = DB_fetch_row($Result);
 
@@ -1719,8 +1698,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 			}
 
 			$ErrMsg = _('Sales analysis record could not be added or updated because');
-			$DbgMsg = _('The following SQL to insert the sales analysis record was used');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/* If GLLink_Stock then insert GLTrans to credit stock and debit cost of sales at standard cost*/
 
@@ -1744,8 +1722,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 												'" . $OrderLine->StandardCost * $OrderLine->Quantity . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The cost of sales GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*now the stock entry*/
 				$StockGLCode = GetStockGLCode($OrderLine->StockID);
@@ -1766,8 +1743,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 											'" . (-$OrderLine->StandardCost * $OrderLine->Quantity) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock side of the cost of sales GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			} /* end of if GL and stock integrated and standard cost !=0 */
 
 			if ($_SESSION['CompanyRecord']['gllink_debtors']==1 AND $OrderLine->Price !=0) {
@@ -1791,8 +1767,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 											'" . (-$OrderLine->Price * $OrderLine->Quantity/$ExRate) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales GL posting could not be inserted because');
-				$DbgMsg = '<br />' ._('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				if ($OrderLine->DiscountPercent !=0) {
 
@@ -1812,8 +1787,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 													'" . ($OrderLine->Price * $OrderLine->Quantity * $OrderLine->DiscountPercent/$ExRate) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales discount GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} /*end of if discount !=0 */
 			} /*end of if sales integrated with debtors */
 		} /*end of OrderLine loop */
@@ -1838,8 +1812,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 												'" . (($_SESSION['Items'.$identifier]->total + filter_number_format($_POST['TaxTotal']))/$ExRate) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The total debtor GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the total debtors control GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 
 
@@ -1861,8 +1834,7 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 													'" . (-$TaxAmount/$ExRate) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The tax GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 			}
 
@@ -1887,9 +1859,8 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 							'" . $_POST['BankAccount'] . "',
 							'" . mb_substr($_SESSION['Items'.$identifier]->LocationName . ' ' . _('Counter Sale') . ' ' . $InvoiceNo, 0, 200) . "',
 							'" . (filter_number_format($_POST['AmountPaid'])/$ExRate) . "')";
-				$DbgMsg = _('The SQL that failed to insert the GL transaction for the bank account debit was');
 				$ErrMsg = _('Cannot insert a GL transaction for the bank account debit');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/* Now Credit Debtors account with receipt */
 				$SQL="INSERT INTO gltrans ( type,
@@ -1906,9 +1877,8 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 					'" . $_SESSION['CompanyRecord']['debtorsact'] . "',
 					'" . mb_substr($_SESSION['Items'.$identifier]->LocationName . ' ' . _('Counter Sale') . ' ' . $InvoiceNo, 0, 200) . "',
 					'" . -(filter_number_format($_POST['AmountPaid'])/$ExRate) . "')";
-				$DbgMsg = _('The SQL that failed to insert the GL transaction for the debtors account credit was');
 				$ErrMsg = _('Cannot insert a GL transaction for the debtors account credit');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}//amount paid we not zero
 
 			EnsureGLEntriesBalance(12,$ReceiptNumber);
@@ -1962,9 +1932,8 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 						'" . filter_number_format($_POST['AmountPaid']) * $BankAccountExRate/$ExRate . "',
 						'" . $_SESSION['Items'.$identifier]->DefaultCurrency . "')";
 
-			$DbgMsg = _('The SQL that failed to insert the bank account transaction was');
 			$ErrMsg = _('Cannot insert a bank transaction');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			//insert a new debtortrans for the receipt
 
@@ -1995,9 +1964,8 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 						'1',
 						'" . $_SESSION['Items'.$identifier]->SalesPerson . "')";
 
-			$DbgMsg = _('The SQL that failed to insert the customer receipt transaction was');
 			$ErrMsg = _('Cannot insert a receipt transaction against the customer because') ;
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$ReceiptDebtorTransID = DB_Last_Insert_ID('debtortrans','id');
 
@@ -2005,9 +1973,8 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 											lastpaid='" . filter_number_format($_POST['AmountPaid']) . "'
 									WHERE debtorsmaster.debtorno='" . $_SESSION['Items'.$identifier]->DebtorNo . "'";
 
-			$DbgMsg = _('The SQL that failed to update the date of the last payment received was');
 			$ErrMsg = _('Cannot update the customer record for the date of the last payment received because');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			//and finally add the allocation record between receipt and invoice
 
@@ -2019,9 +1986,8 @@ if (isset($_POST['ProcessSale']) AND $_POST['ProcessSale'] != '') {
 											'" . $DefaultDispatchDate . "',
 											 '" . $ReceiptDebtorTransID . "',
 											 '" . $DebtorTransID . "')";
-			$DbgMsg = _('The SQL that failed to insert the allocation of the receipt to the invoice was');
 			$ErrMsg = _('Cannot insert the customer allocation of the receipt to the invoice because');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		} //end if $_POST['AmountPaid']!= 0
 
 		DB_Txn_Commit();
@@ -2275,8 +2241,7 @@ if (!isset($_POST['ProcessSale'])) {
 				FROM stockmaster
 				WHERE controlled = 0";
 		$ErrMsg = _('Could not fetch items list because');
-		$DbgMsg = _('The sql that was used to fetch items list was ');
-		$ItemsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$ItemsResult = DB_query($SQL, $ErrMsg);
 		$ItemCount = DB_num_rows($ItemsResult);
 
 		if ($ItemCount==0)

--- a/CreditStatus.php
+++ b/CreditStatus.php
@@ -34,7 +34,7 @@ if (isset($_POST['submit'])) {
 
 	$SQL="SELECT count(reasoncode)
 			FROM holdreasons WHERE reasoncode='".$_POST['ReasonCode']."'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_row($Result);
 
 	if ($MyRow[0]!=0 and !isset($SelectedReason)) {

--- a/Credit_Invoice.php
+++ b/Credit_Invoice.php
@@ -79,8 +79,7 @@ if (!isset($_GET['InvoiceNumber']) and !$_SESSION['ProcessingCredit']) {
 		$SQL.= " AND debtortrans.salesperson='" . $_SESSION['SalesmanLogin'] . "'";
 	}
 	$ErrMsg = _('A credit cannot be produced for the selected invoice') . '. ' . _('The invoice details cannot be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the invoice details was');
-	$GetInvHdrResult = DB_query($InvoiceHeaderSQL, $ErrMsg, $DbgMsg);
+	$GetInvHdrResult = DB_query($InvoiceHeaderSQL, $ErrMsg);
 
 	if (DB_num_rows($GetInvHdrResult) == 1) {
 
@@ -137,9 +136,8 @@ if (!isset($_GET['InvoiceNumber']) and !$_SESSION['ProcessingCredit']) {
 							AND stockmoves.show_on_inv_crds=1";
 
 		$ErrMsg = _('This invoice can not be credited using this program') . '. ' . _('A manual credit note will need to be prepared') . '. ' . _('The line items of the order cannot be retrieved because');
-		$Dbgmsg = _('The SQL used to get the transaction header was');
 
-		$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg, $DbgMsg);
+		$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 
 		if (DB_num_rows($LineItemsResult) > 0) {
 
@@ -184,8 +182,7 @@ if (!isset($_GET['InvoiceNumber']) and !$_SESSION['ProcessingCredit']) {
 							AND stockid = '" . $MyRow['stockid'] . "'";
 
 					$ErrMsg = _('This invoice can not be credited using this program') . '. ' . _('A manual credit note will need to be prepared') . '. ' . _('The line item') . ' ' . $MyRow['stockid'] . ' ' . _('is controlled but the serial numbers or batch numbers could not be retrieved because');
-					$DbgMsg = _('The SQL used to get the controlled item details was');
-					$SerialItemsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+					$SerialItemsResult = DB_query($SQL, $ErrMsg);
 
 					while ($SerialItemsRow = DB_fetch_array($SerialItemsResult)) {
 						$_SESSION['CreditItems' . $identifier]->LineItems[$LineNumber]->SerialItems[$SerialItemsRow['serialno']] = new SerialItem($SerialItemsRow['serialno'], -$SerialItemsRow['moveqty']);
@@ -598,8 +595,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 				AND type=10";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The alteration to the invoice record to reflect the allocation of the credit note to the invoice could not be done because');
-		$DbgMsg = _('The following SQL to update the invoice allocation was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	}
 
 	/*Now insert the Credit Note into the DebtorTrans table with the allocations as calculated above*/
@@ -641,8 +637,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 							'" . $_SESSION['CreditItems' . $identifier]->SalesPerson . "')";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The customer credit note transaction could not be added to the database because');
-	$DbgMsg = _('The following SQL to insert the customer credit note was used');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	$CreditTransID = DB_Last_Insert_ID('debtortrans', 'id');
 
@@ -658,8 +653,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 					'" . (-$TaxAmount / $_SESSION['CurrencyRate']) . "')";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction taxes records could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the debtor transaction taxes record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	}
 
 	/*Now insert the allocation record if > 0 */
@@ -674,9 +668,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 				'" . Date('Y-m-d') . "')";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The allocation record for the credit note could not be added to the database because');
-		$DbgMsg = _('The following SQL to insert the allocation record for the credit note was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
-
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	}
 
 	/* Update sales order details quantity invoiced less this credit quantity. */
@@ -723,8 +715,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 						AND quantity >=" . $CreditLine->QtyDispatched;
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales order detail record could not be updated for the reduced quantity invoiced because');
-				$DbgMsg = _('The following SQL to update the sales order detail record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/* Update location stock records if not a dummy stock item */
 
@@ -736,8 +727,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 								AND loccode = '" . $_SESSION['CreditItems' . $identifier]->Location . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated because');
-					$DbgMsg = _('The following SQL to update the location stock record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				} else if ($CreditLine->MBflag == 'A') { /* its an assembly */
 					/*Need to get the BOM for this part and make stock moves for the components
@@ -755,8 +745,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
                                 AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 					$ErrMsg = _('Could not retrieve assembly components from the database for') . ' ' . $CreditLine->StockID . ' ' . _('because');
-					$DbgMsg = _('The SQL that failed was');
-					$AssResult = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$AssResult = DB_query($SQL, $ErrMsg, '', true);
 
 					while ($AssParts = DB_fetch_array($AssResult)) {
 
@@ -851,8 +840,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 						}
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records for the assembly components of') . ' ' . $CreditLine->StockID . ' ' . _('could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the assembly components stock movement records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						if ($Component_MBFlag == 'M' or $Component_MBFlag == 'B') {
 							$SQL = "UPDATE locstock
@@ -861,8 +849,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 									AND loccode = '" . $_SESSION['CreditItems' . $identifier]->Location . "'";
 
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated for an assembly component because');
-							$DbgMsg = _('The following SQL to update the components location stock record was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						}
 					} /* end of assembly explosion and updates */
 					/*Update the cart with the recalculated standard cost from the explosion of the assembly's components*/
@@ -940,8 +927,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 				}
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$StkMoveNo = DB_Last_Insert_ID('stockmoves', 'stkmoveno');
 				/*Insert the StockSerialMovements and update the StockSerialItems  for controlled items*/
@@ -955,8 +941,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 								AND serialno='" . $Item->BundleRef . "'";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be selected because');
-						$DbgMsg = _('The following SQL to select the serial stock item record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						if (DB_num_rows($Result) == 0) {
 							$SQL = "INSERT INTO stockserialitems(stockid,
@@ -972,8 +957,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 													 	 '')";
 
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-							$DbgMsg = _('The following SQL to update the serial stock item record was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						} else {
 
 							$SQL = "UPDATE stockserialitems
@@ -982,8 +966,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 								AND loccode='" . $_SESSION['CreditItems' . $identifier]->Location . "'
 								AND serialno='" . $Item->BundleRef . "'";
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-							$DbgMsg = _('The following SQL to update the serial stock item record was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						}
 
 						/* now insert the serial stock movement */
@@ -997,8 +980,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 															'" . $Item->BundleRef . "',
 															'" . $Item->BundleQty . "')";
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					} /* foreach controlled item in the serialitems array */
 				} /*end if the orderline is a controlled item */
@@ -1042,8 +1024,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 											'" . $CreditLine->Narrative . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				/*Get the ID of the StockMove... */
 				$StkMoveNo = DB_Last_Insert_ID('stockmoves', 'stkmoveno');
 
@@ -1084,8 +1065,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 											'" . $CreditLine->Narrative . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			} elseif ($_POST['CreditType'] == 'ReverseOverCharge') {
 				/*Insert a stock movement coming back in to show the credit note  - flag the stockmovement not to show on stock movement enquiries - its is not a real stock movement only for invoice line - also no mods to location stock records*/
@@ -1125,9 +1105,8 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 											'" . $CreditLine->Narrative . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement records for the purpose of display on the credit note was used');
 
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				/*Get the ID of the StockMove... */
 				$StkMoveNo = DB_Last_Insert_ID('stockmoves', 'stkmoveno');
 			}
@@ -1157,8 +1136,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 													  '" . $_SESSION['CurrencyRate'] . "'
 													)";
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales commission accrual record could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the sales commission accrual record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SalesPersonSQL = "SELECT salesmanname, glaccount FROM salesman WHERE salesmancode='" . $_SESSION['CreditItems' . $Identifier]->SalesPerson . "'";
 				$SalesPersonResult = DB_query($SalesPersonSQL);
@@ -1181,8 +1159,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 										'" . round(-$Commission / $_SESSION['CurrencyRate'], $_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The expenses side of the sales commission posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the sales commission record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "INSERT INTO gltrans (type,
 											typeno,
@@ -1201,8 +1178,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 										'" . round($Commission / $_SESSION['CurrencyRate'], $_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The accruals side of the sales commission posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the sales commission record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 
 			/*Insert the taxes that applied to this line */
@@ -1220,8 +1196,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 						'" . $Tax->TaxOnTax . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Taxes and rates applicable to this credit note line item could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement tax detail records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 
 			/*Insert Sales Analysis records */
@@ -1251,9 +1226,8 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 							salesanalysis.area";
 
 			$ErrMsg = _('The count to check for existing Sales analysis records could not run because');
-			$DbgMsg = _('SQL to count the no of sales analysis records');
 
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$MyRow = DB_fetch_row($Result);
 
@@ -1363,8 +1337,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 			}
 
 			$ErrMsg = _('The sales analysis record for this credit note could not be added because');
-			$DbgMsg = _('The following SQL to insert the sales analysis record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/* If GLLink_Stock then insert GLTrans to credit stock and debit cost of sales at standard cost*/
 
@@ -1391,8 +1364,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 							)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The cost of sales GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/*now the stock entry*/
 
@@ -1430,8 +1402,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 				}
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock side or write off of the cost of sales GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			} /* end of if GL and stock integrated and standard cost !=0 */
 
@@ -1457,8 +1428,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 						)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The credit note GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				if ($CreditLine->DiscountPercent != 0) {
 
@@ -1478,8 +1448,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 							'" . -round($CreditLine->Price * $CreditLine->QtyDispatched * $CreditLine->DiscountPercent / $_SESSION['CurrencyRate'], $_SESSION['CompanyRecord']['decimalplaces']) . "'
 							)";
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The credit note discount GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} /*end of if discount !=0 */
 			} /*end of if sales integrated with debtors */
 		} /*Quantity dispatched is more than 0 */
@@ -1506,8 +1475,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 					)";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The total debtor GL posting for the credit note could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 
 		/*Could do with setting up a more flexible freight posting schema that looks at the sales type and area of the customer branch to determine where to post the freight recovery */
@@ -1530,8 +1498,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 					)";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The freight GL posting for this credit note could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 
 		foreach ($TaxTotals as $TaxAuthID => $TaxAmount) {
@@ -1556,8 +1523,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 					)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The tax GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 		}
 

--- a/Currencies.php
+++ b/Currencies.php
@@ -53,7 +53,7 @@ if (isset($_POST['submit'])) {
 			FROM currencies
 			WHERE currabrev='".$_POST['Abbreviation']."'";
 
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_row($Result);
 
 	if ($MyRow[0]!=0 AND !isset($SelectedCurrency)) {
@@ -179,7 +179,7 @@ if (isset($_POST['submit'])) {
 					AND account='" . $MyRowBankAccount['accountcode'] . "'";
 
 			$ErrMsg = _('The bank account balance could not be returned by the SQL because');
-			$BalanceResult = DB_query($SQL,$ErrMsg);
+			$BalanceResult = DB_query($SQL, $ErrMsg);
 			$MyRow = DB_fetch_row($BalanceResult);
 			$OldBalanceInFunctionalCurrency = $MyRow[0];
 			$BalanceInAccountCurrency = $OldBalanceInFunctionalCurrency * $OldRate;
@@ -208,8 +208,7 @@ if (isset($_POST['submit'])) {
 								mb_substr($MyRowBankAccount['bankaccountname'] . ' ' . _('currency rate adjustment to') . ' ' . locale_number_format($NewRate, 'Variable') . ' ' . $SelectedCurrency . '/' . $_SESSION['CompanyRecord']['currencydefault'], 0, 200) . "', '" .
 								(-$DifferenceToAdjust) . "')";
 				$ErrMsg = _('Cannot insert a GL entry for the exchange difference because');
-				$DbgMsg = _('The SQL that failed to insert the exchange difference GL entry was');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				$SQL = "INSERT INTO gltrans (
 								type,
 								typeno,
@@ -226,7 +225,7 @@ if (isset($_POST['submit'])) {
 								mb_substr($MyRowBankAccount['bankaccountname'] . ' ' . _('currency rate adjustment to') . ' ' . locale_number_format($NewRate, 'Variable') . ' ' . $SelectedCurrency . '/' . $_SESSION['CompanyRecord']['currencydefault'], 0, 200) . "', '" .
 								($DifferenceToAdjust) . "')";
 
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				prnMsg(_('Bank Account') . ' ' . $MyRowBankAccount['bankaccountname'] . ' ' . _('Currency Rate difference of') . ' ' . locale_number_format($DifferenceToAdjust, $_SESSION['CompanyRecord']['decimalplaces']) . ' ' . _('has been posted'),'success');
 			}
 		}

--- a/CustItem.php
+++ b/CustItem.php
@@ -74,8 +74,7 @@ if ((isset($_POST['AddRecord']) or isset($_POST['UpdateRecord'])) and isset($Deb
 							'" . $_POST['cust_description'] . "',
 							'" . $_POST['cust_part'] . "')";
 		$ErrMsg = _('The customer Item details could not be added to the database because');
-		$DbgMsg = _('The SQL that failed was');
-		$AddResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$AddResult = DB_query($SQL, $ErrMsg);
 		prnMsg(_('This customer data has been added to the database'), 'success');
 		unset($DebtorsMasterResult);
 	}
@@ -87,8 +86,7 @@ if ((isset($_POST['AddRecord']) or isset($_POST['UpdateRecord'])) and isset($Deb
 							WHERE custitem.stockid='" . $StockId . "'
 							AND custitem.debtorno='" . $DebtorNo . "'";
 		$ErrMsg = _('The customer details could not be updated because');
-		$DbgMsg = _('The SQL that failed was');
-		$UpdResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$UpdResult = DB_query($SQL, $ErrMsg);
 		prnMsg(_('customer data has been updated'), 'success');
 		unset($DebtorsMasterResult);
 		unset($DebtorNo);
@@ -187,8 +185,7 @@ if (isset($DebtorNo) and $DebtorNo != '' and !isset($_POST['Searchcustomer'])) {
 			ON debtorsmaster.currcode=currencies.currabrev
 			WHERE DebtorNo='" . $DebtorNo . "'";
 	$ErrMsg = _('The customer details for the selected customer could not be retrieved because');
-	$DbgMsg = _('The SQL that failed was');
-	$SuppSelResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SuppSelResult = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($SuppSelResult) == 1) {
 		$MyRow = DB_fetch_array($SuppSelResult);
 		$Name = $MyRow['name'];
@@ -271,8 +268,7 @@ if (isset($_POST['Searchcustomer'])) {
 
 	} //one of keywords or cust_part was more than a zero length string
 	$ErrMsg = _('The cuswtomer matching the criteria entered could not be retrieved because');
-	$DbgMsg = _('The SQL to retrieve customer details that failed was');
-	$DebtorsMasterResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$DebtorsMasterResult = DB_query($SQL, $ErrMsg);
 } //end of if search
 if (isset($DebtorsMasterResult) and DB_num_rows($DebtorsMasterResult) > 0) {
 	if (isset($StockId)) {

--- a/CustLoginSetup.php
+++ b/CustLoginSetup.php
@@ -24,7 +24,7 @@ $SQL="SELECT name
 		FROM debtorsmaster
 		WHERE debtorno='".$_SESSION['CustomerID']."'";
 
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 $MyRow=DB_fetch_array($Result);
 $CustomerName=$MyRow['name'];
 
@@ -70,8 +70,7 @@ if (isset($_POST['submit'])) {
 				AND branchcode='" . $_POST['BranchCode'] . "'";
 
 		$ErrMsg = _('The check on validity of the customer code and branch failed because');
-		$DbgMsg = _('The SQL that was used to check the customer code and branch was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($Result)==0){
 			prnMsg(_('The entered Branch Code is not valid for the entered Customer Code'),'error');
@@ -115,8 +114,7 @@ if (isset($_POST['submit'])) {
 											'". $_POST['UserLanguage'] ."')";
 
 			$ErrMsg = _('The user could not be added because');
-			$DbgMsg = _('The SQL that was used to insert the new user and failed was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg( _('A new customer login has been created'), 'success' );
 			include('includes/footer.php');
 			exit();

--- a/CustWhereAlloc.php
+++ b/CustWhereAlloc.php
@@ -204,7 +204,7 @@ if ($_POST['TransType']== 12) {
 					FROM gltrans LEFT JOIN bankaccounts ON account=accountcode
 					WHERE type=12 AND typeno='".$_POST['TransNo']."' AND account !='". $_SESSION['CompanyRecord']['debtorsact'] ."' AND accountcode IS NULL";
 	$ErrMsg = _('Failed to retrieve charge data');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result)>0) {
 		while ($MyRow = DB_fetch_array($Result)){
 			echo '<div class="centre">

--- a/CustomerAccount.php
+++ b/CustomerAccount.php
@@ -27,7 +27,7 @@ if ($_SESSION['SalesmanLogin'] != '') {
 	$ViewAllowed = false;
 	$SQL = "SELECT salesman FROM custbranch WHERE debtorno = '" . $CustomerID . "'";
 	$ErrMsg = _('Failed to retrieve sales data');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if(DB_num_rows($Result)>0) {
 		while($MyRow = DB_fetch_array($Result)) {
 			if ($_SESSION['SalesmanLogin'] == $MyRow['salesman']) {

--- a/CustomerAllocations.php
+++ b/CustomerAllocations.php
@@ -314,7 +314,7 @@ if (isset($_GET['AllocTrans'])) {
 
 	$SQL .= " ORDER BY debtortrans.trandate, debtortrans.transno";
 
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 
 	while ($MyRow=DB_fetch_array($Result)) {
 		$DiffOnExchThisOne = ($MyRow['amt']/$MyRow['rate']) - ($MyRow['amt']/$_SESSION['Alloc']->TransExRate);

--- a/CustomerBranches.php
+++ b/CustomerBranches.php
@@ -344,7 +344,7 @@ if (isset($_POST['submit'])) {
 								$SQL .= " AND custbranch.salesman='" . $_SESSION['SalesmanLogin'] . "'";
 							}
 							$ErrMsg = _('The branch record could not be deleted') . ' - ' . _('the SQL server returned the following message');
-							$Result = DB_query($SQL,$ErrMsg);
+							$Result = DB_query($SQL, $ErrMsg);
 							if (DB_error_no()==0){
 								prnMsg(_('Branch Deleted'),'success');
 							}

--- a/CustomerInquiry.php
+++ b/CustomerInquiry.php
@@ -26,7 +26,7 @@ if ($_SESSION['SalesmanLogin'] != '') {
 	$ViewAllowed = false;
 	$SQL = "SELECT salesman FROM custbranch WHERE debtorno = '" . $CustomerID . "'";
 	$ErrMsg = _('Failed to retrieve sales data');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if(DB_num_rows($Result)>0) {
 		while($MyRow = DB_fetch_array($Result)) {
 			if ($_SESSION['SalesmanLogin'] == $MyRow['salesman']){

--- a/CustomerReceipt.php
+++ b/CustomerReceipt.php
@@ -3,7 +3,10 @@
 
 include('includes/DefineReceiptClass.php');
 include('includes/session.php');
-if (isset($_POST['DateBanked'])){$_POST['DateBanked'] = ConvertSQLDate($_POST['DateBanked']);}
+
+if (isset($_POST['DateBanked'])) {
+	$_POST['DateBanked'] = ConvertSQLDate($_POST['DateBanked']);
+}
 
 include('includes/GetPaymentMethods.php');
 
@@ -74,7 +77,7 @@ if (!isset($_GET['Delete']) AND isset($_SESSION['ReceiptBatch' . $identifier])){
 			WHERE accountcode='" . $_POST['BankAccount']."'";
 
 	$ErrMsg =_('The bank account name cannot be retrieved because');
-	$Result= DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result)==1){
 		$MyRow = DB_fetch_array($Result);
@@ -302,7 +305,7 @@ if (isset($_POST['CommitBatch'])){
 	foreach ($_SESSION['ReceiptBatch' . $identifier]->Items as $ReceiptItem) {
 
 		$SQL = "SELECT accountname FROM chartmaster WHERE accountcode='" . $ReceiptItem->GLCode . "'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 
 		echo '<tr class="striped_row">
@@ -336,8 +339,7 @@ if (isset($_POST['CommitBatch'])){
 						'" . -($ReceiptItem->Amount/$_SESSION['ReceiptBatch' . $identifier]->ExRate/$_SESSION['ReceiptBatch' . $identifier]->FunctionalExRate) . "'
 					)";
 				$ErrMsg = _('Cannot insert a GL entry for the receipt because');
-				$DbgMsg = _('The SQL that failed to insert the receipt GL entry was');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				InsertGLTags($ReceiptItem->tag);
 			}
 
@@ -415,9 +417,8 @@ if (isset($_POST['CommitBatch'])){
 							'" . $_SESSION['ReceiptBatch' . $identifier]->Currency . "'
 						)";
 
-				$DbgMsg = _('The SQL that failed to insert the bank transaction was');
 				$ErrMsg = _('Cannot insert a bank transaction using the SQL');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			} //end if an item is a transfer between bank accounts
 
 		} else { //its not a GL item - its a customer receipt then
@@ -461,18 +462,16 @@ if (isset($_POST['CommitBatch'])){
 						'" . $ReceiptItem->Narrative. "',
 						'" . $_SESSION['SalesmanLogin']. "'
 					)";
-			$DbgMsg = _('The SQL that failed to insert the customer receipt transaction was');
 			$ErrMsg = _('Cannot insert a receipt transaction against the customer because') ;
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$SQL = "UPDATE debtorsmaster
 						SET lastpaiddate = '" . FormatDateForSQL($_SESSION['ReceiptBatch' . $identifier]->DateBanked) . "',
 						lastpaid='" . $ReceiptItem->Amount ."'
 					WHERE debtorsmaster.debtorno='" . $ReceiptItem->Customer . "'";
 
-			$DbgMsg = _('The SQL that failed to update the date of the last payment received was');
 			$ErrMsg = _('Cannot update the customer record for the date of the last payment received because');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		} //end of if its a customer receipt
 		$BatchDiscount += ($ReceiptItem->Discount/$_SESSION['ReceiptBatch' . $identifier]->ExRate/$_SESSION['ReceiptBatch' . $identifier]->FunctionalExRate);
@@ -505,9 +504,8 @@ if (isset($_POST['CommitBatch'])){
 			'" . ($BatchReceiptsTotal * $_SESSION['ReceiptBatch' . $identifier]->FunctionalExRate * $_SESSION['ReceiptBatch' . $identifier]->ExRate) . "',
 			'" . $_SESSION['ReceiptBatch' . $identifier]->Currency . "'
 		)";
-	$DbgMsg = _('The SQL that failed to insert the bank account transaction was');
 	$ErrMsg = _('Cannot insert a bank transaction');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 	if ($_SESSION['CompanyRecord']['gllink_debtors']==1){ /* then enter GLTrans records for discount, bank and debtors */
@@ -530,9 +528,8 @@ if (isset($_POST['CommitBatch'])){
 					'" . mb_substr($_SESSION['ReceiptBatch' . $identifier]->Narrative, 0, 200) . "',
 					'" . $BatchReceiptsTotal . "'
 				)";
-			$DbgMsg = _('The SQL that failed to insert the GL transaction fro the bank account debit was');
 			$ErrMsg = _('Cannot insert a GL transaction for the bank account debit');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 		}
@@ -554,9 +551,8 @@ if (isset($_POST['CommitBatch'])){
 							'" . mb_substr($_SESSION['ReceiptBatch' . $identifier]->Narrative, 0, 200) . "',
 							'" . -$BatchDebtorTotal . "'
 							)";
-			$DbgMsg = _('The SQL that failed to insert the GL transaction for the debtors account credit was');
 			$ErrMsg = _('Cannot insert a GL transaction for the debtors account credit');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		} //end if there are some customer deposits in this batch
 
@@ -578,17 +574,15 @@ if (isset($_POST['CommitBatch'])){
 								'" . mb_substr($_SESSION['ReceiptBatch' . $identifier]->Narrative, 0, 200) . "',
 								'" . $BatchDiscount . "'
 							)";
-			$DbgMsg = _('The SQL that failed to insert the GL transaction for the payment discount debit was');
 			$ErrMsg = _('Cannot insert a GL transaction for the payment discount debit');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		} //end if there is some discount
 
 	} //end if there is GL work to be done - ie config is to link to GL
 	EnsureGLEntriesBalance(12,$_SESSION['ReceiptBatch' . $identifier]->BatchNo);
 
 	$ErrMsg = _('Cannot commit the changes');
-	$DbgMsg = _('The SQL that failed was');
-	 DB_Txn_Commit();
+	DB_Txn_Commit();
 	prnMsg( _('Receipt batch') . ' ' . $_SESSION['ReceiptBatch' . $identifier]->BatchNo . ' ' . _('has been successfully entered into the database'),'success');
 
 	echo '<div class="centre noPrint">',
@@ -739,8 +733,7 @@ customer record returned by the search - this record is then auto selected */
 
 
 	$ErrMsg = _('The customer details could not be retrieved because');
-	$DbgMsg = _('The SQL that failed was');
-	$CustomerResult = DB_query($SQL,$ErrMsg, $DbgMsg);
+	$CustomerResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($CustomerResult)==0){
 
@@ -767,8 +760,7 @@ customer record returned by the search - this record is then auto selected */
 					WHERE debtorsmaster.debtorno = '" . $_POST['CustomerID'] . "'";
 
 		$ErrMsg = _('The customer details could not be retrieved because');
-		$DbgMsg = _('The SQL that failed was');
-		$CustomerResult = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$CustomerResult = DB_query($SQL, $ErrMsg);
 
 	} else {
 		$NIL_BALANCE = False;
@@ -804,8 +796,7 @@ $SQL = "SELECT bankaccountname,
 		ORDER BY bankaccountname";
 
 $ErrMsg = _('The bank accounts could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve the bank accounts was');
-$AccountsResults = DB_query($SQL,$ErrMsg,$DbgMsg);
+$AccountsResults = DB_query($SQL, $ErrMsg);
 
 if (isset($_POST['GLEntry'])) {
 	echo '<p class="page_title_text"><img src="'.$RootPath.'/css/'.$Theme.'/images/transactions.png" title="' . _('Bank Account Receipts Entry') . '" alt="" />' . ' ' . _('Bank Account Receipts Entry') . '</p>';
@@ -855,7 +846,7 @@ if (!isset($_SESSION['ReceiptBatch' . $identifier]->Currency)){
   $_SESSION['ReceiptBatch' . $identifier]->Currency=$_SESSION['CompanyRecord']['currencydefault'];
 }
 $SQL = "SELECT currency, currabrev, rate FROM currencies";
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 if (DB_num_rows($Result)==0){
 	echo '</select></field>';
 	prnMsg(_('No currencies are defined yet') . '. ' . _('Receipts cannot be entered until a currency is defined'),'warn');
@@ -1021,7 +1012,7 @@ if (isset($_SESSION['ReceiptBatch' . $identifier])){
 			$TagDescriptions = GetDescriptionsFromTagArray($ReceiptItem->tag);
 
 			$SQL = "SELECT accountname FROM chartmaster WHERE accountcode='" . $ReceiptItem->GLCode . "'";
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 			$MyRow=DB_fetch_array($Result);
 
 			echo '<tr>
@@ -1149,7 +1140,7 @@ if (isset($_POST['GLEntry']) AND isset($_SESSION['ReceiptBatch' . $identifier]))
 			FROM chartmaster
 				INNER JOIN glaccountusers ON glaccountusers.accountcode=chartmaster.accountcode AND glaccountusers.userid='" .  $_SESSION['UserID'] . "' AND glaccountusers.canupd=1
 			ORDER BY chartmaster.accountcode";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	if (DB_num_rows($Result)==0){
 		echo '</select>
 			<fieldhelp>' . _('No General ledger accounts have been set up yet') . ' - ' . _('receipts cannot be entered against GL accounts until the GL accounts are set up') . '</fieldhelp>

--- a/CustomerTransInquiry.php
+++ b/CustomerTransInquiry.php
@@ -92,8 +92,7 @@ if (isset($_POST['ShowResults']) && $_POST['TransType'] != ''){
 	$SQL .=  " ORDER BY id";
 
    $ErrMsg = _('The customer transactions for the selected criteria could not be retrieved because') . ' - ' . DB_error_msg();
-   $DbgMsg =  _('The SQL that failed was');
-   $TransResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+   $TransResult = DB_query($SQL, $ErrMsg);
 
    echo '<table class="selection">
 			<thead>

--- a/CustomerTypes.php
+++ b/CustomerTypes.php
@@ -140,7 +140,7 @@ if (isset($_POST['submit'])) {
 	       WHERE debtortrans.type='".$SelectedType."'";
 
 	$ErrMsg = _('The number of transactions using this customer type could not be retrieved');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_row($Result);
 	if ($MyRow[0]>0) {
@@ -151,7 +151,7 @@ if (isset($_POST['submit'])) {
 		$SQL = "SELECT COUNT(*) FROM debtorsmaster WHERE typeid='".$SelectedType."'";
 
 		$ErrMsg = _('The number of transactions using this Type record could not be retrieved because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$MyRow = DB_fetch_row($Result);
 		if ($MyRow[0]>0) {
 			prnMsg (_('Cannot delete this type because customers are currently set up to use this type') . '<br />' . _('There are') . ' ' . $MyRow[0] . ' ' . _('customers with this type code'));
@@ -163,7 +163,7 @@ if (isset($_POST['submit'])) {
 
 				$SQL="DELETE FROM debtortype WHERE typeid='".$SelectedType."'";
 				$ErrMsg = _('The Type record could not be deleted because');
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 				echo '<br />';
 				prnMsg(_('Customer type') . ' ' . $TypeName  . ' ' . _('has been deleted') ,'success');
 			}

--- a/Customers.php
+++ b/Customers.php
@@ -44,7 +44,7 @@ if (isset($_POST['submit'])) {
 	$_POST['DebtorNo'] = mb_strtoupper($_POST['DebtorNo']);
 
 	$SQL="SELECT COUNT(debtorno) FROM debtorsmaster WHERE debtorno='".$_POST['DebtorNo']."'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_row($Result);
 	if ($MyRow[0]>0 AND isset($_POST['New'])) {
 		$InputError = 1;
@@ -200,7 +200,7 @@ if (isset($_POST['submit'])) {
 			}
 
 			$ErrMsg = _('The customer could not be updated because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg( _('Customer updated'),'success');
 			echo '<br />';
 
@@ -261,7 +261,7 @@ if (isset($_POST['submit'])) {
 						'" . $_POST['LanguageID'] . "')";
 
 			$ErrMsg = _('This customer could not be added because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			$BranchCode = mb_substr($_POST['DebtorNo'],0,4);
 
@@ -339,7 +339,7 @@ if (isset($_POST['submit'])) {
 	}
 	if ($CancelDelete==0) { //ie not cancelled the delete as a result of above tests
 		$SQL="DELETE FROM custbranch WHERE debtorno='" . $_POST['DebtorNo'] . "'";
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$SQL="DELETE FROM custcontacts WHERE debtorno='" . $_POST['DebtorNo'] . "'";
 		$Result = DB_query($SQL);
 		$SQL="DELETE FROM debtorsmaster WHERE debtorno='" . $_POST['DebtorNo'] . "'";
@@ -417,7 +417,7 @@ if (!isset($DebtorNo)) {
 	$SetupErrors=0; //Count errors
 	$SQL="SELECT COUNT(typeabbrev)
 				FROM salestypes";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_row($Result);
 	if ($MyRow[0]==0) {
 		prnMsg( _('In order to create a new customer you must first set up at least one sales type/price list') . '<br />' .
@@ -426,7 +426,7 @@ if (!isset($DebtorNo)) {
 	}
 	$SQL="SELECT COUNT(typeid)
 				FROM debtortype";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_row($Result);
 	if ($MyRow[0]==0) {
 		prnMsg( _('In order to create a new customer you must first set up at least one customer type') . '<br />' .
@@ -501,7 +501,7 @@ if (!isset($DebtorNo)) {
 		</field>';
 
 // Show Sales Type drop down list
-	$Result=DB_query("SELECT typeabbrev, sales_type FROM salestypes ORDER BY sales_type");
+	$Result = DB_query("SELECT typeabbrev, sales_type FROM salestypes ORDER BY sales_type");
 	if (DB_num_rows($Result)==0){
 		$DataError =1;
 		echo '<field>
@@ -521,7 +521,7 @@ if (!isset($DebtorNo)) {
 	}
 
 // Show Customer Type drop down list
-	$Result=DB_query("SELECT typeid, typename FROM debtortype ORDER BY typename");
+	$Result = DB_query("SELECT typeid, typename FROM debtortype ORDER BY typename");
 	if (DB_num_rows($Result)==0){
 		$DataError =1;
 		echo '<a href="SalesTypes.php?" target="_parent">' . _('Setup Types') . '</a>';
@@ -570,7 +570,7 @@ if (!isset($DebtorNo)) {
 					<input tabindex="15" type="text" name="TaxRef" size="22" maxlength="20" />
 				</field>';
 
-	$Result=DB_query("SELECT terms, termsindicator FROM paymentterms");
+	$Result = DB_query("SELECT terms, termsindicator FROM paymentterms");
 	if (DB_num_rows($Result)==0){
 		$DataError =1;
 		echo '<field><td colspan="2">' . prnMsg(_('There are no payment terms currently defined - go to the setup tab of the main menu and set at least one up first'),'error','',true) . '</td></field>';
@@ -592,7 +592,7 @@ if (!isset($DebtorNo)) {
 			<label for="HoldReason">' . _('Credit Status') . ':</label>
 			<select tabindex="16" name="HoldReason" required="required">';
 
-	$Result=DB_query("SELECT reasoncode, reasondescription FROM holdreasons");
+	$Result = DB_query("SELECT reasoncode, reasondescription FROM holdreasons");
 	if (DB_num_rows($Result)==0){
 		$DataError =1;
 		echo '<field>
@@ -607,7 +607,7 @@ if (!isset($DebtorNo)) {
 			</field>';
 	}
 
-	$Result=DB_query("SELECT currency, currabrev FROM currencies");
+	$Result = DB_query("SELECT currency, currabrev FROM currencies");
 	if (DB_num_rows($Result)==0){
 		$DataError =1;
 		echo '<field>
@@ -713,7 +713,7 @@ if (!isset($DebtorNo)) {
 				WHERE debtorno = '" . $DebtorNo . "'";
 
 		$ErrMsg = _('The customer details could not be retrieved because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$MyRow = DB_fetch_array($Result);
 		/* if $AutoDebtorNo in config.php has not been set or if it has been set to a number less than one,
@@ -834,13 +834,13 @@ if (!isset($DebtorNo)) {
 	}
 // Select sales types for drop down list
 	if (isset($_GET['Modify'])) {
-		$Result=DB_query("SELECT sales_type FROM salestypes WHERE typeabbrev='".$_POST['SalesType']."'");
+		$Result = DB_query("SELECT sales_type FROM salestypes WHERE typeabbrev='".$_POST['SalesType']."'");
 		$MyRow=DB_fetch_array($Result);
 		echo '<field>
 				<td>' . _('Sales Type') . ':</td>
 				<td>' . $MyRow['sales_type'] . '</td></field>';
 	} else {
-		$Result=DB_query("SELECT typeabbrev, sales_type FROM salestypes");
+		$Result = DB_query("SELECT typeabbrev, sales_type FROM salestypes");
 		echo '<field>
 				<label for="SalesType">' . _('Sales Type') . '/' . _('Price List') . ':</label>
 				<select name="SalesType" required="required">';
@@ -858,14 +858,14 @@ if (!isset($DebtorNo)) {
 
 // Select Customer types for drop down list for SELECT/UPDATE
 	if (isset($_GET['Modify'])) {
-		$Result=DB_query("SELECT typename FROM debtortype WHERE typeid='".$_POST['typeid']."'");
+		$Result = DB_query("SELECT typename FROM debtortype WHERE typeid='".$_POST['typeid']."'");
 		$MyRow=DB_fetch_array($Result);
 		echo '<field>
 				<td>' . _('Customer Type') . ':</td>
 				<td>' . $MyRow['typename'] . '</td>
 			</field>';
 	} else {
-		$Result=DB_query("SELECT typeid, typename FROM debtortype ORDER BY typename");
+		$Result = DB_query("SELECT typeid, typename FROM debtortype ORDER BY typename");
 		echo '<field>
 				<label for="typeid">' . _('Customer Type') . ':</label>
 				<select name="typeid" required="required">';
@@ -941,14 +941,14 @@ if (!isset($DebtorNo)) {
 	}
 
 	if (isset($_GET['Modify'])) {
-		$Result=DB_query("SELECT terms FROM paymentterms WHERE termsindicator='".$_POST['PaymentTerms']."'");
+		$Result = DB_query("SELECT terms FROM paymentterms WHERE termsindicator='".$_POST['PaymentTerms']."'");
 		$MyRow=DB_fetch_array($Result);
 		echo '<field>
 				<td>' . _('Payment Terms') . ':</td>
 				<td>' . $MyRow['terms'] . '</td>
 			</field>';
 	} else {
-		$Result=DB_query("SELECT terms, termsindicator FROM paymentterms");
+		$Result = DB_query("SELECT terms, termsindicator FROM paymentterms");
 		echo '<field>
 				<label for="PaymentTerms">' . _('Payment Terms') . ':</label>
 				<select name="PaymentTerms" required="required">';
@@ -965,14 +965,14 @@ if (!isset($DebtorNo)) {
 	}
 
 	if (isset($_GET['Modify'])) {
-		$Result=DB_query("SELECT reasondescription FROM holdreasons WHERE reasoncode='".$_POST['HoldReason']."'");
+		$Result = DB_query("SELECT reasondescription FROM holdreasons WHERE reasoncode='".$_POST['HoldReason']."'");
 		$MyRow=DB_fetch_array($Result);
 		echo '<field>
 				<td>' . _('Credit Status') . ':</td>
 				<td>' . $MyRow['reasondescription'] . '</td>
 			</field>';
 	} else {
-		$Result=DB_query("SELECT reasoncode, reasondescription FROM holdreasons");
+		$Result = DB_query("SELECT reasoncode, reasondescription FROM holdreasons");
 		echo '<field>
 				<label for="HoldReason">' . _('Credit Status') . ':</label>
 				<select name="HoldReason" required="required">';
@@ -993,7 +993,7 @@ if (!isset($DebtorNo)) {
 				<td>' . _('Customer Currency') . ':</td>
 				<td>' . $CurrencyName[$_POST['CurrCode']] . '</td></field>';
 	} else {
-		$Result=DB_query("SELECT currency, currabrev FROM currencies");
+		$Result = DB_query("SELECT currency, currabrev FROM currencies");
 		echo '<field>
 				<label for="CurrCode">' . _('Customer Currency') . ':</label>
 				<select name="CurrCode" required="required">';

--- a/DailyBankTransactions.php
+++ b/DailyBankTransactions.php
@@ -40,8 +40,7 @@ if (!isset($_POST['Show'])) {
 			WHERE bankaccountusers.userid = '" . $_SESSION['UserID'] . "'
 			ORDER BY bankaccounts.bankaccountname";
 	$ErrMsg = _('The bank accounts could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the bank accounts was');
-	$AccountsResults = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$AccountsResults = DB_query($SQL, $ErrMsg);
 
 	echo '<p class="page_title_text"><img alt="" src="', $RootPath, '/css/', $Theme, '/images/bank.png" title="', // Icon image.
 	$Title, '" /> ', // Icon title.

--- a/DailySalesInquiry.php
+++ b/DailySalesInquiry.php
@@ -48,7 +48,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 
 	$SQL .= " GROUP BY stockmoves.trandate ORDER BY stockmoves.trandate";
 	$ErrMsg = _('The sales data could not be retrieved because') . ' - ' . DB_error_msg();
-	$SalesResult = DB_query($SQL,$ErrMsg);
+	$SalesResult = DB_query($SQL, $ErrMsg);
 
 	$HTML = '';
 

--- a/DeliveryDetails.php
+++ b/DeliveryDetails.php
@@ -163,8 +163,7 @@ if(isset($_POST['Update'])
 				AND custbranch.debtorno = '" . $_SESSION['Items'.$identifier]->DebtorNo . "'";
 
 		$ErrMsg = _('The customer branch record of the customer selected') . ': ' . $_SESSION['Items'.$identifier]->CustomerName . ' ' . _('cannot be retrieved because');
-		$DbgMsg = _('SQL used to retrieve the branch details was') . ':';
-		$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		if(DB_num_rows($Result)==0) {
 
 			prnMsg(_('The branch details for branch code') . ': ' . $_SESSION['Items'.$identifier]->Branch . ' ' . _('against customer code') . ': ' . $_POST['Select'] . ' ' . _('could not be retrieved') . '. ' . _('Check the set up of the customer and branch'),'error');
@@ -244,8 +243,7 @@ if(isset($_POST['Update'])
 						FROM shippers
 						WHERE shipper_id='" . $_SESSION['Default_Shipper']."'";
 			$ErrMsg = _('There was a problem testing for the default shipper');
-			$DbgMsg = _('SQL used to test for the default shipper') . ':';
-			$TestShipperExists = DB_query($SQL,$ErrMsg,$DbgMsg);
+			$TestShipperExists = DB_query($SQL, $ErrMsg);
 
 			if(DB_num_rows($TestShipperExists)==1) {
 
@@ -255,7 +253,7 @@ if(isset($_POST['Update'])
 
 				$SQL = "SELECT shipper_id
 							FROM shippers";
-				$TestShipperExists = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$TestShipperExists = DB_query($SQL, $ErrMsg);
 
 				if(DB_num_rows($TestShipperExists)>=1) {
 					$ShipperReturned = DB_fetch_row($TestShipperExists);
@@ -311,9 +309,7 @@ if(isset($_POST['ProcessOrder'])) {
 			AND debtorsmaster.debtorno = '" . $_SESSION['Items'.$identifier]->DebtorNo . "'";
 
 		$ErrMsg = _('The customer terms cannot be determined') . '. ' . _('This order cannot be processed because');
-		$DbgMsg = _('SQL used to find the customer terms') . ':';
-		$TermsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
-
+		$TermsResult = DB_query($SQL, $ErrMsg);
 
 		$MyRow = DB_fetch_array($TermsResult);
 		if($MyRow['daysbeforedue']==0 AND $MyRow['dayinfollowingmonth']==0) {
@@ -399,7 +395,7 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 								)";
 
 	$ErrMsg = _('The order cannot be added because');
-	$InsertQryResult = DB_query($HeaderSQL,$ErrMsg);
+	$InsertQryResult = DB_query($HeaderSQL, $ErrMsg);
 
 
 	$StartOf_LineItemsSQL = "INSERT INTO salesorderdetails (
@@ -413,7 +409,6 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 											poline,
 											itemdue)
 										VALUES (";
-	$DbgMsg = _('The SQL that failed was');
 	foreach ($_SESSION['Items'.$identifier]->LineItems as $StockItem) {
 
 		$LineItemsSQL = $StartOf_LineItemsSQL ."
@@ -428,7 +423,7 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 					'" . FormatDateForSQL($StockItem->ItemDue) . "'
 				)";
 		$ErrMsg = _('Unable to add the sales order line');
-		$Ins_LineItemResult = DB_query($LineItemsSQL,$ErrMsg,$DbgMsg,true);
+		$Ins_LineItemResult = DB_query($LineItemsSQL, $ErrMsg,'',true);
 
 		/*Now check to see if the item is manufactured
 		 * 			and AutoCreateWOs is on
@@ -469,7 +464,7 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 										'" . Date('Y-m-d') . "',
 										'" . FormatDateForSQL($StockItem->ItemDue) . "')",
 										$ErrMsg,
-										$DbgMsg,
+										'',
 										true);
 				//Need to get the latest BOM to roll up cost
 				$CostResult = DB_query("SELECT SUM((actualcost)*bom.quantity) AS cost
@@ -495,7 +490,7 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 										 '" . $WOQuantity . "',
 										 '" . $Cost . "')";
 				$ErrMsg = _('The work order item could not be added');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				//Recursively insert real component requirements - see includes/SQL_CommonFunctions.in for function WoRealRequirements
 				WoRealRequirements($WONo, $_SESSION['DefaultFactoryLocation'], $StockItem->StockID);
@@ -524,13 +519,13 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 															'" . $StockItem->StockID . "',
 															'" . ($StockItem->NextSerialNo + $i) . "')";
 								$ErrMsg = _('The serial number for the work order item could not be added');
-								$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+								$Result = DB_query($SQL, $ErrMsg, '', true);
 								$FactoryManagerEmail .= "\n" . ($StockItem->NextSerialNo + $i);
 							}
 						}//end loop around creation of woserialnos
 						$NewNextSerialNo = ($StockItem->NextSerialNo + $WOQuantity +1);
 						$ErrMsg = _('Could not update the new next serial number for the item');
-						$UpdateNextSerialNoResult = DB_query("UPDATE stockmaster SET nextserialno='" . $NewNextSerialNo . "' WHERE stockid='" . $StockItem->StockID . "'",$ErrMsg,$DbgMsg,true);
+						$UpdateNextSerialNoResult = DB_query("UPDATE stockmaster SET nextserialno='" . $NewNextSerialNo . "' WHERE stockid='" . $StockItem->StockID . "'", $ErrMsg, '', true);
 				}// end if the item is serialised and nextserialno is set
 
 				$EmailSubject = _('New Work Order Number') . ' ' . $WONo . ' ' . _('for') . ' ' . $StockItem->StockID . ' x ' . $WOQuantity;
@@ -627,12 +622,11 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 			$ContractRow = DB_fetch_array($ContractResult);
 			$WONo = GetNextTransNo(40);
 			$ErrMsg = _('Could not update the contract status');
-			$DbgMsg = _('The SQL that failed to update the contract status was');
-			$UpdContractResult=DB_query("UPDATE contracts SET status=2,
+			$UpdContractResult = DB_query("UPDATE contracts SET status=2,
 															wo='" . $WONo . "'
 										WHERE orderno='" .$_SESSION['ExistingOrder'.$identifier] . "'",
 										$ErrMsg,
-										$DbgMsg,
+										'',
 										true);
 			$ErrMsg = _('Could not insert the contract bill of materials');
 			$InsContractBOM = DB_query("INSERT INTO bom (parent,
@@ -651,8 +645,7 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 													quantity
 											FROM contractbom
 											WHERE contractref='" . $ContractRow['contractref'] . "'",
-											$ErrMsg,
-											$DbgMsg);
+											$ErrMsg);
 
 			$ErrMsg = _('Unable to insert a new work order for the sales order item');
 			$InsWOResult = DB_query("INSERT INTO workorders (wo,
@@ -663,8 +656,7 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 													'" . $_SESSION['Items'.$identifier]->Location ."',
 													'" . $ContractRow['requireddate'] . "',
 													'" . Date('Y-m-d'). "')",
-										$ErrMsg,
-										$DbgMsg);
+										$ErrMsg);
 			//Need to get the latest BOM to roll up cost but also add the contract other requirements
 			$CostResult = DB_query("SELECT SUM((actualcost)*contractbom.quantity) AS cost
 									FROM stockmaster INNER JOIN contractbom
@@ -694,7 +686,7 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 									 '1',
 									 '" . $Cost . "')";
 			$ErrMsg = _('The work order item could not be added');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			//Recursively insert real component requirements - see includes/SQL_CommonFunctions.in for function WoRealRequirements
 			WoRealRequirements($WONo, $_SESSION['Items'.$identifier]->Location, $ContractRow['contractref']);
@@ -729,10 +721,8 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 										deliverblind = '" . $_SESSION['Items'.$identifier]->DeliverBlind . "'
 						WHERE salesorders.orderno='" . $_SESSION['ExistingOrder'.$identifier] ."'";
 
-	$DbgMsg = _('The SQL that was used to update the order and failed was');
 	$ErrMsg = _('The order cannot be updated because');
-	$InsertQryResult = DB_query($HeaderSQL,$ErrMsg,$DbgMsg,true);
-
+	$InsertQryResult = DB_query($HeaderSQL, $ErrMsg, '', true);
 
 	foreach ($_SESSION['Items'.$identifier]->LineItems as $StockItem) {
 
@@ -753,9 +743,8 @@ if(isset($OK_to_PROCESS) AND $OK_to_PROCESS == 1 AND $_SESSION['ExistingOrder'.$
 						WHERE salesorderdetails.orderno='" . $_SESSION['ExistingOrder'.$identifier] . "'
 						AND salesorderdetails.orderlineno='" . $StockItem->LineNumber . "'";
 
-		$DbgMsg = _('The SQL that was used to modify the order line and failed was');
 		$ErrMsg = _('The updated order line cannot be modified because');
-		$Upd_LineItemResult = DB_query($LineItemsSQL,$ErrMsg,$DbgMsg,true);
+		$Upd_LineItemResult = DB_query($LineItemsSQL, $ErrMsg, '', true);
 
 	} /* updated line items into sales order details */
 
@@ -965,8 +954,7 @@ $SQL = "SELECT locations.loccode, locationname
 	WHERE locations.allowinvoicing='1'
 	ORDER BY locations.locationname";
 $ErrMsg = _('The stock locations could not be retrieved');
-$DbgMsg = _('SQL used to retrieve the stock locations was') . ':';
-$StkLocsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+$StkLocsResult = DB_query($SQL, $ErrMsg);
 // COMMENT: What if there is no authorized locations available for this user?
 while($MyRow=DB_fetch_array($StkLocsResult)) {
 	echo '<option', ($_SESSION['Items'.$identifier]->Location==$MyRow['loccode'] ? ' selected="selected"' : ''), ' value="', $MyRow['loccode'], '">', $MyRow['locationname'], '</option>';
@@ -1129,10 +1117,9 @@ echo'<field>
 				<select name="ShipVia">';
 
 		$ErrMsg = _('The shipper details could not be retrieved');
-		$DbgMsg = _('SQL used to retrieve the shipper details was') . ':';
 
 		$SQL = "SELECT shipper_id, shippername FROM shippers";
-		$ShipperResults = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$ShipperResults = DB_query($SQL, $ErrMsg);
 		while ($MyRow=DB_fetch_array($ShipperResults)) {
 			if($MyRow['shipper_id']==$_POST['ShipVia']) {
 				echo '<option selected="selected" value="' . $MyRow['shipper_id'] . '">' . $MyRow['shippername'] . '</option>';

--- a/Departments.php
+++ b/Departments.php
@@ -96,9 +96,8 @@ if (isset($_POST['Submit'])) {
 		if (is_array($SQL)) {
 			DB_Txn_Begin();
 			$ErrMsg = _('The department could not be inserted');
-			$DbgMsg = _('The sql that failed was') . ':';
 			foreach ($SQL as $SQLStatement ) {
-				$Result = DB_query($SQLStatement, $ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQLStatement, $ErrMsg, '', true);
 				if(!$Result) {
 					$InputError = 1;
 					break;
@@ -164,7 +163,7 @@ if (isset($_POST['Submit'])) {
 			ORDER BY description";
 
 	$ErrMsg = _('There are no departments created');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 			<tr>

--- a/DiscountCategories.php
+++ b/DiscountCategories.php
@@ -60,12 +60,12 @@ if (isset($_POST['submit']) and !isset($_POST['SubmitCategory'])) {
 } elseif (isset($_POST['SubmitCategory'])) {
 	$SQL = "SELECT stockid FROM stockmaster WHERE categoryid='".$_POST['stockcategory']."'";
 	$ErrMsg = _('Failed to retrieve stock category data');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if(DB_num_rows($Result)>0){
 		$SQL="UPDATE stockmaster
 				SET discountcategory='".$_POST['DiscountCategory']."'
 				WHERE categoryid='".$_POST['stockcategory']."'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 	}else{
 		prnMsg(_('There are no stock defined for this stock category, you must define stock for it first'),'error');
 		include('includes/footer.php');
@@ -160,7 +160,7 @@ if (isset($_POST['SelectChoice'])) {
 				$SQL="SELECT stockid, description FROM stockmaster
 						WHERE stockid " . LIKE  . " '%".$_POST['PartID']."%'
 						AND description " . LIKE . " '%".$_POST['PartDesc']."%'";
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 			if (!isset($_POST['stockID'])) {
 				echo _('Select a part code').':<br />';
 				while ($MyRow=DB_fetch_array($Result)) {

--- a/EDIMessageFormat.php
+++ b/EDIMessageFormat.php
@@ -41,7 +41,7 @@ if (isset($_POST['NewEDIInvMsg'])){
 			AND messagetype='INVOIC'";
 
 	$ErrMsg = _('There was an error inserting the default template invoice message records for') . ' ' . $PartnerCode . ' ' . _('because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 }
 
 $InputError = 0;

--- a/EDIProcessOrders.php
+++ b/EDIProcessOrders.php
@@ -961,7 +961,7 @@ echo '</pre>';
 								'" . $Order->DeliverBlind ."'
 								)";
 						$ErrMsg = _('The order cannot be created because');
-						$InsertQryResult = DB_query($HeaderSQL,$ErrMsg);
+						$InsertQryResult = DB_query($HeaderSQL, $ErrMsg);
 						// update salesorderdetails too here ..
 						$xi=0;
 						foreach ($Order->LineItems as $lineNumber => $linedetail) {

--- a/EDISendInvoices.php
+++ b/EDISendInvoices.php
@@ -54,7 +54,7 @@ while ($CustDetails = DB_fetch_array($EDIInvCusts)){
 				AND debtortrans.debtorno='" . $CustDetails['debtorno'] . "'";
 
 	$ErrMsg = _('There was a problem retrieving the customer transactions because');
-	$TransHeaders = DB_query($SQL,$ErrMsg);
+	$TransHeaders = DB_query($SQL, $ErrMsg);
 
 
 	if (DB_num_rows($TransHeaders)==0){
@@ -102,7 +102,7 @@ while ($CustDetails = DB_fetch_array($EDIInvCusts)){
                 WHERE partnercode='" . $CustDetails['debtorno'] . "'
                 AND messagetype='INVOIC' ORDER BY sequenceno";
 		$ErrMsg =  _('An error occurred in getting the EDI format template for') . ' ' . $CustDetails['debtorno'] . ' ' . _('because');
-		$MessageLinesResult = DB_query($SQL,$ErrMsg);
+		$MessageLinesResult = DB_query($SQL, $ErrMsg);
 
 
 		if (DB_num_rows($MessageLinesResult)>0){

--- a/EmailConfirmation.php
+++ b/EmailConfirmation.php
@@ -76,7 +76,7 @@ $SQL = "SELECT salesorders.debtorno,
 			AND salesorders.fromstkloc=locations.loccode
 			AND salesorders.orderno='" . $_GET['TransNo'] . "'";
 
-$Result=DB_query($SQL, $ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 //If there are no rows, there's a problem.
 if (DB_num_rows($Result)==0){
@@ -234,7 +234,7 @@ if($_GET['POLine'] == 1){
 			ON salesorderdetails.stkcode=stockmaster.stockid
 		WHERE salesorderdetails.orderno=" . $_GET['TransNo'] . "
 		ORDER BY poline";
-	$Result=DB_query($SQL, $ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$i=0;
 	if (DB_num_rows($Result)>0){
 

--- a/EmailCustTrans.php
+++ b/EmailCustTrans.php
@@ -54,7 +54,7 @@ $SQL = "SELECT email
 		AND debtortrans.transno='" .$_GET['FromTransNo'] . "'";
 
 $ErrMsg = _('There was a problem retrieving the contact details for the customer');
-$ContactResult=DB_query($SQL,$ErrMsg);
+$ContactResult = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($ContactResult)>0){
 	$EmailAddrRow = DB_fetch_row($ContactResult);

--- a/Employees.php
+++ b/Employees.php
@@ -50,9 +50,8 @@ if(isset($_POST['submit'])) {
 						WHERE id = '" . $SelectedEmployee . "'";
 
 		$ErrMsg = _('An error occurred updating the') . ' ' . $SelectedEmployee . ' ' . _('employee record because');
-		$DbgMsg = _('The SQL used to update the employee record was');
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('The employee record has been updated'),'success');
 
@@ -76,11 +75,9 @@ if(isset($_POST['submit'])) {
 								'" . $_POST['Email'] . "')";
 
 		$ErrMsg = _('An error occurred inserting the new employee record because');
-		$DbgMsg = _('The SQL used to insert the employee record was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('The new employee record has been added'),'success');
-
 	}
 
 	unset($_POST['Surname']);

--- a/ExchangeRateTrend.php
+++ b/ExchangeRateTrend.php
@@ -29,7 +29,7 @@ if ( isset($_GET['CurrencyToShow']) ){
 	echo '<table>'; // First column
 
 	$SQL = "SELECT currabrev FROM currencies";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	include('includes/CurrenciesArray.php'); // To get the currency name from the currency code.
 
 	// CurrencyToShow Currency Picker

--- a/FTP_RadioBeacon.php
+++ b/FTP_RadioBeacon.php
@@ -42,7 +42,7 @@ $SQL = "SELECT salesorders.orderno,
 				salesorders.deliverto";
 
 $ErrMsg = _('No orders were returned because');
-$SalesOrdersResult = DB_query($SQL,$ErrMsg);
+$SalesOrdersResult = DB_query($SQL, $ErrMsg);
 
 /*show a table of the orders returned by the SQL */
 
@@ -153,7 +153,7 @@ if (isset($_GET['OrderNo'])){ /*An order has been selected for sending */
 
 
 	$ErrMsg = _('There was a problem retrieving the order header details for Order Number') . ' ' . $_GET['OrderNo'] . ' ' . _('from the database');
-	$Result=DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result)==1){ /*There is ony one order header returned */
 
@@ -179,7 +179,7 @@ if (isset($_GET['OrderNo'])){ /*An order has been selected for sending */
 					AND salesorderdetails.orderno=" . $_GET['OrderNo'];
 
 		$ErrMsg = _('There was a problem retrieving the line details for order number') . ' ' . $_GET['OrderNo'] . ' ' . _('from the database because');
-		$Result=DB_query($SQL, $ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($Result)>0){
 		/*Yes there are line items to start the ball rolling creating the Header record - the PHRecord*/

--- a/Factors.php
+++ b/Factors.php
@@ -79,9 +79,8 @@ if (isset($_POST['Submit']) OR isset($_POST['Update'])) {
 						'" . $_POST['Email']  . "')";
 
 		$ErrMsg = _('The factoring company') . ' ' . $_POST['FactorName'] . ' ' . _('could not be added because');
-		$DbgMsg = _('The SQL that was used to insert the factor but failed was');
 
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('A new factoring company for') . ' ' . $_POST['FactorName'] . ' ' . _('has been added to the database'),'success');
 
@@ -100,8 +99,7 @@ if (isset($_POST['Submit']) OR isset($_POST['Update'])) {
 			WHERE id = '" .$FactorID."'";
 
 		$ErrMsg = _('The factoring company could not be updated because');
-		$DbgMsg = _('The SQL that was used to update the factor but failed was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('The factoring company record for') . ' ' . $_POST['FactorName'] . ' ' . _('has been updated'),'success');
 
@@ -316,7 +314,7 @@ if (empty($FactorID) AND !isset($_POST['Create']) AND !isset($_POST['Amend'])) {
 					fax,
 					email
 			FROM factorcompanies";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 
 	while ($MyRow = DB_fetch_array($Result)) {
 		echo '<tr class="striped_row">

--- a/FixedAssetCategories.php
+++ b/FixedAssetCategories.php
@@ -88,7 +88,7 @@ if (isset($_POST['submit'])) {
 				WHERE categoryid = '".$SelectedCategory . "'";
 
 		$ErrMsg = _('Could not update the fixed asset category') . $_POST['CategoryDescription'] . _('because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('Updated the fixed asset category record for') . ' ' . $_POST['CategoryDescription'],'success');
 
@@ -107,7 +107,7 @@ if (isset($_POST['submit'])) {
 										'" . $_POST['DisposalAct'] . "',
 										'" . $_POST['AccumDepnAct'] . "')";
 		$ErrMsg = _('Could not insert the new fixed asset category') . $_POST['CategoryDescription'] . _('because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg(_('A new fixed asset category record has been added for') . ' ' . $_POST['CategoryDescription'],'success');
 
 	}

--- a/FixedAssetDepreciation.php
+++ b/FixedAssetDepreciation.php
@@ -75,7 +75,7 @@ $SQL="SELECT fixedassets.assetid,
 			fixedassetcategories.categorydescription
 		ORDER BY assetcategoryid, assetid";
 
-$AssetsResult=DB_query($SQL);
+$AssetsResult = DB_query($SQL);
 
 $InputError = false; //always hope for the best
 if (Date1GreaterThanDate2($_POST['ProcessDate'],Date($_SESSION['DefaultDateFormat']))){
@@ -193,8 +193,7 @@ while ($AssetRow=DB_fetch_array($AssetsResult)) {
 								'" . $NewDepreciation ."')";
 
 		$ErrMsg = _('Cannot insert a depreciation GL entry for the depreciation because');
-		$DbgMsg = _('The SQL that failed to insert the GL Trans record was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$SQL = "INSERT INTO gltrans (type,
 									typeno,
@@ -210,7 +209,7 @@ while ($AssetRow=DB_fetch_array($AssetsResult)) {
 								'" . $AssetRow['accumdepnact'] . "',
 								'" . mb_substr(_('Monthly depreciation for asset') . ' ' . $AssetRow['assetid'], 0, 200) . "',
 								'" . -$NewDepreciation ."')";
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		//insert the fixedassettrans record
 		$SQL = "INSERT INTO fixedassettrans (assetid,
@@ -230,15 +229,13 @@ while ($AssetRow=DB_fetch_array($AssetsResult)) {
 											'depn',
 											'" . $NewDepreciation . "')";
 		$ErrMsg = _('Cannot insert a fixed asset transaction entry for the depreciation because');
-		$DbgMsg = _('The SQL that failed to insert the fixed asset transaction record was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*now update the accum depn in fixedassets */
 		$SQL = "UPDATE fixedassets SET accumdepn = accumdepn + " . $NewDepreciation  . "
 				WHERE assetid = '" . $AssetRow['assetid'] . "'";
 		$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE. The fixed asset accumulated depreciation could not be updated:');
-		$DbgMsg = _('The following SQL was used to attempt the update the accumulated depreciation of the asset was:');
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	} //end if Committing the depreciation to DB
 } //end loop around the assets to calculate depreciation for
 echo '<tr>

--- a/FixedAssetItems.php
+++ b/FixedAssetItems.php
@@ -172,8 +172,7 @@ if (isset($_POST['submit'])) {
 								'" . -$OldDetails['cost']. "'
 								)";
 				$ErrMsg = _('Cannot insert a GL entry for the change of asset category because');
-				$DbgMsg = _('The SQL that failed to insert the cost GL Trans record was');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				//debit cost for the new category
 				$SQL = "INSERT INTO gltrans (type,
@@ -192,8 +191,7 @@ if (isset($_POST['submit'])) {
 								'" . $OldDetails['cost']. "'
 								)";
 				$ErrMsg = _('Cannot insert a GL entry for the change of asset category because');
-				$DbgMsg = _('The SQL that failed to insert the cost GL Trans record was');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				if ($OldDetails['accumdepn']!=0) {
 					//debit accumdepn for the old category
 					$SQL = "INSERT INTO gltrans (type,
@@ -212,8 +210,7 @@ if (isset($_POST['submit'])) {
 									'" . $OldDetails['accumdepn']. "'
 									)";
 					$ErrMsg = _('Cannot insert a GL entry for the change of asset category because');
-					$DbgMsg = _('The SQL that failed to insert the cost GL Trans record was');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					//credit accum depn for the new category
 					$SQL = "INSERT INTO gltrans (type,
@@ -232,8 +229,7 @@ if (isset($_POST['submit'])) {
 									'" . -$OldDetails['accumdepn']. "'
 									)";
 					$ErrMsg = _('Cannot insert a GL entry for the change of asset category because');
-					$DbgMsg = _('The SQL that failed to insert the cost GL Trans record was');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} /*end if there was accumulated depreciation for the asset */
 			} /* end if there is a change in asset category */
 			$SQL = "UPDATE fixedassets
@@ -248,8 +244,7 @@ if (isset($_POST['submit'])) {
 					WHERE assetid='" . $AssetID . "'";
 
 			$ErrMsg = _('The asset could not be updated because');
-			$DbgMsg = _('The SQL that was used to update the asset and failed was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			prnMsg( _('Asset') . ' ' . $AssetID . ' ' . _('has been updated'), 'success');
 			echo '<br />';
@@ -272,8 +267,7 @@ if (isset($_POST['submit'])) {
 							'" . $_POST['BarCode'] . "',
 							'" . $_POST['SerialNo'] . "' )";
 			$ErrMsg =  _('The asset could not be added because');
-			$DbgMsg = _('The SQL that was used to add the asset failed was');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			if (DB_error_no() ==0) {
 				$NewAssetID = DB_Last_Insert_ID('fixedassets', 'assetid');
@@ -342,8 +336,7 @@ if (isset($_POST['submit'])) {
 							'" . -$AssetRow['cost']. "'
 							)";
 			$ErrMsg = _('Cannot insert a GL entry for the deletion of the asset because');
-			$DbgMsg = _('The SQL that failed to insert the cost GL Trans record was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			//debit accumdepn for the depreciation removed on deletion of this asset
 			$SQL = "INSERT INTO gltrans (type,
@@ -362,13 +355,12 @@ if (isset($_POST['submit'])) {
 							'" . $Asset['accumdepn']. "'
 							)";
 			$ErrMsg = _('Cannot insert a GL entry for the reversal of accumulated depreciation on deletion of the asset because');
-			$DbgMsg = _('The SQL that failed to insert the cost GL Trans record was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		} //end if cost > 0
 
 		$SQL="DELETE FROM fixedassets WHERE assetid='" . $AssetID . "'";
-		$Result=DB_query($SQL, _('Could not delete the asset record'),'',true);
+		$Result = DB_query($SQL, _('Could not delete the asset record'), '', true);
 
 		DB_Txn_Commit();
 
@@ -537,8 +529,7 @@ echo '<field>
 
 $SQL = "SELECT categoryid, categorydescription FROM fixedassetcategories";
 $ErrMsg = _('The asset categories could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve stock categories and failed was');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 while ($MyRow=DB_fetch_array($Result)){
 	if (!isset($_POST['AssetCategoryID']) or $MyRow['categoryid']==$_POST['AssetCategoryID']){
@@ -562,8 +553,7 @@ if (isset($AssetRow) AND ($AssetRow['datepurchased']!='1000-01-01' AND $AssetRow
 
 $SQL = "SELECT locationid, locationdescription FROM fixedassetlocations";
 $ErrMsg = _('The asset locations could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve asset locations and failed was');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 echo '<field>
 		<label for="AssetLocation">' . _('Asset Location') . ':</label>

--- a/FixedAssetLocations.php
+++ b/FixedAssetLocations.php
@@ -26,7 +26,7 @@ if (isset($_POST['submit']) AND !isset($_POST['delete'])) {
 				VALUES ('".$_POST['LocationID']."',
 						'".$_POST['LocationDescription']."',
 						'".$_POST['ParentLocationID']."')";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 	}
 }
 if (isset($_GET['SelectedLocation'])) {
@@ -57,7 +57,7 @@ if (isset($_POST['update']) and !isset($_POST['delete'])) {
 						parentlocationid='" . $_POST['ParentLocationID'] . "'
 					WHERE locationid ='" . $_POST['LocationID'] . "'";
 
-			 $Result=DB_query($SQL);
+			 $Result = DB_query($SQL);
 			 echo '<meta http-equiv="Refresh" content="0; url="'.htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UTF-8').'">';
 		}
 } else {
@@ -88,7 +88,7 @@ if (isset($_POST['update']) and !isset($_POST['delete'])) {
 }
 
 $SQL='SELECT * FROM fixedassetlocations';
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 
 if (DB_num_rows($Result) > 0) {
 	echo '<table class="selection">
@@ -107,7 +107,7 @@ if (DB_num_rows($Result) > 0) {
 				<td>' . $MyRow['locationdescription'] . '</td>';
 		if ($MyRow['parentlocationid'] != '') {
 			$ParentSql="SELECT locationdescription FROM fixedassetlocations WHERE locationid='".$MyRow['parentlocationid']."'";
-			$ParentResult=DB_query($ParentSql);
+			$ParentResult = DB_query($ParentSql);
 			$ParentRow=DB_fetch_array($ParentResult);
 			echo '<td>' . $ParentRow['locationdescription'] . '</td>';
 		} else {
@@ -151,7 +151,7 @@ echo '<field>
 		<select name="ParentLocationID">';
 
 $SQL="SELECT locationid, locationdescription FROM fixedassetlocations";
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 
 echo '<option value=""></option>';
 while ($MyRow=DB_fetch_array($Result)) {

--- a/FixedAssetTransfer.php
+++ b/FixedAssetTransfer.php
@@ -20,7 +20,7 @@ foreach ($_POST as $AssetToMove => $Value) { //Value is not used?
 						SET assetlocation='".$_POST['Location'.$AssetID] ."'
 						WHERE assetid='". $AssetID . "'";
 
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 			prnMsg(_('The Fixed Asset has been moved successfully'), 'success');
 			echo '<br />';
 		}
@@ -33,7 +33,7 @@ if (isset($_GET['AssetID'])) {
 	$AssetID=$_POST['AssetID'];
 } else {
 	$SQL="SELECT categoryid, categorydescription FROM fixedassetcategories";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	echo '<form action="'. htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UTF-8') . '" method="post">';
 	echo '<input type="hidden" name="FormID" value="' . $_SESSION['FormID'] . '" />';
 
@@ -154,7 +154,7 @@ if (isset($_POST['Search'])) {
 			ORDER BY fixedassets.assetid";
 
 
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	echo '<br />';
 	echo '<form action="'. htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UTF-8') . '" method="post">
           <div>';
@@ -171,7 +171,7 @@ if (isset($_POST['Search'])) {
 		</tr>';
 
 	$LocationSQL="SELECT locationid, locationdescription from fixedassetlocations";
-	$LocationResult=DB_query($LocationSQL);
+	$LocationResult = DB_query($LocationSQL);
 
 	while ($MyRow=DB_fetch_array($Result)) {
 

--- a/FreightCosts.php
+++ b/FreightCosts.php
@@ -174,7 +174,7 @@ if (isset($_POST['submit'])) {
 	//run the SQL from either of the above possibilites
 
 	$ErrMsg = _('The freight cost record could not be updated because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	prnMsg($Msg,'success');
 

--- a/GLAccountUsersCopyAuthority.php
+++ b/GLAccountUsersCopyAuthority.php
@@ -24,9 +24,8 @@ if(isset($_POST['ProcessCopyAuthority'])) {
 		DB_Txn_Begin();
 
 		$SQL = "DELETE FROM glaccountusers WHERE UPPER(userid) = UPPER('" . $_POST['ToUserID'] . "')";
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg = _('The SQL to delete the auhority in glaccountusers record failed');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		prnMsg(_('Deleting the previous authority to view / update the GL Accounts of user') . ' ' . $_POST['ToUserID'], 'success');
 
 		$SQL = "INSERT INTO glaccountusers (userid, accountcode, canview, canupd)
@@ -34,9 +33,8 @@ if(isset($_POST['ProcessCopyAuthority'])) {
 				FROM glaccountusers
 				WHERE UPPER(userid) = UPPER('" . $_POST['FromUserID'] . "')";
 
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg = _('The SQL to insert the auhority in glaccountusers record failed');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		prnMsg(_('Copied the authority to view / update the GL Accounts from user') . ' ' . $_POST['FromUserID'] . ' ' . _('to user') . ' ' . $_POST['ToUserID'], 'success');
 
 		DB_Txn_Commit();

--- a/GLAccounts.php
+++ b/GLAccounts.php
@@ -184,7 +184,7 @@ if(isset($_POST['submit'])) {
 									OR materialuseagevarac='" . $SelectedAccount . "'
 									OR wipact='" . $SelectedAccount . "'";
 							$Errmsg = _('Could not test for existing stock GL codes because');
-							$Result = DB_query($SQL,$ErrMsg);
+							$Result = DB_query($SQL, $ErrMsg);
 
 							$MyRow = DB_fetch_row($Result);
 							if($MyRow[0]>0) {
@@ -195,7 +195,7 @@ if(isset($_POST['submit'])) {
 								$SQL= "SELECT COUNT(*) FROM bankaccounts
 								WHERE accountcode='" . $SelectedAccount ."'";
 								$ErrMsg = _('Could not test for existing bank account GL codes because');
-								$Result = DB_query($SQL,$ErrMsg);
+								$Result = DB_query($SQL, $ErrMsg);
 
 								$MyRow = DB_fetch_row($Result);
 								if($MyRow[0]>0) {

--- a/GLBankAccountUsersCopyAuthority.php
+++ b/GLBankAccountUsersCopyAuthority.php
@@ -24,9 +24,8 @@ if(isset($_POST['ProcessCopyAuthority'])) {
 		DB_Txn_Begin();
 
 		$SQL = "DELETE FROM bankaccountusers WHERE UPPER(userid) = UPPER('" . $_POST['ToUserID'] . "')";
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg = _('The SQL to delete the auhority in bankaccountusers record failed');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		prnMsg(_('Deleting the previous authority to view / update the Bank Accounts of user') . ' ' . $_POST['ToUserID'], 'success');
 
 		$SQL = "INSERT INTO bankaccountusers (userid, accountcode)
@@ -34,9 +33,8 @@ if(isset($_POST['ProcessCopyAuthority'])) {
 				FROM bankaccountusers
 				WHERE UPPER(userid) = UPPER('" . $_POST['FromUserID'] . "')";
 
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg = _('The SQL to insert the auhority in bankaccountusers record failed');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		prnMsg(_('Copied the authority to view / update the Bank Accounts from user') . ' ' . $_POST['FromUserID'] . ' ' . _('to user') . ' ' . $_POST['ToUserID'], 'success');
 
 		DB_Txn_Commit();

--- a/GLCodesInquiry.php
+++ b/GLCodesInquiry.php
@@ -21,7 +21,7 @@ $SQL = "SELECT group_,
 				accountcode";
 
 $ErrMsg = _('No general ledger accounts were returned by the SQL because');
-$AccountsResult = DB_query($SQL,$ErrMsg);
+$AccountsResult = DB_query($SQL, $ErrMsg);
 
 /*show a table of the orders returned by the SQL */
 

--- a/GLJournal.php
+++ b/GLJournal.php
@@ -285,8 +285,7 @@ if (isset($_POST['CommitBatch']) and $_POST['CommitBatch'] == _('Accept and Proc
 					'" . $JournalItem->Amount . "'
 					)";
 		$ErrMsg = _('Cannot insert a GL entry for the journal line because');
-		$DbgMsg = _('The SQL that failed to insert the GL Trans record was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		InsertGLTags($JournalItem->tag);
 
 		if ($_POST['JournalType'] == 'Reversing') {
@@ -307,8 +306,7 @@ if (isset($_POST['CommitBatch']) and $_POST['CommitBatch'] == _('Accept and Proc
 						)";
 
 			$ErrMsg = _('Cannot insert a GL entry for the reversing journal because');
-			$DbgMsg = _('The SQL that failed to insert the GL Trans record was');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 			InsertGLTags($JournalItem->tag);
 		}
 	}

--- a/GeocodeSetup.php
+++ b/GeocodeSetup.php
@@ -31,7 +31,7 @@ if (isset($_POST['submit'])) {
 
 	$SQL="SELECT count(geocodeid)
 			FROM geocode_param WHERE geocodeid='".$_POST['GeoCodeID']."'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_row($Result);
 
 	if ($MyRow[0]!=0 and !isset($SelectedParam)) {

--- a/GoodsReceived.php
+++ b/GoodsReceived.php
@@ -338,8 +338,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 			ORDER BY podetailitem";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not check that the details of the purchase order had not been changed by another user because'). ':';
-	$DbgMsg = _('The following SQL to retrieve the purchase order details was used');
-	$Result=DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$Changes=0;
 	$LineNo=1;
@@ -446,8 +445,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 							FROM stockmaster
 							WHERE stockid='" . $OrderLine->StockID . "'";
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The standard cost of the item being received cannot be retrieved because');
-				$DbgMsg = _('The following SQL to retrieve the standard cost was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$MyRow = DB_fetch_row($Result);
 				if($MyRow[1] != 'D') {
@@ -492,9 +490,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 			}
 
 			$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The purchase order detail record could not be updated with the quantity received because');
-			$DbgMsg = _('The following SQL to update the purchase order detail record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
-
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			if ($OrderLine->StockID !='' AND !isset($Dummy)) { /*Its a stock item so use the standard cost for the journals */
 				$UnitCost = $CurrentStandardCost;
@@ -524,8 +520,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 								'" . trim($_POST['SupplierReference']) ."')";
 
 			$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('A GRN record could not be inserted') . '. ' . _('This receipt of goods has not been processed because');
-			$DbgMsg =  _('The following SQL to insert the GRN record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			if ($OrderLine->StockID!='') { /* if the order line is in fact a stock item */
 
@@ -552,8 +547,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 						AND loccode = '" . $_SESSION['PO'.$identifier]->Location . "'";
 
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-				$DbgMsg =  _('The following SQL to update the location stock record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	/* Insert stock movements - with unit cost */
 
@@ -585,8 +579,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 										)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('stock movement records could not be inserted because');
-				$DbgMsg =  _('The following SQL to insert the stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/*Get the ID of the StockMove... */
 				$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -603,8 +596,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 									AND loccode = '" . $_SESSION['PO'.$identifier]->Location . "'
 									AND serialno = '" . $Item->BundleRef . "'";
 							$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not check if a batch or lot stock item already exists because');
-							$DbgMsg =  _('The following SQL to test for an already existing controlled but not serialised stock item was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 							$AlreadyExistsRow = DB_fetch_row($Result);
 							if (trim($Item->BundleRef) != '') {
 								if ($AlreadyExistsRow[0]>0) {
@@ -632,8 +624,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 								}
 
 								$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be inserted because');
-								$DbgMsg =  _('The following SQL to insert the serial stock item records was used');
-								$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+								$Result = DB_query($SQL, $ErrMsg, '', true);
 
 								/* end of handle stockserialitems records */
 
@@ -649,8 +640,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 																'" . $Item->BundleQty . "'
 																)";
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-							$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 							if ($_SESSION['QualityLogSamples']==1) {
 								CreateQASample($OrderLine->StockID,$Item->BundleRef, '', 'Created from Purchase Order', 0, 0);
 							}
@@ -690,8 +680,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 											'" . _('cost') . "',
 											'" . $CurrentStandardCost * $OrderLine->ReceiveQty . "')";
 					$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE The fixed asset transaction could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the fixed asset transaction record was used');
-					$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					/*Now get the correct cost GL account from the asset category */
 					$AssetRow = DB_fetch_array($CheckAssetExistsResult);
@@ -711,8 +700,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 									WHERE assetid = '" . $OrderLine->AssetID . "'";
 					}
 					$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE. The fixed asset cost and date purchased was not able to be updated because:');
-					$DbgMsg = _('The following SQL was used to attempt the update of the cost and the date the asset was purchased');
-					$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				} //assetid provided doesn't exist so ignore it and treat as a normal nominal item
 			} //assetid is set so the nominal item is an asset
@@ -739,8 +727,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 											$CurrentStandardCost * $OrderLine->ReceiveQty . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The purchase GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the purchase GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/* If the CurrentStandardCost != UnitCost (the standard at the time the first delivery was booked in,  and its a stock item, then the difference needs to be booked in against the purchase price variance account */
 
@@ -761,8 +748,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 											-$UnitCost * $OrderLine->ReceiveQty . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GRN suspense side of the GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GRN Suspense GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '',true);
 
 			} /* end of if GL and stock integrated and standard cost !=0 */
 		} /*Quantity received is != 0 */
@@ -774,7 +760,7 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 				SET status='Completed',
 				stat_comment='" . $StatusComment . "'
 				WHERE orderno='" . $_SESSION['PO'.$identifier]->OrderNo . "'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 	}
 
 	if ($_SESSION['PO'.$identifier]->GLLink==1) {

--- a/HistoricalTestResults.php
+++ b/HistoricalTestResults.php
@@ -110,7 +110,7 @@ $SQLTests="SELECT sampleresults.testid,
 				AND sampledate <='" . $ToDate . "'";
 
 
-$TestResult=DB_query($SQLTests);
+$TestResult = DB_query($SQLTests);
 $TestsArray=array();
 $SamplesArray=array();
 $AllResultsArray=array();

--- a/ImportBankTrans.php
+++ b/ImportBankTrans.php
@@ -33,8 +33,7 @@ if (!isset($_FILES['ImportFile']) AND !isset($_SESSION['Statement'])) {
 			ORDER BY bankaccountname";
 
 	$ErrMsg = _('The bank accounts set up could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the bank accounts was') . '<br />' . $SQL;
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result) ==0) {
 		prnMsg(_('There are no bank accounts defined that are set up to allow importation of bank statement transactions. First define the file format used by your bank for statement exports.'),'error');
 		echo '<br /><a href="BankAccounts.php>' . _('Setup Import Format for Bank Accounts') . '</a>';
@@ -124,7 +123,7 @@ if (!isset($_FILES['ImportFile']) AND !isset($_SESSION['Statement'])) {
 
 	$ErrMsg = _('Could not retrieve bank accounts that match with the statement being imported');
 
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result)==0) { //but check for the worst!
 		//there is no bank account set up for the bank account being imported
 		prnMsg(_('The account') . ' ' . $_SESSION['Statement']->AccountNumber . ' ' . _('is not defined as a bank account of the business. No imports can be processed'), 'warn');
@@ -437,7 +436,7 @@ if (isset($_POST['ProcessBankTrans'])) {
 			/* Now insert the bank transaction if necessary */
 			/* it is not possible to import transaction that were originally in another currency converted to the currency of the bank account by the bank - these entries would need to be done through the usual method */
 
-				$Result=DB_query("INSERT INTO banktrans (transno,
+				$Result = DB_query("INSERT INTO banktrans (transno,
 														type,
 														bankact,
 														ref,

--- a/ImportBankTransAnalysis.php
+++ b/ImportBankTransAnalysis.php
@@ -306,7 +306,7 @@ if ($AllowGLAnalysis==false){
 			FROM tags
 			ORDER BY tagref";
 
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	while ($MyRow=DB_fetch_array($Result)){
 		if (isset($_POST['tag']) and $_POST['tag']==$MyRow['tagref']){
 			echo '<option selected value="' . $MyRow['tagref'] . '">' . $MyRow['tagref'].' - ' .$MyRow['tagdescription'] . '</option>';

--- a/InternalStockCategoriesByRole.php
+++ b/InternalStockCategoriesByRole.php
@@ -100,7 +100,7 @@ if (isset($_POST['submit'])) {
 		AND categoryid='".$SelectedType."'";
 
 	$ErrMsg = _('The Stock Category by Role record could not be deleted because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	prnMsg(_('Internal Stock Category').' '. $SelectedType .' '. _('for user role').' '. $SelectedRole .' '. _('has been deleted') ,'success');
 	unset($_GET['delete']);
 }

--- a/InternalStockRequest.php
+++ b/InternalStockRequest.php
@@ -87,8 +87,7 @@ if (isset($_POST['Submit']) and (!empty($_SESSION['Request']->LineItems))) {
 											'" . $_SESSION['Request']->Narrative . "',
 											'" . $_SESSION['UserID'] . "')";
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The request header record could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the request header record was used');
-		$Result = DB_query($HeaderSQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($HeaderSQL, $ErrMsg, '', true);
 
 		foreach ($_SESSION['Request']->LineItems as $LineItems) {
 			$LineSQL = "INSERT INTO stockrequestitems (dispatchitemsid,
@@ -105,8 +104,7 @@ if (isset($_POST['Submit']) and (!empty($_SESSION['Request']->LineItems))) {
 													'" . $LineItems->DecimalPlaces . "',
 													'" . $LineItems->UOM . "')";
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The request line record could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the request header record was used');
-			$Result = DB_query($LineSQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($LineSQL, $ErrMsg, '', true);
 		}
 
 		$EmailSQL = "SELECT email
@@ -487,8 +485,7 @@ if (isset($_POST['Search']) or isset($_POST['Next']) or isset($_POST['Previous']
 	$SQL = $SQL . ' LIMIT ' . $_SESSION['DisplayRecordsMax'] . ' OFFSET ' . ($_SESSION['DisplayRecordsMax'] * $Offset);
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL used to get the part selection was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('There are no products available meeting the criteria specified'), 'info');

--- a/InternalStockRequestAuthorisation.php
+++ b/InternalStockRequestAuthorisation.php
@@ -17,7 +17,7 @@ if (isset($_POST['UpdateAll'])) {
 			$SQL="UPDATE stockrequest
 					SET authorised='1'
 					WHERE dispatchid='" . $RequestNo . "'";
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 		}
 		if (strpos($POSTVariableName, 'cancel')!== false) {
 			$CancelItems = explode('cancel', $POSTVariableName);
@@ -56,7 +56,7 @@ $SQL="SELECT stockrequest.dispatchid,
 		WHERE stockrequest.authorised=0
 		AND stockrequest.closed=0
 		AND www_users.userid='".$_SESSION['UserID']."'";
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 
 echo '<form method="post" action="' . htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8') . '">';
 echo '<div>';
@@ -92,7 +92,7 @@ while ($MyRow=DB_fetch_array($Result)) {
 				ON stockmaster.stockid=stockrequestitems.stockid
 			WHERE dispatchid='".$MyRow['dispatchid'] . "'
 			AND completed=0";
-	$LineResult=DB_query($LinesSQL);
+	$LineResult = DB_query($LinesSQL);
 
 	echo '<tr>
 			<td></td>

--- a/InternalStockRequestFulfill.php
+++ b/InternalStockRequestFulfill.php
@@ -88,8 +88,7 @@ if (isset($_POST['UpdateAll'])) {
 								)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock movement record cannot be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/*Get the ID of the StockMove... */
 				$StkMoveNo = DB_Last_Insert_ID('stockmoves', 'stkmoveno');
@@ -103,8 +102,7 @@ if (isset($_POST['UpdateAll'])) {
 							AND serialno='" . $SerialNo . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-					$DbgMsg = _('The following SQL to update the serial stock item record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					/* now insert the serial stock movement */
 
@@ -118,8 +116,7 @@ if (isset($_POST['UpdateAll'])) {
 											'" . -$Quantity . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} /*end if the orderline is a controlled item */
 
 				$SQL = "UPDATE stockrequestitems
@@ -128,17 +125,15 @@ if (isset($_POST['UpdateAll'])) {
 							AND dispatchitemsid='" . $LineID . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-				$DbgMsg = _('The following SQL to update the stock record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "UPDATE locstock SET quantity = quantity - '" . $Quantity . "'
 									WHERE stockid='" . $StockID . "'
 										AND loccode='" . $Location . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-				$DbgMsg = _('The following SQL to update the stock record was used');
 
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				if ($_SESSION['CompanyRecord']['gllink_stock'] == 1 AND $StandardCost > 0) {
 
@@ -161,8 +156,7 @@ if (isset($_POST['UpdateAll'])) {
 											)";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction entries could not be added because');
-					$DbgMsg = _('The following SQL to insert the GL entries was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					InsertGLTags($Tags);
 
 					$SQL = "INSERT INTO gltrans (type,
@@ -182,8 +176,7 @@ if (isset($_POST['UpdateAll'])) {
 											)";
 
 					$Errmsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction entries could not be added because');
-					$DbgMsg = _('The following SQL to insert the GL entries was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 
 				if (($Quantity >= $RequestedQuantity) OR $Completed == True) {
@@ -191,7 +184,7 @@ if (isset($_POST['UpdateAll'])) {
 								SET completed=1
 							WHERE dispatchid='" . $RequestID . "'
 								AND dispatchitemsid='" . $LineID . "'";
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 
 				DB_Txn_Commit();

--- a/InternalStockRequestInquiry.php
+++ b/InternalStockRequestInquiry.php
@@ -547,8 +547,6 @@ function GetSearchItems ($SQLConstraint='') {
 					    stockmaster.units
 					    ORDER BY stockmaster.stockid";
 	$ErrMsg =  _('No stock items were returned by the SQL because');
-	$DbgMsg = _('The SQL used to retrieve the searched parts was');
-	$StockItemsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$StockItemsResult = DB_query($SQL, $ErrMsg);
 	return $StockItemsResult;
-
-	}
+}

--- a/InventoryPlanning.php
+++ b/InventoryPlanning.php
@@ -397,7 +397,7 @@ if (isset($_POST['PrintPDF'])) {
 			<select name="Location">';
 
 	$SQL = "SELECT locations.loccode, locationname FROM locations INNER JOIN locationusers ON locationusers.loccode=locations.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' AND locationusers.canview=1";
-	$LocnResult=DB_query($SQL);
+	$LocnResult = DB_query($SQL);
 
 	echo '<option value="All">' . _('All Locations') . '</option>';
 

--- a/InventoryPlanningPrefSupplier.php
+++ b/InventoryPlanningPrefSupplier.php
@@ -234,7 +234,7 @@ if (isset($_POST['PrintPDF'])){
    		   $SQL .= "	AND stockmoves.loccode ='" . $_POST['Location'] . "'";
 		}
 
-		$SalesResult=DB_query($SQL,'','',FALSE,FALSE);
+		$SalesResult = DB_query($SQL,'','',FALSE,FALSE);
 
 		if (DB_error_no() !=0) {
 	 		 $Title = _('Inventory Planning') . ' - ' . _('Problem Report') . '....';
@@ -335,7 +335,7 @@ if (isset($_POST['PrintPDF'])){
 			<select name="Location">';
 	$SQL = "SELECT locations.loccode, locationname FROM locations
 			INNER JOIN locationusers ON locationusers.loccode=locations.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' AND locationusers.canview=1";
-	$LocnResult=DB_query($SQL);
+	$LocnResult = DB_query($SQL);
 
 	echo '<option value="All">' . _('All Locations') . '</option>';
 

--- a/InventoryValuation.php
+++ b/InventoryValuation.php
@@ -323,7 +323,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['Spreadsheet']) or isset($_POST['V
 			INNER JOIN locationusers ON locationusers.loccode=locations.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' AND locationusers.canview=1
 			ORDER BY locationname";
 
-	$LocnResult=DB_query($SQL);
+	$LocnResult = DB_query($SQL);
 
 	echo '<option value="All">' . _('All Locations') . '</option>';
 

--- a/Labels.php
+++ b/Labels.php
@@ -129,7 +129,7 @@ if (isset($_POST['SelectedLabelID'])){
 				AND ctype_digit($_POST['HPos' . $i])
 				AND ctype_digit($_POST['FontSize' . $i])){ // if all entries are integers
 
-				$Result =DB_query("UPDATE labelfields SET fieldvalue='" . $_POST['FieldName' . $i] . "',
+				$Result = DB_query("UPDATE labelfields SET fieldvalue='" . $_POST['FieldName' . $i] . "',
 														vpos='" . $_POST['VPos' . $i] . "',
 														hpos='" . $_POST['HPos' . $i] . "',
 														fontsize='" . $_POST['FontSize' . $i] . "',
@@ -205,7 +205,7 @@ if (isset($_POST['submit'])) {
 				WHERE labelid = '" . $SelectedLabelID . "'";
 
 		$ErrMsg = _('The update of this label template failed because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$Message = _('The label template has been updated');
 		prnMsg($Message, 'success');
@@ -234,7 +234,7 @@ if (isset($_POST['submit'])) {
 					'" . $_POST['PageHeight'] . "')";
 
 		$ErrMsg = _('The addition of this label failed because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$Message = _('The new label template has been added to the database');
 		prnMsg($Message, 'success');
 	}
@@ -279,8 +279,7 @@ if (!isset($SelectedLabelID)) {
 			FROM labels";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The defined label templates could not be retrieved because');
-	$DbgMsg = _('The following SQL to retrieve the label templates was used');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result)>0){
 		echo '<table class="selection">
@@ -513,7 +512,7 @@ if (isset($SelectedLabelID)) {
 			WHERE labelid = '" . $SelectedLabelID . "'
 			ORDER BY vpos DESC";
 	$ErrMsg = _('Could not get the label fields because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$i=0;
 	echo '<table class="selection">
 				<tr>

--- a/LocationUsersCopyAuthority.php
+++ b/LocationUsersCopyAuthority.php
@@ -24,9 +24,8 @@ if(isset($_POST['ProcessCopyAuthority'])) {
 		DB_Txn_Begin();
 
 		$SQL = "DELETE FROM locationusers WHERE UPPER(userid) = UPPER('" . $_POST['ToUserID'] . "')";
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg = _('The SQL to delete the auhority in locationusers record failed');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		prnMsg(_('Deleting the previous authority to view / update the Locations of user') . ' ' . $_POST['ToUserID'], 'success');
 
 		$SQL = "INSERT INTO locationusers (userid, loccode, canview, canupd)
@@ -34,9 +33,8 @@ if(isset($_POST['ProcessCopyAuthority'])) {
 				FROM locationusers
 				WHERE UPPER(userid) = UPPER('" . $_POST['FromUserID'] . "')";
 
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg = _('The SQL to insert the auhority in locationusers record failed');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		prnMsg(_('Copied the authority to view / update the Locations from user') . ' ' . $_POST['FromUserID'] . ' ' . _('to user') . ' ' . $_POST['ToUserID'], 'success');
 
 		DB_Txn_Commit();

--- a/Locations.php
+++ b/Locations.php
@@ -82,9 +82,8 @@ if(isset($_POST['submit'])) {
 						WHERE loccode = '" . $SelectedLocation . "'";
 
 		$ErrMsg = _('An error occurred updating the') . ' ' . $SelectedLocation . ' ' . _('location record because');
-		$DbgMsg = _('The SQL used to update the location record was');
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('The location record has been updated'),'success');
 		unset($_POST['LocCode']);
@@ -163,8 +162,7 @@ if(isset($_POST['submit'])) {
 								'" . $_POST['AllowInvoicing'] . "')";
 
 		$ErrMsg = _('An error occurred inserting the new location record because');
-		$DbgMsg = _('The SQL used to insert the location record was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('The new location record has been added'),'success');
 
@@ -182,8 +180,7 @@ if(isset($_POST['submit'])) {
 			FROM stockmaster";
 
 		$ErrMsg = _('An error occurred inserting the new location stock records for all pre-existing parts because');
-		$DbgMsg = _('The SQL used to insert the new stock location records was');
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg('........ ' . _('and new stock locations inserted for all existing stock items for the new location'), 'success');
 
 	/* Also need to add locationuser records for all existing users*/
@@ -200,7 +197,7 @@ if(isset($_POST['submit'])) {
 				AND locations.loccode='". $_POST['LocCode'] . "';";
 
 		$ErrMsg = _('The users/locations that need user location records created cannot be retrieved because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg(_('Existing users have been authorized for this location'),'success');
 
 		unset($_POST['LocCode']);
@@ -372,7 +369,7 @@ if(isset($_POST['submit'])) {
 								WHERE dispatchtaxprovince='" . $TaxProvinceRow[0] . "'");
 		}
 
-		$Result= DB_query("DELETE FROM locstock WHERE loccode ='" . $SelectedLocation . "'");
+		$Result = DB_query("DELETE FROM locstock WHERE loccode ='" . $SelectedLocation . "'");
 		$Result = DB_query("DELETE FROM locationusers WHERE loccode='" . $SelectedLocation . "'");
 		$Result = DB_query("DELETE FROM locations WHERE loccode='" . $SelectedLocation . "'");
 

--- a/MRP.php
+++ b/MRP.php
@@ -24,7 +24,7 @@ if (isset($_POST['submit'])) {
 	$SQL = "CREATE TEMPORARY TABLE passbom (part char(20),
 											sortpart text) DEFAULT CHARSET=utf8";
 	$ErrMsg = _('The SQL to create passbom failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$SQL = "CREATE TEMPORARY TABLE tempbom (parent char(20),
 											component char(20),

--- a/MRPCalendar.php
+++ b/MRPCalendar.php
@@ -88,7 +88,7 @@ function submit(&$ChangeDate)  //####SUBMIT_SUBMIT_SUBMIT_SUBMIT_SUBMIT_SUBMIT_S
 				INDEX (daynumber),
 				PRIMARY KEY (calendardate)) DEFAULT CHARSET=utf8";
 	$ErrMsg = _('The SQL to create passbom failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$i = 0;
 
@@ -119,7 +119,7 @@ function submit(&$ChangeDate)  //####SUBMIT_SUBMIT_SUBMIT_SUBMIT_SUBMIT_SUBMIT_S
 				 VALUES ('" . $DateAdd . "',
 						'1',
 						'" . $ManuFlag . "')";
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 
 	// Update daynumber. Set it so non-manufacturing days will have the same daynumber as a valid
@@ -128,7 +128,7 @@ function submit(&$ChangeDate)  //####SUBMIT_SUBMIT_SUBMIT_SUBMIT_SUBMIT_SUBMIT_S
 	$DayNumber = 1;
 	$SQL = "SELECT * FROM mrpcalendar
 			ORDER BY calendardate";
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	while ($MyRow = DB_fetch_array($Result)) {
 		   if ($MyRow['manufacturingflag'] == "1") {
 			   $DayNumber++;
@@ -136,7 +136,7 @@ function submit(&$ChangeDate)  //####SUBMIT_SUBMIT_SUBMIT_SUBMIT_SUBMIT_SUBMIT_S
 		   $CalDate = $MyRow['calendardate'];
 		   $SQL = "UPDATE mrpcalendar SET daynumber = '" . $DayNumber . "'
 					WHERE calendardate = '" . $CalDate . "'";
-		   $Resultupdate = DB_query($SQL,$ErrMsg);
+		   $Resultupdate = DB_query($SQL, $ErrMsg);
 	}
 	prnMsg(_('The MRP Calendar has been created'),'success');
 	ShowInputForm($ChangeDate);
@@ -176,7 +176,7 @@ function update(&$ChangeDate)  //####UPDATE_UPDATE_UPDATE_UPDATE_UPDATE_UPDATE_U
 	$SQL = "UPDATE mrpcalendar SET manufacturingflag = '".$NewManufacturingFlag."'
 			WHERE calendardate = '".$CalDate."'";
 	$ErrMsg = _('Cannot update the MRP Calendar');
-	$Resultupdate = DB_query($SQL,$ErrMsg);
+	$Resultupdate = DB_query($SQL, $ErrMsg);
 	prnMsg(_('The MRP calendar record for') . ' ' . $ChangeDate  . ' ' . _('has been updated'),'success');
 	unset ($ChangeDate);
 	ShowInputForm($ChangeDate);
@@ -187,7 +187,7 @@ function update(&$ChangeDate)  //####UPDATE_UPDATE_UPDATE_UPDATE_UPDATE_UPDATE_U
 	// subtract the leadtime from the daynumber, and find the valid manufacturing day with that daynumber.
 	$DayNumber = 1;
 	$SQL = "SELECT * FROM mrpcalendar ORDER BY calendardate";
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	while ($MyRow = DB_fetch_array($Result)) {
 		   if ($MyRow['manufacturingflag'] == '1') {
 			   $DayNumber++;
@@ -195,7 +195,7 @@ function update(&$ChangeDate)  //####UPDATE_UPDATE_UPDATE_UPDATE_UPDATE_UPDATE_U
 		   $CalDate = $MyRow['calendardate'];
 		   $SQL = "UPDATE mrpcalendar SET daynumber = '" . $DayNumber . "'
 					WHERE calendardate = '" . $CalDate . "'";
-		   $Resultupdate = DB_query($SQL,$ErrMsg);
+		   $Resultupdate = DB_query($SQL, $ErrMsg);
 	} // End of while
 
 } // End of function update()
@@ -215,7 +215,7 @@ function ShowDays()  {//####LISTALL_LISTALL_LISTALL_LISTALL_LISTALL_LISTALL_LIST
 			AND calendardate <='" . $ToDate . "'";
 
 	$ErrMsg = _('The SQL to find the parts selected failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 			<thead style="position: -webkit-sticky; position: sticky; top: 0px; z-index: 100;">

--- a/MRPCreateDemands.php
+++ b/MRPCreateDemands.php
@@ -236,7 +236,7 @@ echo '<field>
 		<select name="Location">';
 echo '<option selected="selected" value="All">' . _('All Locations') . '</option>';
 
-$Result= DB_query("SELECT locations.loccode,
+$Result = DB_query("SELECT locations.loccode,
 						   locationname
 					FROM locations INNER JOIN locationusers ON locationusers.loccode=locations.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' AND locationusers.canupd=1");
 while ($MyRow=DB_fetch_array($Result)){

--- a/MRPDemands.php
+++ b/MRPDemands.php
@@ -78,7 +78,7 @@ function search(&$StockID) { //####SEARCH_SEARCH_SEARCH_SEARCH_SEARCH_SEARCH_SEA
 		}
 
 		$ErrMsg = _('The SQL to find the parts selected failed with the message');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 	} //one of keywords or StockCode was more than a zero length string
 
@@ -281,7 +281,7 @@ function listall($Part,$DemandType)  {//####LISTALL_LISTALL_LISTALL_LISTALL_LIST
 			 $Where	. " ORDER BY mrpdemands.stockid, mrpdemands.duedate";
 
 	$ErrMsg = _('The SQL to find the parts selected failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 		<tr>

--- a/MRPReport.php
+++ b/MRPReport.php
@@ -27,7 +27,7 @@ if (isset($_POST['PrintPDF']) AND $_POST['Part']!='') {
 			WHERE part = '" . $_POST['Part'] ."'
 			ORDER BY daterequired,whererequired";
 
-	$Result = DB_query($SQL,'','',False,False);
+	$Result = DB_query($SQL, '', '', false, false);
 	if (DB_error_no() !=0) {
 		$Errors = 1;
 		$Title = _('Print MRP Report Error');
@@ -76,7 +76,7 @@ if (isset($_POST['PrintPDF']) AND $_POST['Part']!='') {
 			 FROM mrpsupplies
 			 WHERE part = '" . $_POST['Part'] . "'
 			 ORDER BY mrpdate";
-	$Result = DB_query($SQL,'','',false,true);
+	$Result = DB_query($SQL);
 	if (DB_error_no() !=0) {
 		$Errors = 1;
 	}
@@ -713,8 +713,7 @@ if (isset($_POST['Search']) OR isset($_POST['Go']) OR isset($_POST['Next']) OR i
 		}
 	}
 	$ErrMsg = _('No stock items were returned by the SQL because');
-	$DbgMsg = _('The SQL that returned an error was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('No stock items were returned by this search please re-enter alternative criteria to try again'), 'info');
 	}

--- a/MaintenanceTasks.php
+++ b/MaintenanceTasks.php
@@ -29,7 +29,7 @@ if (isset($_POST['Submit'])) {
 								'" . $_POST['Manager'] . "',
 								'" . Date('Y-m-d') . "' )";
 		$ErrMsg = _('The authentication details cannot be inserted because');
-		$Result=DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		unset($_POST['AssetID']);
 		unset($_POST['TaskDescription']);
 		unset($_POST['FrequencyDays']);
@@ -51,7 +51,7 @@ if (isset($_POST['Update'])) {
 				WHERE taskid='".$_POST['TaskID']."'";
 
 		$ErrMsg = _('The task details cannot be updated because');
-		$Result=DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		unset($_POST['AssetID']);
 		unset($_POST['TaskDescription']);
 		unset($_POST['FrequencyDays']);
@@ -65,7 +65,7 @@ if (isset($_GET['Delete'])) {
 		WHERE taskid='".$_GET['TaskID']."'";
 
 	$ErrMsg = _('The maintenance task cannot be deleted because');
-	$Result=DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 }
 
 $SQL="SELECT taskid,
@@ -84,7 +84,7 @@ $SQL="SELECT taskid,
 		ON fixedassettasks.userresponsible=www_users.userid";
 
 $ErrMsg = _('The maintenance task details cannot be retrieved because');
-$Result=DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 echo '<table class="selection">
      <tr>
@@ -141,7 +141,7 @@ if (isset($_GET['Edit'])) {
 			FROM fixedassettasks
 			WHERE taskid='".$_GET['TaskID']."'";
 	$ErrMsg = _('The maintenance task details cannot be retrieved because');
-	$Result=DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$MyRow=DB_fetch_array($Result);
 	$_POST['TaskDescription'] = $MyRow['taskdescription'];
 	$_POST['FrequencyDays'] = $MyRow['frequencydays'];
@@ -172,7 +172,7 @@ echo '<field>
 		<label for="AssetID">' . _('Asset to Maintain').':</label>
 		<select required="required" name="AssetID">';
 $AssetSQL="SELECT assetid, description FROM fixedassets";
-$AssetResult=DB_query($AssetSQL);
+$AssetResult = DB_query($AssetSQL);
 while ($MyRow=DB_fetch_array($AssetResult)) {
 	if ($MyRow['assetid']==$_POST['AssetID']) {
 		echo '<option selected="selected" value="'.$MyRow['assetid'].'">' . $MyRow['assetid'] . ' - ' . $MyRow['description']  . '</option>';
@@ -197,7 +197,7 @@ echo '<field>
 		<label for="UserResponsible">' . _('Responsible') . ':</label>
 		<select required="required" name="UserResponsible">';
 $UserSQL="SELECT userid FROM www_users";
-$UserResult=DB_query($UserSQL);
+$UserResult = DB_query($UserSQL);
 while ($MyRow=DB_fetch_array($UserResult)) {
 	if ($MyRow['userid']==$_POST['UserResponsible']) {
 		echo '<option selected="selected" value="'.$MyRow['userid'].'">' . $MyRow['userid'] . '</option>';
@@ -217,7 +217,7 @@ if ($_POST['Manager']==''){
 	echo '<option value="">' . _('No Manager') . '</option>';
 }
 $ManagerSQL="SELECT userid FROM www_users";
-$ManagerResult=DB_query($UserSQL);
+$ManagerResult = DB_query($UserSQL);
 while ($MyRow=DB_fetch_array($ManagerResult)) {
 	if ($MyRow['userid']==$_POST['Manager']) {
 		echo '<option selected="selected" value="'.$MyRow['userid'].'">' . $MyRow['userid'] . '</option>';

--- a/MaintenanceUserSchedule.php
+++ b/MaintenanceUserSchedule.php
@@ -41,7 +41,7 @@ $SQL="SELECT taskid,
 		ORDER BY ADDDATE(lastcompleted,frequencydays) DESC";
 
 $ErrMsg = _('The maintenance schedule cannot be retrieved because');
-$Result=DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 echo '<table class="selection">
      <tr>

--- a/Manufacturers.php
+++ b/Manufacturers.php
@@ -100,9 +100,8 @@ if (isset($_POST['submit'])) {
 		$SQL .= " WHERE manufacturers_id = '" . $SelectedManufacturer . "'";
 
 		$ErrMsg = _('An error occurred updating the') . ' ' . $SelectedManufacturer . ' ' . _('manufacturer record because');
-		$DbgMsg = _('The SQL used to update the manufacturer record was');
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg( _('The manufacturer record has been updated'),'success');
 		unset($_POST['ManufacturersName']);
@@ -120,8 +119,7 @@ if (isset($_POST['submit'])) {
 								'" . $_POST['ManufacturersURL'] . "')";
 
 		$ErrMsg =  _('An error occurred inserting the new manufacturer record because');
-		$DbgMsg =  _('The SQL used to insert the manufacturer record was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$LastInsertId = DB_Last_Insert_ID('manufacturers', 'manufacturers_id');
 
 		if (isset($_FILES['BrandPicture']) AND $_FILES['BrandPicture']['name'] !='') {

--- a/OrderDetails.php
+++ b/OrderDetails.php
@@ -48,8 +48,7 @@ $OrderHeaderSQL = "SELECT salesorders.debtorno,
 					WHERE salesorders.orderno = '" . $_GET['OrderNumber'] . "'";
 
 $ErrMsg =  _('The order cannot be retrieved because');
-$DbgMsg = _('The SQL that failed to get the order header was');
-$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg, $DbgMsg);
+$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg);
 
 if (DB_num_rows($GetOrdHdrResult)==1) {
 
@@ -169,8 +168,7 @@ if (DB_num_rows($GetOrdHdrResult)==1) {
 						WHERE orderno ='" . $_GET['OrderNumber'] . "'";
 
 	$ErrMsg =  _('The line items of the order cannot be retrieved because');
-	$DbgMsg =  _('The SQL used to retrieve the line items, that failed was');
-	$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg, $DbgMsg);
+	$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 
 	if (DB_num_rows($LineItemsResult)>0) {
 

--- a/PDFBankingSummary.php
+++ b/PDFBankingSummary.php
@@ -27,8 +27,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 			AND banktrans.type=12";
 
 	$ErrMsg = _('An error occurred getting the header information about the receipt batch number') . ' ' . $_POST['BatchNo'];
-	$DbgMsg = _('The SQL used to get the receipt header information that failed was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result) == 0){
 		$Title = _('Create PDF Print-out For A Batch Of Receipts');

--- a/PDFCOA.php
+++ b/PDFCOA.php
@@ -120,7 +120,7 @@ if (isset($SelectedCOA)) {
 				AND sampleresults.showoncert='1'
 				ORDER by groupby, sampleresults.testid";
 }
-$Result=DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 //If there are no rows, there's a problem.
 if (DB_num_rows($Result)==0){
@@ -307,7 +307,7 @@ $SQL = "SELECT confvalue
 			FROM config
 			WHERE confname='QualityCOAText'";
 
-$Result=DB_query($SQL, $ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 $MyRow=DB_fetch_array($Result);
 $Disclaimer=$MyRow[0];
 $LeftOvers = $pdf->addTextWrap($XPos+5,$YPos,500,$FontSize,$Disclaimer);

--- a/PDFChequeListing.php
+++ b/PDFChequeListing.php
@@ -45,7 +45,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				AND transdate >='" . FormatDateForSQL($_POST['FromDate']) . "'
 				AND transdate <='" . FormatDateForSQL($_POST['ToDate']) . "'";
 
-	$Result=DB_query($SQL,'','',false,false);
+	$Result = DB_query($SQL,'','',false,false);
 	if (DB_error_no()!=0){
 		$Title = _('Payment Listing');
 		include('includes/header.php');

--- a/PDFCustTransListing.php
+++ b/PDFCustTransListing.php
@@ -29,7 +29,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 			WHERE type='" . $_POST['TransType'] . "'
 			AND date_format(inputdate, '%Y-%m-%d')='".FormatDateForSQL($_POST['Date'])."'";
 
-	$Result=DB_query($SQL,'','',false,false);
+	$Result = DB_query($SQL,'','',false,false);
 
 	if (DB_error_no()!=0){
 		$Title = _('Payment Listing');

--- a/PDFCustomerList.php
+++ b/PDFCustomerList.php
@@ -466,7 +466,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 			<select name="Areas[]" multiple="multiple">';
 
 	$SQL="SELECT areacode, areadescription FROM areas";
-	$AreasResult= DB_query($SQL);
+	$AreasResult = DB_query($SQL);
 
 	echo '<option selected="selected" value="All">' . _('All Areas') . '</option>';
 

--- a/PDFOrderStatus.php
+++ b/PDFOrderStatus.php
@@ -166,7 +166,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 
 	$SQL .= " ORDER BY salesorders.orderno";
 
-	$Result=DB_query($SQL,'','',false,false); //dont trap errors here
+	$Result = DB_query($SQL,'','',false,false); //dont trap errors here
 
 	if (DB_error_no()!=0){
 		include('includes/header.php');

--- a/PDFOrdersInvoiced.php
+++ b/PDFOrdersInvoiced.php
@@ -164,7 +164,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 					stockmaster.decimalplaces
 			ORDER BY salesorders.orderno";
 
-	$Result=DB_query($SQL,'','',false,false); //dont trap errors here
+	$Result = DB_query($SQL,'','',false,false); //dont trap errors here
 
 	$HTML = '';
 
@@ -279,7 +279,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				WHERE debtortrans.order_ ='" . $OrderNo . "'
 				AND stockmoves.stockid ='" . $MyRow['stkcode'] . "'";
 
-		$InvoicesResult =DB_query($SQL);
+		$InvoicesResult = DB_query($SQL);
 		if (DB_num_rows($InvoicesResult)>0){
 			$HTML .= '<tr>
 						<th></th>
@@ -396,7 +396,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 			<select required="required" name="Location">
 				<option selected="selected" value="All">' . _('All Locations') . '</option>';
 
-	$Result= DB_query("SELECT locations.loccode, locationname FROM locations INNER JOIN locationusers ON locationusers.loccode=locations.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' AND locationusers.canview=1");
+	$Result = DB_query("SELECT locations.loccode, locationname FROM locations INNER JOIN locationusers ON locationusers.loccode=locations.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' AND locationusers.canview=1");
 	while ($MyRow=DB_fetch_array($Result)){
 		echo '<option value="' . $MyRow['loccode'] . '">' . $MyRow['locationname'] . '</option>';
 	}

--- a/PDFPeriodStockTransListing.php
+++ b/PDFPeriodStockTransListing.php
@@ -133,7 +133,7 @@ if ($_POST['StockLocation']=='All') {
 			AND date_format(trandate, '%Y-%m-%d')<='".FormatDateForSQL($_POST['ToDate'])."'
 			AND stockmoves.loccode='" . $_POST['StockLocation'] . "'";
 }
-$Result=DB_query($SQL,'','',false,false);
+$Result = DB_query($SQL,'','',false,false);
 
 if (DB_error_no()!=0){
 	$Title = _('Transaction Listing');

--- a/PDFPickingList.php
+++ b/PDFPickingList.php
@@ -26,7 +26,7 @@ if ((!isset($_GET['TransNo']) or $_GET['TransNo']=='') and !isset($_POST['TransD
 				locationname
 			FROM locations
 			INNER JOIN locationusers ON locationusers.loccode=locations.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' AND locationusers.canview=1";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	echo '<p class="page_title_text"><img src="'.$RootPath.'/css/'.$Theme.'/images/sales.png" title="' . _('Search') . '" alt="" />' . ' ' . $Title . '</p>';
 	echo '<form action="' . htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UTF-8') . '" method="post" name="form">
 		<input type="hidden" name="FormID" value="' . $_SESSION['FormID'] . '" />
@@ -136,7 +136,7 @@ if ($_SESSION['SalesmanLogin'] != '') {
 
 if (isset($_POST['TransDate'])
 	OR (isset($_GET['TransNo']) AND $_GET['TransNo'] != 'Preview')) {
-	$Result=DB_query($SQL, $ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	/*if there are no rows, there's a problem. */
 	if (DB_num_rows($Result)==0){
@@ -226,7 +226,7 @@ for ($i=0;$i<sizeof($OrdersToPick);$i++){
 		$SQL="SELECT COUNT(orderno)
 				FROM pickinglists
 				WHERE orderno='" . $OrdersToPick[$i]['orderno'] . "'";
-		$CountResult=DB_query($SQL);
+		$CountResult = DB_query($SQL);
 		$Count=DB_fetch_row($CountResult);
 		if ($Count[0]==0) {
 		/* There are no previous picking lists for this order */
@@ -266,7 +266,7 @@ for ($i=0;$i<sizeof($OrdersToPick);$i++){
             			WHERE salesorderdetails.orderno='" . $OrdersToPick[$i]['orderno'] ."'
             			AND salesorderdetails.orderlineno=pickinglistdetails.orderlineno";
 		}
-		$LineResult=DB_query($SQL, $ErrMsg);
+		$LineResult = DB_query($SQL, $ErrMsg);
 	}
 	if ((isset($_GET['TransNo'])
 		AND $_GET['TransNo'] == 'Preview')
@@ -284,7 +284,7 @@ for ($i=0;$i<sizeof($OrdersToPick);$i++){
 				'" . FormatDateForSQL($_POST['TransDate'])."',
 				CURRENT_DATE,
 				'1000-01-01')";
-			$HeaderResult=DB_query($SQL);
+			$HeaderResult = DB_query($SQL);
 		} else {
 			$LinesToShow=1;
 		}
@@ -318,7 +318,7 @@ for ($i=0;$i<sizeof($OrdersToPick);$i++){
 					'" . $MyRow2['orderlineno']."',
 					'" . $DisplayQtySupplied ."',
 					0)";
-					$LineResult=DB_query($SQL);
+					$LineResult = DB_query($SQL);
 			}
 			$ListCount ++;
 

--- a/PDFPriceList.php
+++ b/PDFPriceList.php
@@ -386,7 +386,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 			<label for="SalesType">', _('For Sales Type/Price List'), ':</label>
 			<select name="SalesType">';
 	$SQL = "SELECT sales_type, typeabbrev FROM salestypes";
-	$SalesTypesResult=DB_query($SQL);
+	$SalesTypesResult = DB_query($SQL);
 
 	while ($MyRow=DB_fetch_array($SalesTypesResult)) {
 		echo '<option value="', $MyRow['typeabbrev'], '">', $MyRow['sales_type'], '</option>';
@@ -398,7 +398,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 			<label for="Currency">', _('For Currency'), ':</label>
 			<select name="Currency">';
 	$SQL = "SELECT currabrev, currency FROM currencies ORDER BY currency";
-	$CurrencyResult=DB_query($SQL);
+	$CurrencyResult = DB_query($SQL);
 	echo '<option selected="selected" value="All">', _('All'), '</option>';
 	while ($MyRow=DB_fetch_array($CurrencyResult)) {
 		echo '<option value="', $MyRow['currabrev'], '">', $MyRow['currency'], '</option>';

--- a/PDFPrintLabel.php
+++ b/PDFPrintLabel.php
@@ -298,7 +298,7 @@ if (isset($_POST['PrintLabels']) AND $NoOfLabels>0) {
 				<label for="StockCategory">' .  _('For Stock Category') .':</label>
 				<select name="StockCategory">';
 
-		$CatResult= DB_query("SELECT categoryid, categorydescription FROM stockcategory ORDER BY categorydescription");
+		$CatResult = DB_query("SELECT categoryid, categorydescription FROM stockcategory ORDER BY categorydescription");
 		while ($MyRow = DB_fetch_array($CatResult)){
 			echo '<option value="' . $MyRow['categoryid'] . '">' . $MyRow['categorydescription'] . '</option>';
 		}
@@ -309,7 +309,7 @@ if (isset($_POST['PrintLabels']) AND $NoOfLabels>0) {
 				<label for="SalesType">' . _('For Sales Type/Price List').':</label>
 				<select name="SalesType">';
 		$SQL = "SELECT sales_type, typeabbrev FROM salestypes";
-		$SalesTypesResult=DB_query($SQL);
+		$SalesTypesResult = DB_query($SQL);
 
 		while ($MyRow=DB_fetch_array($SalesTypesResult)){
 			if ($_SESSION['DefaultPriceList']==$MyRow['typeabbrev']){
@@ -325,7 +325,7 @@ if (isset($_POST['PrintLabels']) AND $NoOfLabels>0) {
 				<label for="Currency">' . _('For Currency').':</label>
 				<select name="Currency">';
 		$SQL = "SELECT currabrev, country, currency FROM currencies";
-		$CurrenciesResult=DB_query($SQL);
+		$CurrenciesResult = DB_query($SQL);
 
 		while ($MyRow=DB_fetch_array($CurrenciesResult)){
 			if ($_SESSION['CompanyRecord']['currencydefault']==$MyRow['currabrev']){

--- a/PDFProdSpec.php
+++ b/PDFProdSpec.php
@@ -87,7 +87,7 @@ $SQL = "SELECT keyval,
 			AND prodspecs.showonspec='1'
 			ORDER by groupby, prodspecs.testid";
 
-$Result=DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 //If there are no rows, there's a problem.
 if (DB_num_rows($Result)==0){
@@ -277,7 +277,7 @@ $SQL = "SELECT confvalue
 			FROM config
 			WHERE confname='QualityProdSpecText'";
 
-$Result=DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 $MyRow=DB_fetch_array($Result);
 $Disclaimer=$MyRow[0];
 $LeftOvers = $pdf->addTextWrap($XPos+5,$YPos,500,$FontSize,$Disclaimer);

--- a/PDFQALabel.php
+++ b/PDFQALabel.php
@@ -40,7 +40,7 @@ if ($GRNNo == 'Preview'){
 			ON grns.itemcode=stockmaster.stockid
 			WHERE grnbatch='". $GRNNo ."'";
 
-	$GRNResult=DB_query($SQL);
+	$GRNResult = DB_query($SQL);
 	$NoOfGRNs = DB_num_rows($GRNResult);
 	if($NoOfGRNs>0) { //there are GRNs to print
 

--- a/PDFQuotation.php
+++ b/PDFQuotation.php
@@ -71,7 +71,7 @@ $SQL = "SELECT salesorders.customerref,
 			WHERE salesorders.quotation=1
 			AND salesorders.orderno='" . $_GET['QuotationNo'] ."'";
 
-$Result=DB_query($SQL, $ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 //If there are no rows, there's a problem.
 if (DB_num_rows($Result)==0){
@@ -133,7 +133,7 @@ $SQL = "SELECT salesorderdetails.stkcode,
 		ON salesorderdetails.stkcode=stockmaster.stockid
 	WHERE salesorderdetails.orderno='" . $_GET['QuotationNo'] . "'";
 
-$Result=DB_query($SQL, $ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 $ListCount = 0;
 

--- a/PDFQuotationPortrait.php
+++ b/PDFQuotationPortrait.php
@@ -73,7 +73,7 @@ $SQL = "SELECT salesorders.customerref,
 			WHERE salesorders.quotation=1
 			AND salesorders.orderno='" . $_GET['QuotationNo'] ."'";
 
-$Result=DB_query($SQL, $ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 //If there are no rows, there's a problem.
 if (DB_num_rows($Result)==0){
@@ -135,7 +135,7 @@ $SQL = "SELECT salesorderdetails.stkcode,
 		ON salesorderdetails.stkcode=stockmaster.stockid
 	WHERE salesorderdetails.orderno='" . $_GET['QuotationNo'] . "'";
 
-$Result=DB_query($SQL, $ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 $ListCount = 0;
 

--- a/PDFReceipt.php
+++ b/PDFReceipt.php
@@ -49,7 +49,7 @@ $YPos -= (1.5 * $LineHeight);
 $PageNumber++;
 
 $SQL="SELECT MIN(id) as start FROM debtortrans WHERE type=12 AND transno='". $_GET['BatchNumber']. "'";
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 $MyRow=DB_fetch_array($Result);
 $StartReceiptNumber=$MyRow['start'];
 
@@ -73,7 +73,7 @@ $SQL = "SELECT 	currabrev,
 				FROM banktrans
 				WHERE type=12
 				AND transno='" . $_GET['BatchNumber']."')";
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 $MyRow=DB_fetch_array($Result);
 $CurrencyCode=$MyRow['currabrev'];
 $DecimalPlaces=$MyRow['decimalplaces'];
@@ -88,7 +88,7 @@ $SQL="SELECT name,
 		FROM debtorsmaster
 		WHERE debtorno='".$DebtorNo."'";
 
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 $MyRow=DB_fetch_array($Result);
 
 /* Prints customer info */

--- a/PDFShipLabel.php
+++ b/PDFShipLabel.php
@@ -183,8 +183,7 @@ if ($SelectedORD == 'Preview') {
 	}
 	//echo $OrderHeaderSQL;
 	$ErrMsg = _('The order cannot be retrieved because');
-	$DbgMsg = _('The SQL that failed to get the order header was');
-	$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg, $DbgMsg);
+	$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg);
 
 	if (DB_num_rows($GetOrdHdrResult) > 0) {
 		$BoxNumber = 1;

--- a/PDFStockCheckComparison.php
+++ b/PDFStockCheckComparison.php
@@ -120,22 +120,19 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['ReportOrClose'])){
 						)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock movement record cannot be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "UPDATE locstock
 						SET quantity = quantity + '" . $StockQtyDifference . "'
 						WHERE stockid='" . $MyRow['stockid'] . "'
 						AND loccode='" . $MyRow['loccode'] . "'";
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-				$DbgMsg = _('The following SQL to update the stock record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				if ($_SESSION['CompanyRecord']['gllink_stock']==1 AND $MyRow['standardcost'] > 0){
 
 					$StockGLCodes = GetStockGLCode($MyRow['stockid']);
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction entries could not be added because');
-					$DbgMsg = _('The following SQL to insert the GL entries was used');
 
 					$SQL = "INSERT INTO gltrans (type,
 									typeno,
@@ -151,10 +148,9 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['ReportOrClose'])){
 								'" .  $StockGLCodes['adjglact'] . "',
 								'" . ($MyRow['standardcost'] * -($StockQtyDifference)) . "',
 								'" . mb_substr($MyRow['stockid'] . " x " . $StockQtyDifference . " @ " . $MyRow['standardcost'] . " - " . _('Inventory Check'), 0, 200) . "')";
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction entries could not be added because');
-					$DbgMsg = _('The following SQL to insert the GL entries was used');
 
 					$SQL = "INSERT INTO gltrans (type,
 									typeno,
@@ -170,7 +166,7 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['ReportOrClose'])){
 								'" .  $StockGLCodes['stockact'] . "',
 								'" . $MyRow['standardcost'] * $StockQtyDifference . "',
                                 '" . mb_substr($MyRow['stockid'] . " x " . $StockQtyDifference . " @ " . $MyRow['standardcost'] . " - " . _('Inventory Check'), 0, 200) . "')";
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				} //END INSERT GL TRANS
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Unable to COMMIT transaction while adjusting stock in StockCheckAdjustmet report');
@@ -183,7 +179,6 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['ReportOrClose'])){
 
 	// now do the report
 	$ErrMsg = _('The Inventory Comparison data could not be retrieved because');
-	$DbgMsg = _('The following SQL to retrieve the Inventory Comparison data was used');
 	$SQL = "SELECT stockcheckfreeze.stockid,
 					description,
 					stockmaster.categoryid,
@@ -206,7 +201,7 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['ReportOrClose'])){
 				stockmaster.categoryid,
 				stockcheckfreeze.stockid";
 
-	$CheckedItems = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$CheckedItems = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($CheckedItems)==0){
 		$Title= _('Inventory Comparison Comparison Report');

--- a/PDFStockLocTransfer.php
+++ b/PDFStockLocTransfer.php
@@ -57,7 +57,6 @@ $PageNumber=1;
 $LineHeight=30;
 
 $ErrMsg = _('An error occurred retrieving the items on the transfer'). '.' . '<p>' .  _('This page must be called with a location transfer reference number').'.';
-$DbgMsg = _('The SQL that failed while retrieving the items on the transfer was');
 $SQL = "SELECT loctransfers.reference,
 			   loctransfers.stockid,
 			   stockmaster.description,
@@ -77,7 +76,7 @@ $SQL = "SELECT loctransfers.reference,
 		INNER JOIN locationusers as locationusersrec ON locationusersrec.loccode=locationsrec.loccode AND locationusersrec.userid='" .  $_SESSION['UserID'] . "' AND locationusersrec.canview=1
 		WHERE loctransfers.reference='" . $_GET['TransferNo'] . "'";
 
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($Result)==0){
 

--- a/PDFStockNegatives.php
+++ b/PDFStockNegatives.php
@@ -11,7 +11,6 @@ $LineHeight=15;
 
 $Title = _('Negative Stock Listing Error');
 $ErrMsg = _('An error occurred retrieving the negative quantities.');
-$DbgMsg = _('The sql that failed to retrieve the negative quantities was');
 
 $SQL = "SELECT stockmaster.stockid,
                stockmaster.description,
@@ -31,7 +30,7 @@ $SQL = "SELECT stockmaster.stockid,
 			stockmaster.stockid,
 			stockmaster.decimalplaces";
 
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($Result)==0){
 	include('includes/header.php');

--- a/PDFStockTransfer.php
+++ b/PDFStockTransfer.php
@@ -82,7 +82,7 @@ $SQL="SELECT stockmoves.stockid,
 		AND qty < 0
 		AND type=16";
 
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 if (DB_num_rows($Result) == 0){
 	$Title = _('Print Stock Transfer - Error');
 	include('includes/header.php');

--- a/PDFSuppTransListing.php
+++ b/PDFSuppTransListing.php
@@ -73,7 +73,7 @@ $SQL= "SELECT type,
 		WHERE type='" . $_POST['TransType'] . "'
 		AND trandate='" . FormatDateForSQL($_POST['Date']) . "'";
 
-$Result=DB_query($SQL,'','',false,false);
+$Result = DB_query($SQL,'','',false,false);
 
 if (DB_error_no()!=0){
 	$Title = _('Payment Listing');

--- a/PDFWeeklyOrders.php
+++ b/PDFWeeklyOrders.php
@@ -46,7 +46,7 @@ $SQL= "SELECT salesorders.orderno,
 		 AND salesorders.quotation=0
 		 ORDER BY salesorders.orderno";
 
-$Result=DB_query($SQL,'','',false,false); //dont trap errors here
+$Result = DB_query($SQL,'','',false,false); //dont trap errors here
 
 if (DB_error_no()!=0){
 	include('includes/header.php');

--- a/POFinancialPlanning.php
+++ b/POFinancialPlanning.php
@@ -48,7 +48,7 @@ function submit($Country, $Currency, $RootPath, $Title) {
 			ORDER BY suppliers.supplierid ASC";
 
 	$ErrMsg = _('The SQL to find the suppliers with active Purchase Orders');
-	$ResultSuppliers = DB_query($SQL,$ErrMsg);
+	$ResultSuppliers = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($ResultSuppliers) != 0){
 
 		echo '<p class="page_title_text" align="center"><strong>' . $Title . '</strong></p>';
@@ -104,7 +104,7 @@ function submit($Country, $Currency, $RootPath, $Title) {
 							ORDER BY purchorders.orderno ASC";
 
 			$ErrMsg = _('The bill of material could not be retrieved because');
-			$SupplierResult = DB_query($SQLSupplier,$ErrMsg);
+			$SupplierResult = DB_query($SQLSupplier, $ErrMsg);
 
 			$TotalSupplierOwnCurrency = 0;
 			$TotalSupplierFunctionalCurrency = 0;
@@ -202,7 +202,7 @@ function display($Title)
 	$SQL = "SELECT DISTINCT(address6) AS country
 			FROM suppliers
 			ORDER BY address6";
-	$CountryResult=DB_query($SQL);
+	$CountryResult = DB_query($SQL);
 	echo '<option value="All">' . _('All Countries') . '</option>';
 	while ($MyRow=DB_fetch_array($CountryResult)){
 		echo '<option value="' . $MyRow['country'] . '">' . $MyRow['country'] . '</option>';
@@ -217,7 +217,7 @@ function display($Title)
 				currency
 			FROM currencies
 			ORDER BY currency";
-	$CurrencyResult=DB_query($SQL);
+	$CurrencyResult = DB_query($SQL);
 	echo '<option value="All">' . _('All Currencies') . '</option>';
 	while ($MyRow=DB_fetch_array($CurrencyResult)){
 		echo '<option value="' . $MyRow['currabrev'] . '">' . $MyRow['currency'] . '</option>';

--- a/POReport.php
+++ b/POReport.php
@@ -483,7 +483,7 @@ function submit($PartNumber,$PartNumberOp,$SupplierId,$SupplierIdOp,$SupplierNam
 		} // End of if ($_POST['ReportType']
 		//echo "<br/>$SQL<br/>";
 		$ErrMsg = _('The SQL to find the parts selected failed with the message');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$ctr = 0;
 		$TotalQty = 0;
 		$TotalRecdQty = 0;
@@ -1207,7 +1207,7 @@ function submitcsv( $PartNumber,
 		} // End of if ($_POST['ReportType']
 		//echo "<br/>$SQL<br/>";
 		$ErrMsg = _('The SQL to find the parts selected failed with the message');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$ctr = 0;
 		$TotalQty = 0;
 		$TotalExtCost = 0;
@@ -1545,7 +1545,7 @@ function display()  //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_#####
 			<label for="Category">' . _('Stock Categories') . ':</label>
 			<select name="Category">';
 	$SQL="SELECT categoryid, categorydescription FROM stockcategory";
-	$CategoryResult= DB_query($SQL);
+	$CategoryResult = DB_query($SQL);
 	echo '<option selected="selected" value="All">' . _('All Categories') . '</option>';
 	while ($MyRow = DB_fetch_array($CategoryResult)){
 		echo '<option value="' . $MyRow['categoryid'] . '">' . $MyRow['categorydescription'] . '</option>';

--- a/PO_AuthorisationLevels.php
+++ b/PO_AuthorisationLevels.php
@@ -36,7 +36,7 @@ if (isset($_POST['Submit'])) {
 		FROM purchorderauth
 		WHERE userid='" . $_POST['UserID'] . "'
 		AND currabrev='" . $_POST['CurrCode'] . "'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_array($Result);
 	if ($MyRow[0]==0) {
 		$SQL="INSERT INTO purchorderauth ( userid,
@@ -50,7 +50,7 @@ if (isset($_POST['Submit'])) {
 						'".$OffHold."',
 						'" . filter_number_format($_POST['AuthLevel'])."')";
 	$ErrMsg = _('The authentication details cannot be inserted because');
-	$Result=DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	} else {
 		prnMsg(_('There already exists an entry for this user/currency combination'), 'error');
 		echo '<br />';
@@ -76,7 +76,7 @@ if (isset($_POST['Update'])) {
 			AND currabrev='".$_POST['CurrCode']."'";
 
 	$ErrMsg = _('The authentication details cannot be updated because');
-	$Result=DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 }
 
 if (isset($_GET['Delete'])) {
@@ -85,7 +85,7 @@ if (isset($_GET['Delete'])) {
 		AND currabrev='".$_GET['Currency']."'";
 
 	$ErrMsg = _('The authentication details cannot be deleted because');
-	$Result=DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 }
 
 if (isset($_GET['Edit'])) {
@@ -96,7 +96,7 @@ if (isset($_GET['Edit'])) {
 			WHERE userid='".$_GET['UserID']."'
 			AND currabrev='".$_GET['Currency']."'";
 	$ErrMsg = _('The authentication details cannot be retrieved because');
-	$Result=DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$MyRow=DB_fetch_array($Result);
 	$UserID=$_GET['UserID'];
 	$Currency=$_GET['Currency'];
@@ -119,7 +119,7 @@ $SQL="SELECT purchorderauth.userid,
 		ON purchorderauth.currabrev=currencies.currabrev";
 
 $ErrMsg = _('The authentication details cannot be retrieved because');
-$Result=DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 echo '<table class="selection">
 		<thead>
@@ -208,7 +208,7 @@ if (isset($_GET['Edit'])) {
 			WHERE userid='".$_GET['UserID']."'
 			AND purchorderauth.currabrev='".$_GET['Currency']."'";
 	$ErrMsg = _('The authentication details cannot be retrieved because');
-	$Result=DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$MyRow=DB_fetch_array($Result);
 	$UserID=$_GET['UserID'];
 	$Currency=$_GET['Currency'];

--- a/PO_AuthoriseMyOrders.php
+++ b/PO_AuthoriseMyOrders.php
@@ -13,7 +13,7 @@ echo '<p class="page_title_text"><img src="'.$RootPath.'/css/'.$Theme.'/images/t
 	 '" alt="" />' . ' ' . $Title . '</p>';
 
 $EmailSQL="SELECT email FROM www_users WHERE userid='".$_SESSION['UserID']."'";
-$EmailResult=DB_query($EmailSQL);
+$EmailResult = DB_query($EmailSQL);
 $EmailRow=DB_fetch_array($EmailResult);
 
 if (isset($_POST['UpdateAll'])) {
@@ -27,7 +27,7 @@ if (isset($_POST['UpdateAll'])) {
 						stat_comment='".$Comment."',
 						allowprint=1
 					WHERE orderno='". $OrderNo."'";
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 		}
 	}
 }
@@ -47,7 +47,7 @@ $SQL="SELECT purchorders.*,
 		INNER JOIN www_users
 			ON www_users.userid=purchorders.initiator
 	WHERE status='Pending'";
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 
 echo '<form method="post" action="' . htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UTF-8') . '">';
 echo '<input type="hidden" name="FormID" value="' . $_SESSION['FormID'] . '" />
@@ -72,7 +72,7 @@ while ($MyRow=DB_fetch_array($Result)) {
 				WHERE userid='".$_SESSION['UserID']."'
 				AND currabrev='".$MyRow['currcode']."'";
 
-	$AuthResult=DB_query($AuthSQL);
+	$AuthResult = DB_query($AuthSQL);
 	$MyAuthRow=DB_fetch_array($AuthResult);
 	$AuthLevel=$MyAuthRow['authlevel'];
 
@@ -80,7 +80,7 @@ while ($MyRow=DB_fetch_array($Result)) {
 		           	FROM purchorderdetails
 			        WHERE orderno='".$MyRow['orderno'] . "'";
 
-	$OrderValueResult=DB_query($OrderValueSQL);
+	$OrderValueResult = DB_query($OrderValueSQL);
 	$MyOrderValueRow=DB_fetch_array($OrderValueResult);
 	$OrderValue=$MyOrderValueRow['ordervalue'];
 
@@ -106,7 +106,7 @@ while ($MyRow=DB_fetch_array($Result)) {
 				LEFT JOIN stockmaster
 				ON stockmaster.stockid=purchorderdetails.itemcode
 			WHERE orderno='".$MyRow['orderno'] . "'";
-		$LineResult=DB_query($LineSQL);
+		$LineResult = DB_query($LineSQL);
 
 		echo '<tr>
 				<td></td>

--- a/PO_Header.php
+++ b/PO_Header.php
@@ -409,8 +409,7 @@ if (isset($_POST['Select'])) {
 				WHERE supplierid='" . $_POST['Select'] . "'";
 
 	$ErrMsg = _('The supplier record of the supplier selected') . ': ' . $_POST['Select'] . ' ' . _('cannot be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the supplier details and failed was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$MyRow = DB_fetch_array($Result);
 	// added for suppliers lookup fields
 	$AuthSql = "SELECT cancreate
@@ -485,8 +484,7 @@ else {
 			WHERE supplierid='" . $_POST['Select'] . "'";
 
 	$ErrMsg = _('The supplier record of the supplier selected') . ': ' . $_POST['Select'] . ' ' . _('cannot be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the supplier details and failed was');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_array($Result);
 

--- a/PO_Items.php
+++ b/PO_Items.php
@@ -91,7 +91,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 						WHERE userid='".$_SESSION['UserID']."'
 						AND currabrev='".$_SESSION['PO'.$identifier]->CurrCode."'";
 
-			$AuthResult=DB_query($AuthSQL);
+			$AuthResult = DB_query($AuthSQL);
 			$AuthRow=DB_fetch_array($AuthResult);
 
 			if (DB_num_rows($AuthResult) > 0 AND $AuthRow['authlevel'] > $_SESSION['PO'.$identifier]->Order_Value()) { //user has authority to authrorise as well as create the order
@@ -196,8 +196,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 									'" . $_SESSION['PO'.$identifier]->AllowPrintPO . "' )";
 
 			$ErrMsg =  _('The purchase order header record could not be inserted into the database because');
-			$DbgMsg = _('The SQL statement used to insert the purchase order header record and failed was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		     /*Insert the purchase order detail records */
 			foreach ($_SESSION['PO'.$identifier]->LineItems as $POLine) {
@@ -230,9 +229,8 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 									'" . $POLine->AssetID . "',
 									'" . $POLine->ConversionFactor . "')";
 					$ErrMsg =_('One of the purchase order detail records could not be inserted into the database because');
-					$DbgMsg =_('The SQL statement used to insert the purchase order detail record and failed was');
 
-					$Result =DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 			} /* end of the loop round the detail line items on the order */
 			echo '<p />';
@@ -294,8 +292,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 										WHERE orderno = '" . $_SESSION['PO'.$identifier]->OrderNo ."'";
 
 			$ErrMsg =  _('The purchase order could not be updated because');
-			$DbgMsg = _('The SQL statement used to update the purchase order header record, that failed was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/*Now Update the purchase order detail records */
 			foreach ($_SESSION['PO'.$identifier]->LineItems as $POLine) {
@@ -304,8 +301,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 					if ($POLine->PODetailRec!='') {
 						$SQL="DELETE FROM purchorderdetails WHERE podetailitem='" . $POLine->PODetailRec . "'";
 						$ErrMsg =  _('The purchase order detail line could not be deleted because');
-						$DbgMsg = _('The SQL statement used to delete the purchase order detail record, that failed was');
-						$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 					}
 				} else if ($POLine->PODetailRec=='') {
 						/*When the purchase order line is an existing record the auto-increment
@@ -365,8 +361,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 				}
 
 				$ErrMsg = _('One of the purchase order detail records could not be updated because');
-				$DbgMsg = _('The SQL statement used to update the purchase order detail record that failed was');
-				$Result =DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			} /* end of the loop round the detail line items on the order */
 			echo '<br /><br />';
@@ -442,8 +437,7 @@ if (isset($_POST['EnterLine'])){ /*Inputs from the form directly without selecti
 				FROM chartmaster
 				WHERE accountcode ='" . $_POST['GLCode'] . "'";
 		$ErrMsg =  _('The account details for') . ' ' . $_POST['GLCode'] . ' ' . _('could not be retrieved because');
-		$DbgMsg =  _('The SQL used to retrieve the details of the account, but failed was');
-		$GLValidResult = DB_query($SQL,$ErrMsg,$DbgMsg,false,false);
+		$GLValidResult = DB_query($SQL, $ErrMsg,'',false,false);
 		if (DB_error_no() !=0) {
 			$AllowUpdate = false;
 			prnMsg( _('The validation process for the GL Code entered could not be executed because') . ' ' . DB_error_msg(), 'error');
@@ -572,8 +566,7 @@ if (isset($_POST['NewItem'])
 						WHERE stockmaster.stockid = '". $ItemCode . "'";
 
 				$ErrMsg = _('The item details for') . ' ' . $ItemCode . ' ' . _('could not be retrieved because');
-				$DbgMsg = _('The SQL used to retrieve the item details but failed was');
-				$ItemResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$ItemResult = DB_query($SQL, $ErrMsg);
 				if (DB_num_rows($ItemResult)==1){
 					$ItemRow = DB_fetch_array($ItemResult);
 
@@ -597,8 +590,7 @@ if (isset($_POST['NewItem'])
 							ORDER BY latesteffectivefrom DESC";
 
 					$ErrMsg = _('The purchasing data for') . ' ' . $ItemCode . ' ' . _('could not be retrieved because');
-					$DbgMsg = _('The SQL used to retrieve the purchasing data but failed was');
-					$PurchDataResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+					$PurchDataResult = DB_query($SQL, $ErrMsg);
 					if (DB_num_rows($PurchDataResult)>0){ //the purchasing data is set up
 						$PurchRow = DB_fetch_array($PurchDataResult);
 
@@ -614,8 +606,7 @@ if (isset($_POST['NewItem'])
 						$ItemDiscountPercent = 0;
 						$ItemDiscountAmount = 0;
 						$ErrMsg = _('Could not retrieve the supplier discounts applicable to the item');
-						$DbgMsg = _('The SQL used to retrive the supplier discounts that failed was');
-						$DiscountResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+						$DiscountResult = DB_query($SQL, $ErrMsg);
 						while ($DiscountRow = DB_fetch_array($DiscountResult)) {
 							$ItemDiscountPercent += $DiscountRow['discountpercent'];
 							$ItemDiscountAmount += $DiscountRow['discountamount'];
@@ -740,8 +731,7 @@ if (isset($_POST['UploadFile'])) {
 							WHERE  stockmaster.stockid = '". $ItemCode . "'";
 
 					$ErrMsg = _('The item details for') . ' ' . $ItemCode . ' ' . _('could not be retrieved because');
-					$DbgMsg = _('The SQL used to retrieve the item details but failed was');
-					$ItemResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+					$ItemResult = DB_query($SQL, $ErrMsg);
 					if (DB_num_rows($ItemResult)==1){
 						$ItemRow = DB_fetch_array($ItemResult);
 
@@ -765,8 +755,7 @@ if (isset($_POST['UploadFile'])) {
 								ORDER BY latesteffectivefrom DESC";
 
 						$ErrMsg = _('The purchasing data for') . ' ' . $ItemCode . ' ' . _('could not be retrieved because');
-						$DbgMsg = _('The SQL used to retrieve the purchasing data but failed was');
-						$PurchDataResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+						$PurchDataResult = DB_query($SQL, $ErrMsg);
 						if (DB_num_rows($PurchDataResult)>0){ //the purchasing data is set up
 							$PurchRow = DB_fetch_array($PurchDataResult);
 
@@ -782,8 +771,7 @@ if (isset($_POST['UploadFile'])) {
 							$ItemDiscountPercent = 0;
 							$ItemDiscountAmount = 0;
 							$ErrMsg = _('Could not retrieve the supplier discounts applicable to the item');
-							$DbgMsg = _('The SQL used to retrive the supplier discounts that failed was');
-							$DiscountResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+							$DiscountResult = DB_query($SQL, $ErrMsg);
 							while ($DiscountRow = DB_fetch_array($DiscountResult)) {
 								$ItemDiscountPercent += $DiscountRow['discountpercent'];
 								$ItemDiscountAmount += $DiscountRow['discountamount'];
@@ -963,7 +951,7 @@ if (isset($_POST['NonStockOrder'])) {
 				FROM chartmaster
 				ORDER BY accountcode ASC";
 
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	while ($MyRow=DB_fetch_array($Result)) {
 		echo '<option value="'.$MyRow['accountcode'].'">' . $MyRow['accountcode'].' - '.$MyRow['accountname'] . '</option>';
 	}
@@ -1241,8 +1229,7 @@ if (isset($_POST['Search']) OR isset($_POST['Prev']) OR isset($_POST['Next'])){ 
 	$SQLCount = substr($SQLCount,0, strpos($SQLCount,   "ORDER"));
 	$SQLCount = 'SELECT COUNT(*) '.$SQLCount;
 	$ErrMsg = _('Failed to retrieve result count');
-	$DbgMsg = _('The SQL failed is ');
-	$SearchResult = DB_query($SQLCount,$ErrMsg,$DbgMsg);
+	$SearchResult = DB_query($SQLCount, $ErrMsg);
 	$MyRow=DB_fetch_array($SearchResult);
 	DB_free_result($SearchResult);
 	unset($SearchResult);
@@ -1270,8 +1257,7 @@ if (isset($_POST['Search']) OR isset($_POST['Prev']) OR isset($_POST['Next'])){ 
 	$SQL = $SQL . " LIMIT " . $_SESSION['DisplayRecordsMax']." OFFSET " . strval($_SESSION['DisplayRecordsMax']*$Offset);
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL statement that failed was');
-	$SearchResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult)==0 AND $Debug==1){
 		prnMsg( _('There are no products to display matching the criteria provided'),'warn');
@@ -1292,8 +1278,7 @@ if (!isset($_GET['Edit'])) {
 			WHERE stocktype<>'D'
 			ORDER BY categorydescription";
 	$ErrMsg = _('The supplier category details could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the category details but failed was');
-	$Result1 = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result1 = DB_query($SQL, $ErrMsg);
 
 	echo '<fieldset>
 			<legend>' .  _('Search For Stock Items') . ':</legend>';
@@ -1404,7 +1389,7 @@ if (isset($SearchResult)) {
 					WHERE purchdata.supplierno='" . $_SESSION['PO'.$identifier]->SupplierID . "'
 						AND purchdata.stockid='" . $MyRow['stockid'] . "'";
 		$ErrMsg = _('Could not retrieve the purchasing data for the item');
-		$PurchDataResult = DB_query($SQL,$ErrMsg);
+		$PurchDataResult = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($PurchDataResult)>0) {
 			$PurchDataRow = DB_fetch_array($PurchDataResult);

--- a/PO_SelectOSPurchOrder.php
+++ b/PO_SelectOSPurchOrder.php
@@ -143,8 +143,7 @@ if (isset($_POST['SearchParts'])) {
 	}
 
 	$ErrMsg = _('No stock items were returned by the SQL because');
-	$DbgMsg = _('The SQL used to retrieve the searched parts was');
-	$StockItemsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$StockItemsResult = DB_query($SQL, $ErrMsg);
 } //isset($_POST['SearchParts'])
 
 
@@ -185,7 +184,7 @@ if (!isset($OrderNumber) or $OrderNumber == '') {
 	$SQL = "SELECT locations.loccode, locationname,(SELECT count(*) FROM locations) AS total FROM locations
 				INNER JOIN locationusers ON locationusers.loccode=locations.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' AND locationusers.canview=1";
 	$ErrMsg = _('Failed to retrieve location data');
-	$ResultStkLocs = DB_query($SQL,$ErrMsg);
+	$ResultStkLocs = DB_query($SQL, $ErrMsg);
 	$UserLocations = DB_num_rows($ResultStkLocs);
 	$AllListed = false;
 	while ($MyRow = DB_fetch_array($ResultStkLocs)) {
@@ -351,7 +350,7 @@ if (isset($StockItemsResult)) {
 	$StockStr .=')';
 	$QOHSQL = "SELECT stockid, sum(quantity) FROM locstock INNER JOIN locationusers ON locationusers.loccode=locationusers.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' GROUP BY stockid";
 	$ErrMsg = _('Failed to retrieve qoh');
-	$QOHResult = DB_query($QOHSQL,$ErrMsg);
+	$QOHResult = DB_query($QOHSQL, $ErrMsg);
 	$QOH = array();
 	while ($MyRow=DB_fetch_array($QOHResult)){
 		$QOH[$MyRow['stockid']] = $MyRow[1];
@@ -652,7 +651,7 @@ else {
 			//lets retrieve the PO balance here to make it a standard sql query.
 			$BalSql = "SELECT itemcode, quantityord - quantityrecd as balance FROM purchorderdetails WHERE orderno = '" . $MyRow['orderno'] . "'";
 			$ErrMsg = _('Failed to retrieve purchorder details');
-			$BalResult  = DB_query($BalSql,$ErrMsg);
+			$BalResult = DB_query($BalSql, $ErrMsg);
 			if (DB_num_rows($BalResult)>0) {
 				while ($BalRow = DB_fetch_array($BalResult)) {
 					$Bal .= '<br/>' . $BalRow['itemcode'] . ' -- ' . $BalRow['balance'];

--- a/PO_SelectPurchOrder.php
+++ b/PO_SelectPurchOrder.php
@@ -103,8 +103,7 @@ if (isset($_POST['SearchParts'])) {
 			ORDER BY stockmaster.stockid";
 	}
 	$ErrMsg = _('No stock items were returned by the SQL because');
-	$DbgMsg = _('The SQL used to retrieve the searched parts was');
-	$StockItemsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$StockItemsResult = DB_query($SQL, $ErrMsg);
 }
 /* Not appropriate really to restrict search by date since user may miss older
 * ouststanding orders

--- a/PaymentMethods.php
+++ b/PaymentMethods.php
@@ -198,7 +198,7 @@ if (isset($_POST['submit'])) {
 			ORDER BY paymentid";
 
 	$ErrMsg = _('Could not get payment methods because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 		<thead>

--- a/Payments.php
+++ b/Payments.php
@@ -65,8 +65,7 @@ $SQL = "SELECT pagesecurity
 		 WHERE scripts.script = 'BankAccountBalances.php'";
 
 $ErrMsg = _('The security for G/L Accounts cannot be retrieved because');
-$DbgMsg = _('The SQL that was used and failed was');
-$Security2Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+$Security2Result = DB_query($SQL, $ErrMsg);
 $MyUserRow = DB_fetch_array($Security2Result);
 $CashSecurity = $MyUserRow['pagesecurity'];
 
@@ -560,8 +559,7 @@ if (isset($_POST['CommitBatch']) AND empty($Errors)) {
 								$_SESSION['PaymentDetail' . $identifier]->Currency . "'
 							)";
 					$ErrMsg = _('Cannot insert a bank transaction because');
-					$DbgMsg = _('Cannot insert a bank transaction with the SQL');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 			}
 		}
@@ -611,8 +609,7 @@ if (isset($_POST['CommitBatch']) AND empty($Errors)) {
 							$_POST['ChequeNum'] . "'
 						)";
 			$ErrMsg = _('Cannot insert a payment transaction against the supplier because');
-			$DbgMsg = _('Cannot insert a payment transaction against the supplier using the SQL');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 			$SQL = "SELECT id FROM supptrans WHERE transno='" . $TransNo . "' AND type=22";
 			$Result = DB_query($SQL, '', '', true);
 			$MyRow = DB_fetch_array($Result);
@@ -622,13 +619,11 @@ if (isset($_POST['CommitBatch']) AND empty($Errors)) {
 					/* Firstly subtract from the payment the amount of the invoice  */
 					$SQL = "UPDATE supptrans SET alloc=alloc-" . $PaidAmount . " WHERE id='" . $PaymentID . "'";
 					$ErrMsg = _('Cannot update an allocation against the supplier because');
-					$DbgMsg = _('Cannot update an allocation against the supplier using the SQL');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					/* Then add theamount of the invoice to the invoice allocation */
 					$SQL = "UPDATE supptrans SET alloc=alloc+" . $PaidAmount . " WHERE id='" . $PaidID . "'";
 					$ErrMsg = _('Cannot update an allocation against the supplier because');
-					$DbgMsg = _('Cannot update an allocation against the supplier using the SQL');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					/* Finally update the supplier allocations table */
 					$SQL = "INSERT INTO suppallocs (amt,
 													datealloc,
@@ -641,8 +636,7 @@ if (isset($_POST['CommitBatch']) AND empty($Errors)) {
 													'" . $PaidID . "'
 												)";
 					$ErrMsg = _('Cannot update an allocation against the supplier because');
-					$DbgMsg = _('Cannot update an allocation against the supplier using the SQL');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 			}
 
@@ -652,8 +646,7 @@ if (isset($_POST['CommitBatch']) AND empty($Errors)) {
 						lastpaid='" . $_SESSION['PaymentDetail' . $identifier]->Amount . "'
 					WHERE suppliers.supplierid='" . $_SESSION['PaymentDetail' . $identifier]->SupplierID . "'";
 			$ErrMsg = _('Cannot update the supplier record for the date of the last payment made because');
-			$DbgMsg = _('Cannot update the supplier record for the date of the last payment made using the SQL');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$_SESSION['PaymentDetail' . $identifier]->gltrans_narrative = $_SESSION['PaymentDetail' . $identifier]->SupplierID . ' - ' . $_SESSION['PaymentDetail' . $identifier]->gltrans_narrative;
 
@@ -678,8 +671,7 @@ if (isset($_POST['CommitBatch']) AND empty($Errors)) {
 							$CreditorTotal . "'
 						)";
 				$ErrMsg = _('Cannot insert a GL transaction for the creditors account debit because');
-				$DbgMsg = _('Cannot insert a GL transaction for the creditors account debit using the SQL');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				if ($_SESSION['PaymentDetail' . $identifier]->Discount != 0) {
 					/* Now credit Discount received account with discounts */
@@ -701,8 +693,7 @@ if (isset($_POST['CommitBatch']) AND empty($Errors)) {
 								(-$_SESSION['PaymentDetail' . $identifier]->Discount / $_SESSION['PaymentDetail' . $identifier]->ExRate / $_SESSION['PaymentDetail' . $identifier]->FunctionalExRate) . "'
 							)";
 					$ErrMsg = _('Cannot insert a GL transaction for the payment discount credit because');
-					$DbgMsg = _('Cannot insert a GL transaction for the payment discount credit using the SQL');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} // end if discount
 
 			} // end if gl creditors
@@ -730,8 +721,7 @@ if (isset($_POST['CommitBatch']) AND empty($Errors)) {
 							(-$_SESSION['PaymentDetail' . $identifier]->Amount / $_SESSION['PaymentDetail' . $identifier]->ExRate / $_SESSION['PaymentDetail' . $identifier]->FunctionalExRate) . "'
 						)";
 				$ErrMsg = _('Cannot insert a GL transaction for the bank account credit because');
-				$DbgMsg = _('Cannot insert a GL transaction for the bank account credit using the SQL');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				EnsureGLEntriesBalance($TransType, $TransNo);
 			}
 		}
@@ -763,8 +753,7 @@ if (isset($_POST['CommitBatch']) AND empty($Errors)) {
 					$_POST['ChequeNum'] . "'
 				)";
 		$ErrMsg = _('Cannot insert a bank transaction because');
-		$DbgMsg = _('Cannot insert a bank transaction using the SQL');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		DB_Txn_Commit();
 		prnMsg(_('Payment') . ' ' . $TransNo . ' ' . _('has been successfully entered') , 'success');
@@ -917,9 +906,8 @@ if (isset($_POST['BankAccount']) AND $_POST['BankAccount'] != '') {
 			AND chartmaster.accountcode='" . $_POST['BankAccount'] . "'";
 
 	$ErrMsg = _('The bank account name cannot be retrieved because');
-	$DbgMsg = _('SQL used to retrieve the bank account name was');
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result) == 1) {
 		$MyRow = DB_fetch_row($Result);
@@ -968,8 +956,7 @@ $SQL = "SELECT bankaccountname,
 		ORDER BY bankaccountname";
 
 $ErrMsg = _('The bank accounts could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve the bank accounts was');
-$AccountsResults = DB_query($SQL, $ErrMsg, $DbgMsg);
+$AccountsResults = DB_query($SQL, $ErrMsg);
 
 echo '<field>
 		<label for="BankAccount">', _('Bank Account') , ':</label>

--- a/PcAuthorizeCash.php
+++ b/PcAuthorizeCash.php
@@ -185,8 +185,7 @@ if (isset($_POST['Submit']) or isset($_POST['update']) or isset($SelectedTabs) o
 											'" . $MyRow['currency'] . "'
 										)";
 			$ErrMsg = _('Cannot insert a bank transaction because');
-			$DbgMsg = _('Cannot insert a bank transaction with the SQL');
-			$ResultBank = DB_query($SQLBank, $ErrMsg, $DbgMsg, true);
+			$ResultBank = DB_query($SQLBank, $ErrMsg, '', true);
 
 			$SQL = "UPDATE pcashdetails
 					SET authorized = CURRENT_DATE,

--- a/PeriodsInquiry.php
+++ b/PeriodsInquiry.php
@@ -13,7 +13,7 @@ $SQL = "SELECT periodno ,
 		ORDER BY periodno";
 
 $ErrMsg =  _('No periods were returned by the SQL because');
-$PeriodsResult = DB_query($SQL,$ErrMsg);
+$PeriodsResult = DB_query($SQL, $ErrMsg);
 
 echo '<p class="page_title_text"><img src="'.$RootPath.'/css/'.$Theme.'/images/transactions.png" title="' . $Title . '" alt="" />' . ' '
 		. $Title . '</p>';

--- a/PickingLists.php
+++ b/PickingLists.php
@@ -95,8 +95,7 @@ if (!isset($_GET['Prid']) and !isset($_SESSION['ProcessingPick'])) {
 	}
 
 	$ErrMsg = _('The pick list cannot be retrieved because');
-	$DbgMsg = _('The SQL to get the order header was');
-	$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg, $DbgMsg);
+	$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg);
 
 	if (DB_num_rows($GetOrdHdrResult) == 1) {
 
@@ -188,8 +187,7 @@ if (!isset($_GET['Prid']) and !isset($_SESSION['ProcessingPick'])) {
 							ORDER BY salesorderdetails.orderlineno";
 
 		$ErrMsg = _('The line items of the pick list cannot be retrieved because');
-		$DbgMsg = _('The SQL that failed was');
-		$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg, $DbgMsg);
+		$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 
 		if (DB_num_rows($LineItemsResult) > 0) {
 
@@ -232,8 +230,7 @@ if (!isset($_GET['Prid']) and !isset($_SESSION['ProcessingPick'])) {
 										AND pickserialdetails.detailno='" . $MyRow['detailno'] . "'";
 
 				$ErrMsg = _('The serial items of the pick list cannot be retrieved because');
-				$DbgMsg = _('The SQL that failed was');
-				$SerialItemsResult = DB_query($SerialItemsSQL, $ErrMsg, $DbgMsg);
+				$SerialItemsResult = DB_query($SerialItemsSQL, $ErrMsg);
 				if (DB_num_rows($SerialItemsResult) > 0) {
 					$InOutModifier = 1;
 					while ($MySerial = DB_fetch_array($SerialItemsResult)) {
@@ -563,8 +560,7 @@ if (isset($_POST['ProcessPickList']) and $_POST['ProcessPickList'] != '') {
 					ON pickreqdetails.detailno=pickserialdetails.detailno
 				WHERE prid='" . $_SESSION['ProcessingPick'] . "'";
 	$ErrMsg = _('CRITICAL ERROR') . ' ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The pickserialdetails could not be deleted');
-	$DbgMsg = _('The following SQL to delete them was used');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	/*Update order header for invoice charged on */
 	$ExtraUpdSQL = '';
@@ -593,8 +589,7 @@ if (isset($_POST['ProcessPickList']) and $_POST['ProcessPickList'] != '') {
 			AND salesorders.orderno=pickreq.orderno";
 
 	$ErrMsg = _('CRITICAL ERROR') . ' ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales order header could not be updated with the internal comments');
-	$DbgMsg = _('The following SQL to update the order was used');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	foreach ($_SESSION['Items' . $identifier]->LineItems as $OrderLine) {
 		$LineItemsSQL = "SELECT pickreqdetails.detailno
@@ -606,8 +601,7 @@ if (isset($_POST['ProcessPickList']) and $_POST['ProcessPickList'] != '') {
 						AND salesorderdetails.orderlineno='" . $OrderLine->LineNumber . "'";
 
 		$ErrMsg = _('The line items of the pick list cannot be retrieved because');
-		$DbgMsg = _('The SQL that failed was');
-		$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg, $DbgMsg);
+		$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 		$MyLine = DB_fetch_array($LineItemsResult);
 		$DetailNo = $MyLine['detailno'];
 		$SQL = "UPDATE pickreqdetails
@@ -616,8 +610,7 @@ if (isset($_POST['ProcessPickList']) and $_POST['ProcessPickList'] != '') {
 				WHERE detailno='" . $DetailNo . "'";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The pickreqdetail record could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the pickreqdetail records was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		if ($OrderLine->Controlled == 1) {
 			foreach($OrderLine->SerialItems as $Item) {
@@ -632,8 +625,7 @@ if (isset($_POST['ProcessPickList']) and $_POST['ProcessPickList'] != '') {
 										'" . $Item->BundleQty . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}/* foreach controlled item in the serialitems array */
 		} /*end if the orderline is a controlled item */
 

--- a/PriceMatrix.php
+++ b/PriceMatrix.php
@@ -92,7 +92,7 @@ if (isset($_POST['submit'])) {
 				AND quantitybreak='" . filter_number_format($_POST['OldQuantityBreak']) . "'";
 
 		$ErrMsg = _('Could not be update the existing prices');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		ReSequenceEffectiveDates ($StockID, $_POST['SalesType'],$_POST['CurrAbrev'],$_POST['QuantityBreak']);
 
@@ -117,7 +117,7 @@ if (isset($_POST['submit'])) {
 						'" . $SQLStartDate . "',
 						'" . $SQLEndDate . "')";
 		$ErrMsg = _('Failed to insert price data');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg( _('The price matrix record has been added'),'success');
 		echo '<br />';
 		unset($_POST['StockID']);
@@ -141,7 +141,7 @@ if (isset($_POST['submit'])) {
 		AND startdate='" . $_GET['StartDate'] . "'
 		AND enddate='" . $_GET['EndDate'] . "'";
 	$ErrMsg = _('Failed to delete price data');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	prnMsg( _('The price matrix record has been deleted'),'success');
 }
 

--- a/PricesBasedOnMarkUp.php
+++ b/PricesBasedOnMarkUp.php
@@ -116,8 +116,7 @@ echo '<field>
 $SQL = "SELECT categoryid, categorydescription FROM stockcategory ORDER BY categoryid";
 
 $ErrMsg = _('The stock categories could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve stock categories and failed was');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 while ($MyRow=DB_fetch_array($Result)){
 	if (isset($_POST['StkCatFrom']) and $MyRow['categoryid']==$_POST['StkCatFrom']){
@@ -285,7 +284,7 @@ if (isset($_POST['UpdatePrices'])){
 								ON suppliers.currcode=currencies.currabrev
 							WHERE purchdata.preferred=1 AND purchdata.stockid='" . $MyRow['stockid'] ."'";
 				$ErrMsg = _('Could not get the supplier purchasing information for a preferred supplier for the item') . ' ' . $MyRow['stockid'];
-				$PrefSuppResult = DB_query($SQL,$ErrMsg);
+				$PrefSuppResult = DB_query($SQL, $ErrMsg);
 				if (DB_num_rows($PrefSuppResult)==0){
 					prnMsg(_('There is no preferred supplier data for the item') . ' ' . $MyRow['stockid'] . ' ' . _('prices will not be updated for this item'),'warn');
 					$Cost = 0;
@@ -307,7 +306,7 @@ if (isset($_POST['UpdatePrices'])){
 								AND stockid='" . $MyRow['stockid'] . "'
 							ORDER BY startdate DESC";
 				$ErrMsg = _('Could not get the base price for the item') . ' ' . $MyRow['stockid'] . _('from the price list') . ' ' . $_POST['BasePriceList'];
-				$BasePriceResult = DB_query($SQL,$ErrMsg);
+				$BasePriceResult = DB_query($SQL, $ErrMsg);
 				if (DB_num_rows($BasePriceResult)==0){
 					prnMsg(_('There is no default price defined in the base price list for the item') . ' ' . $MyRow['stockid'] . ' ' . _('prices will not be updated for this item'),'warn');
 					$Cost = 0;
@@ -356,7 +355,7 @@ if (isset($_POST['UpdatePrices'])){
 												AND enddate ='" . $CurrentPriceRow['enddate'] . "'
 												AND stockid='" . $MyRow['stockid'] . "'";
 					$ErrMsg =_('Error updating prices for') . ' ' . $MyRow['stockid'] . ' ' . _('because');
-					$Result = DB_query($UpdateSQL,$ErrMsg);
+					$Result = DB_query($UpdateSQL, $ErrMsg);
 
 				}
 				$SQL = "INSERT INTO prices (stockid,
@@ -372,7 +371,7 @@ if (isset($_POST['UpdatePrices'])){
 										'" . $SQLEndDate . "',
 								 		'" . filter_number_format($RoundedPrice) . "')";
 				$ErrMsg =_('Error inserting new price for') . ' ' . $MyRow['stockid'] . ' ' . _('because');
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 				prnMsg(_('Inserting new price for') . ' ' . $MyRow['stockid'] . ' ' . _('to') . ' ' . $RoundedPrice,'info');
 
 			}// end if cost > 0

--- a/Prices_Customer.php
+++ b/Prices_Customer.php
@@ -187,8 +187,7 @@ $SQL = "SELECT prices.price,
 						startdate";
 
 $ErrMsg = _('Could not retrieve the normal prices set up because');
-$DbgMsg = _('The SQL used to retrieve these records was');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 echo '<table class="selection">';
 
@@ -231,8 +230,7 @@ $SQL = "SELECT prices.price,
 				prices.startdate";
 
 $ErrMsg = _('Could not retrieve the special prices set up because');
-$DbgMsg = _('The SQL used to retrieve these records was');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 echo '<table class="selection">';
 

--- a/PrintCustOrder.php
+++ b/PrintCustOrder.php
@@ -74,7 +74,7 @@ if ($_SESSION['SalesmanLogin'] != '') {
 	$SQL .= " AND salesorders.salesperson='" . $_SESSION['SalesmanLogin'] . "'";
 }
 
-$Result=DB_query($SQL, $ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 //If there are no rows, there's a problem.
 if (DB_num_rows($Result)==0){
@@ -155,7 +155,7 @@ $SQL = "SELECT salesorderdetails.stkcode,
 		FROM salesorderdetails INNER JOIN stockmaster
 			ON salesorderdetails.stkcode=stockmaster.stockid
 		 WHERE salesorderdetails.orderno='" . $_GET['TransNo'] . "'";
-$Result=DB_query($SQL, $ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($Result)>0){
 /*Yes there are line items to start the ball rolling with a page header */

--- a/PrintCustOrder_generic.php
+++ b/PrintCustOrder_generic.php
@@ -77,7 +77,7 @@ if ($_SESSION['SalesmanLogin'] != '') {
 	$SQL .= " AND salesorders.salesperson='" . $_SESSION['SalesmanLogin'] . "'";
 }
 
-$Result=DB_query($SQL, $ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 //If there are no rows, there's a problem.
 if (DB_num_rows($Result)==0){
@@ -199,7 +199,7 @@ for ($i=1;$i<=2;$i++){  /*Print it out twice one copy for customer and one for o
 					AND custitem.stockid=salesorderdetails.stkcode
 				WHERE locstock.loccode = '" . $MyRow['fromstkloc'] . "'
 					AND salesorderdetails.orderno='" . $_GET['TransNo'] . "'";
-	$Result=DB_query($SQL, $ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result)>0){
 		/*Yes there are line items to start the ball rolling with a page header */
@@ -274,7 +274,7 @@ for ($i=1;$i<=2;$i++){  /*Print it out twice one copy for customer and one for o
 							AND bom.effectiveafter <= CURRENT_DATE
 							AND bom.effectiveto > CURRENT_DATE";
 				$ErrMsg = _('Could not retrieve the components of the ordered assembly item');
-				$AssemblyResult = DB_query($SQL,$ErrMsg);
+				$AssemblyResult = DB_query($SQL, $ErrMsg);
 				$LeftOvers = $pdf->addTextWrap($XPos,$YPos,150,$FontSize, _('Assembly Components:-'));
 				$YPos -= ($LineHeight);
 				/*Loop around all the components of the assembly and list the quantity supplied */

--- a/PrintCustStatements.php
+++ b/PrintCustStatements.php
@@ -46,10 +46,9 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['FromCust']) AND $_POST['FromCust
 
 /* Do a quick tidy up to settle any transactions that should have been settled at the time of allocation but for whatever reason weren't */
 	$ErrMsg = _('There was a problem settling the old transactions.');
-	$DbgMsg = _('The SQL used to settle outstanding transactions was');
 	$SQL = "UPDATE debtortrans SET settled=1
 			WHERE ABS(debtortrans.balance)<0.009";
-	$SettleAsNec = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SettleAsNec = DB_query($SQL, $ErrMsg);
 
 /*Figure out who all the customers in this range are */
 	$ErrMsg= _('There was a problem retrieving the customer information for the statements from the database');
@@ -109,7 +108,7 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['FromCust']) AND $_POST['FromCust
 				bankaccounts.bankaccountcode
 			FROM bankaccounts
 			WHERE bankaccounts.invoice = '1'";
-	$Result=DB_query($SQL,'','',false,false);
+	$Result = DB_query($SQL,'','',false,false);
 	if (DB_error_no()!=1) {
 		if (DB_num_rows($Result)==1){
 			$MyRow = DB_fetch_array($Result);

--- a/PrintCustTrans.php
+++ b/PrintCustTrans.php
@@ -69,7 +69,7 @@ if (isset($PrintPDF)
 					bankaccounts.bankaccountcode
 				FROM bankaccounts
 				WHERE bankaccounts.invoice = '1'";
-		$Result=DB_query($SQL,'','',false,false);
+		$Result = DB_query($SQL,'','',false,false);
 		if(DB_error_no()!=1) {
 			if(DB_num_rows($Result)==1) {
 				$MyRow = DB_fetch_array($Result);
@@ -219,7 +219,7 @@ if (isset($PrintPDF)
 			}
 		} // end else
 
-		$Result=DB_query($SQL,'','',false, false);
+		$Result = DB_query($SQL,'','',false, false);
 
 		if (DB_error_no()!=0) {
 			$Title = _('Transaction Print Error Report');
@@ -296,7 +296,7 @@ if (isset($PrintPDF)
 							AND stockmoves.show_on_inv_crds=1";
 			} // end else
 
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 			if(DB_error_no()!=0) {
 
 				$Title = _('Transaction Print Error Report');
@@ -742,7 +742,7 @@ if (isset($PrintPDF)
 							AND debtortrans.transno='" . $FromTransNo . "'";
 			}
 
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 			if(DB_num_rows($Result)==0 OR DB_error_no()!=0) {
 				echo '<p>' . _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $FromTransNo . ' ' . _('from the database') . '. ' . _('To print an invoice, the sales order record, the customer transaction record and the branch record for the customer must not have been purged') . '. ' . _('To print a credit note only requires the customer, transaction, salesman and branch records be available');
 				if ($Debug==1) {
@@ -952,7 +952,7 @@ if (isset($PrintPDF)
 				echo '<hr />';
 				echo '<div class="centre"><h4>' . _('All amounts stated in') . ' ' . $MyRow['currcode'] . '</h4></div>';
 
-				$Result=DB_query($SQL);
+				$Result = DB_query($SQL);
 				if (DB_error_no()!=0) {
 					echo '<br />' . _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo . ' ' . _('from the database');
 					if ($Debug==1){

--- a/PrintCustTransPortrait.php
+++ b/PrintCustTransPortrait.php
@@ -70,7 +70,7 @@ if(isset($PrintPDF)
 					bankaccounts.bankaccountcode
 				FROM bankaccounts
 				WHERE bankaccounts.invoice = '1'";
-		$Result=DB_query($SQL,'','',false,false);
+		$Result = DB_query($SQL,'','',false,false);
 		if(DB_error_no()!=1) {
 			if(DB_num_rows($Result)==1) {
 				$MyRow = DB_fetch_array($Result);
@@ -220,7 +220,7 @@ if(isset($PrintPDF)
 			}
 		}
 
-		$Result=DB_query($SQL,'','',false,false);
+		$Result = DB_query($SQL,'','',false,false);
 
 		if(DB_error_no()!=0) {
 
@@ -298,7 +298,7 @@ if(isset($PrintPDF)
 					AND stockmoves.show_on_inv_crds=1";
 			} // end else
 
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		if(DB_error_no()!=0) {
 			$Title = _('Transaction Print Error Report');
 			include('includes/header.php');
@@ -749,7 +749,7 @@ if(isset($PrintPDF)
 
 			}
 
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 			if(DB_num_rows($Result)==0 OR DB_error_no()!=0) {
 				echo '<p>' . _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $InvoiceToPrint . ' ' . _('from the database') . '. ' . _('To print an invoice, the sales order record, the customer transaction record and the branch record for the customer must not have been purged') . '. ' . _('To print a credit note only requires the customer, transaction, salesman and branch records be available');
 				if($Debug==1) {
@@ -960,7 +960,7 @@ if(isset($PrintPDF)
 				echo '<hr />';
 				echo '<div class="centre"><h4>' . _('All amounts stated in') . ' ' . $MyRow['currcode'] . '</h4></div>';
 
-				$Result=DB_query($SQL);
+				$Result = DB_query($SQL);
 				if(DB_error_no()!=0) {
 					echo '<br />' . _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo . ' ' . _('from the database');
 					if($Debug==1) {

--- a/ProductSpecs.php
+++ b/ProductSpecs.php
@@ -75,8 +75,7 @@ if (isset($_GET['CopySpec']) OR isset($_POST['CopySpec'])) {
 					FROM prodspecs WHERE keyval='" .$KeyValue. "'";
 			$Msg = _('A Product Specification has been copied to') . ' ' . $_POST['CopyTo']  . ' from ' . ' ' . $KeyValue ;
 			$ErrMsg = _('The insert of the Product Specification failed because');
-			$DbgMsg = _('The SQL that was used and failed was');
-			$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg($Msg , 'success');
 		$KeyValue=$_POST['CopyTo'];
 		unset($_GET['CopySpec']);
@@ -266,8 +265,7 @@ if (isset($_POST['AddTests'])) {
 						FROM qatests WHERE testid='" .$_POST['AddTestID' .$i]. "'";
 			$Msg = _('A Product Specification record has been added for Test ID') . ' ' . $_POST['AddTestID' .$i]  . ' for ' . ' ' . $KeyValue ;
 			$ErrMsg = _('The insert of the Product Specification failed because');
-			$DbgMsg = _('The SQL that was used and failed was');
-			$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg($Msg , 'success');
 		} //if on
 	} //for
@@ -301,8 +299,7 @@ if (isset($_POST['submit'])) {
 
 		$Msg = _('Product Specification record for') . ' ' . $_POST['QATestName']  . ' for ' . ' ' . $KeyValue .  _('has been updated');
 		$ErrMsg = _('The update of the Product Specification failed because');
-		$DbgMsg = _('The SQL that was used and failed was');
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg($Msg , 'success');
 
@@ -331,7 +328,7 @@ if (isset($_POST['submit'])) {
 		$SQL="DELETE FROM prodspecs WHERE keyval='". $KeyValue."'
 									AND testid='". $SelectedQATest."'";
 		$ErrMsg = _('The Product Specification could not be deleted because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('Product Specification') . ' ' . $SelectedQATest . ' for ' . ' ' . $KeyValue . _('has been deleted from the database'),'success');
 		unset ($SelectedQATest);

--- a/PurchData.php
+++ b/PurchData.php
@@ -116,8 +116,7 @@ if ((isset($_POST['AddRecord']) OR isset($_POST['UpdateRecord'])) AND isset($Sup
 							'" . filter_number_format($_POST['MinOrderQty']) . "',
 							'" . $_POST['Preferred'] . "')";
 		$ErrMsg = _('The supplier purchasing details could not be added to the database because');
-		$DbgMsg = _('The SQL that failed was');
-		$AddResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$AddResult = DB_query($SQL, $ErrMsg);
 		prnMsg(_('This supplier purchasing data has been added to the database'), 'success');
 	}
 	if ($InputError == 0 AND isset($_POST['UpdateRecord'])) {
@@ -134,8 +133,7 @@ if ((isset($_POST['AddRecord']) OR isset($_POST['UpdateRecord'])) AND isset($Sup
 							AND purchdata.supplierno='" . $SupplierID . "'
 							AND purchdata.effectivefrom='" . $_POST['WasEffectiveFrom'] . "'";
 		$ErrMsg = _('The supplier purchasing details could not be updated because');
-		$DbgMsg = _('The SQL that failed was');
-		$UpdResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$UpdResult = DB_query($SQL, $ErrMsg);
 		prnMsg(_('Supplier purchasing data has been updated'), 'success');
 
 		/*Now need to validate supplier purchasing discount records  and update/insert as necessary */
@@ -162,7 +160,7 @@ if ((isset($_POST['AddRecord']) OR isset($_POST['UpdateRecord'])) AND isset($Sup
 													effectivefrom = '" . FormatDateForSQL($_POST['DiscountEffectiveFrom' . $i]) . "',
 													effectiveto = '" . FormatDateForSQL($_POST['DiscountEffectiveTo' . $i]) . "'
 						WHERE id = " . intval($_POST['DiscountID' . $i]);
-				$UpdResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+				$UpdResult = DB_query($SQL, $ErrMsg);
 			}
 		} /*end loop through all supplier discounts */
 
@@ -194,8 +192,7 @@ if ((isset($_POST['AddRecord']) OR isset($_POST['UpdateRecord'])) AND isset($Sup
 								'" . FormatDateForSQL($_POST['DiscountEffectiveFrom']) . "',
 								'" . FormatDateForSQL($_POST['DiscountEffectiveTo']) . "')";
 			$ErrMsg = _('Could not insert a new supplier discount entry because');
-			$DbgMsg = _('The SQL used to insert the supplier discount entry that failed was');
-			$InsertResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$InsertResult = DB_query($SQL, $ErrMsg);
 			prnMsg(_('A new supplier purchasing discount record was entered successfully'),'success');
 		}
 
@@ -340,8 +337,7 @@ if (isset($SupplierID) AND $SupplierID != '' AND !isset($_POST['SearchSupplier']
 				ON suppliers.currcode=currencies.currabrev
 			WHERE supplierid='".$SupplierID."'";
     $ErrMsg = _('The supplier details for the selected supplier could not be retrieved because');
-    $DbgMsg = _('The SQL that failed was');
-    $SuppSelResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+    $SuppSelResult = DB_query($SQL, $ErrMsg);
     if (DB_num_rows($SuppSelResult) == 1) {
         $MyRow = DB_fetch_array($SuppSelResult);
         $SuppName = $MyRow['suppname'];
@@ -419,8 +415,7 @@ if (isset($_POST['SearchSupplier'])) {
 
     } //one of keywords or SupplierCode was more than a zero length string
     $ErrMsg = _('The suppliers matching the criteria entered could not be retrieved because');
-    $DbgMsg = _('The SQL to retrieve supplier details that failed was');
-    $SuppliersResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+    $SuppliersResult = DB_query($SQL, $ErrMsg);
 } //end of if search
 
 if (isset($SuppliersResult)) {
@@ -669,8 +664,7 @@ if (!isset($SuppliersResult)) {
 					AND stockid = '" . $StockID . "'";
 
 		$ErrMsg = _('The supplier discounts could not be retrieved because');
-		$DbgMsg = _('The SQL to retrieve supplier discounts for this item that failed was');
-		$DiscountsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$DiscountsResult = DB_query($SQL, $ErrMsg);
 
 		echo '<table cellpadding="2" colspan="7" class="selection">
 			<thead>

--- a/PurchaseByPrefSupplier.php
+++ b/PurchaseByPrefSupplier.php
@@ -27,8 +27,7 @@ if (isset($_POST['CreatePO']) AND isset($_POST['Supplier'])){
 						WHERE  stockmaster.stockid = '". $StockID . "'";
 
 				$ErrMsg = _('The item details for') . ' ' . $StockID . ' ' . _('could not be retrieved because');
-				$DbgMsg = _('The SQL used to retrieve the item details but failed was');
-				$ItemResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$ItemResult = DB_query($SQL, $ErrMsg);
 				if (DB_num_rows($ItemResult)==1){
 					$ItemRow = DB_fetch_array($ItemResult);
 
@@ -52,8 +51,7 @@ if (isset($_POST['CreatePO']) AND isset($_POST['Supplier'])){
 							ORDER BY latesteffectivefrom DESC";
 
 					$ErrMsg = _('The purchasing data for') . ' ' . $StockID . ' ' . _('could not be retrieved because');
-					$DbgMsg = _('The SQL used to retrieve the purchasing data but failed was');
-					$PurchDataResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+					$PurchDataResult = DB_query($SQL, $ErrMsg);
 					if (DB_num_rows($PurchDataResult)>0){ //the purchasing data is set up
 						$PurchRow = DB_fetch_array($PurchDataResult);
 
@@ -70,8 +68,7 @@ if (isset($_POST['CreatePO']) AND isset($_POST['Supplier'])){
 						$ItemDiscountPercent = 0;
 						$ItemDiscountAmount = 0;
 						$ErrMsg = _('Could not retrieve the supplier discounts applicable to the item');
-						$DbgMsg = _('The SQL used to retrive the supplier discounts that failed was');
-						$DiscountResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+						$DiscountResult = DB_query($SQL, $ErrMsg);
 						while ($DiscountRow = DB_fetch_array($DiscountResult)) {
 							$ItemDiscountPercent += $DiscountRow['discountpercent'];
 							$ItemDiscountAmount += $DiscountRow['discountamount'];
@@ -161,7 +158,7 @@ if (isset($_POST['CreatePO']) AND isset($_POST['Supplier'])){
 						WHERE userid='" . $_SESSION['UserID'] . "'
 						AND currabrev='" . $SupplierRow['currcode'] ."'";
 
-			$AuthResult=DB_query($AuthSQL);
+			$AuthResult = DB_query($AuthSQL);
 			$AuthRow=DB_fetch_array($AuthResult);
 
 			if (DB_num_rows($AuthResult) > 0 AND $AuthRow['authlevel'] > $OrderValue) { //user has authority to authrorise as well as create the order
@@ -252,10 +249,9 @@ if (isset($_POST['CreatePO']) AND isset($_POST['Supplier'])){
 								'" . $AllowPrintPO . "' )";
 
 		$ErrMsg =  _('The purchase order header record could not be inserted into the database because');
-		$DbgMsg = _('The SQL statement used to insert the purchase order header record and failed was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
-	     /*Insert the purchase order detail records */
+	    /*Insert the purchase order detail records */
 		foreach ($PurchItems as $StockID=>$POLine) {
 
 			//print_r($POLine);
@@ -287,9 +283,8 @@ if (isset($_POST['CreatePO']) AND isset($_POST['Supplier'])){
 							'0',
 							'" . $POLine['ConversionFactor'] . "')";
 			$ErrMsg =_('One of the purchase order detail records could not be inserted into the database because');
-			$DbgMsg =_('The SQL statement used to insert the purchase order detail record and failed was');
 
-			$Result =DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		} /* end of the loop round the detail line items on the order */
 		echo '<p />';
 		prnMsg(_('Purchase Order') . ' ' . $OrderNo . ' ' .  _('has been created.') . ' ' . _('Total order value of') . ': ' . locale_number_format($OrderValue,$SupplierRow['decimalplaces']) . ' ' . $SupplierRow['currcode']  ,'success');
@@ -312,7 +307,7 @@ echo '<p class="page_title_text"><img src="'.$RootPath.'/css/'.$Theme.'/images/i
 		<select name="Supplier">';
 
 $SQL = "SELECT supplierid, suppname FROM suppliers WHERE supptype<>7 ORDER BY suppname";
-$SuppResult=DB_query($SQL);
+$SuppResult = DB_query($SQL);
 
 echo '<option value="">' . _('Not Yet Selected') . '</option>';
 
@@ -445,7 +440,7 @@ if (isset($_POST['Supplier']) AND isset($_POST['ShowItems']) AND $_POST['Supplie
 					FROM stockmoves
 					WHERE stockid='" . $ItemRow['stockid'] . "'
 					AND (type=10 OR type=11)";
-			$SalesResult=DB_query($SQL,'','',FALSE,FALSE);
+			$SalesResult = DB_query($SQL,'','',FALSE,FALSE);
 
 			if (DB_error_no() !=0) {
 		 		$Title = _('Preferred supplier purchasing') . ' - ' . _('Problem Report') . '....';

--- a/QATests.php
+++ b/QATests.php
@@ -106,8 +106,7 @@ if (isset($_POST['submit'])) {
 	if ($InputError !=1) {
 		//run the SQL from either of the above possibilites
 		$ErrMsg = _('The insert or update of the QA Test failed because');
-		$DbgMsg = _('The SQL that was used and failed was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg($Msg , 'success');
 

--- a/RecurringSalesOrders.php
+++ b/RecurringSalesOrders.php
@@ -75,7 +75,7 @@ if (isset($_GET['NewRecurringOrder'])){
 								WHERE recurringsalesorders.recurrorderno = '" . $_GET['ModifyRecurringSalesOrder'] . "'";
 
 		$ErrMsg =  _('The order cannot be retrieved because');
-		$GetOrdHdrResult = DB_query($OrderHeaderSQL,$ErrMsg);
+		$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg);
 
 		if (DB_num_rows($GetOrdHdrResult)==1) {
 
@@ -134,7 +134,7 @@ if (isset($_GET['NewRecurringOrder'])){
 									AND recurrsalesorderdetails.recurrorderno ='" . $_GET['ModifyRecurringSalesOrder'] . "'";
 
 			$ErrMsg = _('The line items of the order cannot be retrieved because');
-			$LineItemsResult = DB_query($LineItemsSQL,$ErrMsg);
+			$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 			if (DB_num_rows($LineItemsResult)>0) {
 
 				while ($MyRow=DB_fetch_array($LineItemsResult)) {
@@ -174,11 +174,11 @@ if ((!isset($_SESSION['Items'.$identifier]) OR $_SESSION['Items'.$identifier]->I
 if (isset($_POST['DeleteRecurringOrder'])){
 	$SQL = "DELETE FROM recurrsalesorderdetails WHERE recurrorderno='" . $_POST['ExistingRecurrOrderNo'] . "'";
 	$ErrMsg = _('Could not delete recurring sales order lines for the recurring order template') . ' ' . $_POST['ExistingRecurrOrderNo'];
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$SQL = "DELETE FROM recurringsalesorders WHERE recurrorderno='" . $_POST['ExistingRecurrOrderNo'] . "'";
 	$ErrMsg = _('Could not delete the recurring sales order template number') . ' ' . $_POST['ExistingRecurrOrderNo'];
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	prnMsg(_('Successfully deleted recurring sales order template number') . ' ' . $_POST['ExistingRecurrOrderNo'],'success');
 
@@ -265,8 +265,7 @@ if (isset($_POST['Process'])) {
 										'" . $_POST['AutoInvoice'] . "')";
 
 			$ErrMsg = _('The recurring order cannot be added because');
-			$DbgMsg = _('The SQL that failed was');
-			$InsertQryResult = DB_query($HeaderSQL,$ErrMsg,$DbgMsg,true);
+			$InsertQryResult = DB_query($HeaderSQL, $ErrMsg, '', true);
 
 			$RecurrOrderNo = DB_Last_Insert_ID('recurringsalesorders','recurrorderno');
 			$StartOf_LineItemsSQL = "INSERT INTO recurrsalesorderdetails (recurrorderno,
@@ -286,7 +285,7 @@ if (isset($_POST['Process'])) {
 								'" . filter_number_format($StockItem->Quantity) . "',
 								'" . filter_number_format($StockItem->DiscountPercent) . "',
 								'" . $StockItem->Narrative . "')";
-				$Ins_LineItemResult = DB_query($LineItemsSQL,$ErrMsg,$DbgMsg,true);
+				$Ins_LineItemResult = DB_query($LineItemsSQL, $ErrMsg, '', true);
 
 			} /* inserted line items into sales order details */
 
@@ -301,7 +300,7 @@ if (isset($_POST['Process'])) {
 					WHERE recurrorderno = '" . $_POST['ExistingRecurrOrderNo'] . "'";
 
 			$ErrMsg = _('The recurring order cannot be updated because');
-			$UpdateQryResult = DB_query($HeaderSQL,$ErrMsg);
+			$UpdateQryResult = DB_query($HeaderSQL, $ErrMsg);
 			prnmsg(_('The recurring order template has been updated'),'success');
 		}
 

--- a/RecurringSalesOrdersProcess.php
+++ b/RecurringSalesOrdersProcess.php
@@ -142,7 +142,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 							'" . $DelDate . "')";
 
 	$ErrMsg = _('The order cannot be added because');
-	$InsertQryResult = DB_query($HeaderSQL,$ErrMsg,true);
+	$InsertQryResult = DB_query($HeaderSQL, $ErrMsg,true);
 
 	$EmailText = _('A new order has been created from a recurring order template for customer') .' ' .  $RecurrOrderRow['debtorno'] . ' ' . $RecurrOrderRow['branchcode'] . "\n" . _('The order number is:') . ' ' . $OrderNo;
 
@@ -158,7 +158,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 						WHERE recurrsalesorderdetails.recurrorderno ='" . $RecurrOrderRow['recurrorderno'] . "'";
 
 	$ErrMsg = _('The line items of the recurring order cannot be retrieved because');
-	$LineItemsResult = DB_query($LineItemsSQL,$ErrMsg);
+	$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 
 	$LineCounter = 0;
 
@@ -193,7 +193,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 	$SQL = "UPDATE recurringsalesorders SET lastrecurrence = '" . $DelDate . "'
 			WHERE recurrorderno='" . $RecurrOrderRow['recurrorderno'] ."'";
 	$ErrMsg = _('Could not update the last recurrence of the recurring order template. The database reported the error:');
-	$Result = DB_query($SQL,$ErrMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, true);
 
 	DB_Txn_Commit();
 
@@ -224,13 +224,13 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 				ON debtorsmaster.currcode=currencies.currabrev
 				WHERE debtorno='" . $RecurrOrderRow['debtorno'] . "'";
 		$ErrMsg = _('The exchange rate for the customer currency could not be retrieved from the currency table because:');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$MyRow = DB_fetch_row($Result);
 		$CurrencyRate = $MyRow[0];
 
 		$SQL = "SELECT taxprovinceid FROM locations WHERE loccode='" . $RecurrOrderRow['fromstkloc'] ."'";
 		$ErrMsg = _('Could not retrieve the tax province of the location from where the order was fulfilled because:');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$MyRow=DB_fetch_row($Result);
 		$DispTaxProvinceID = $MyRow[0];
 
@@ -271,7 +271,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 			ORDER BY taxgrouptaxes.calculationorder";
 
 			$ErrMsg = _('The taxes and rates for this item could not be retrieved because');
-			$GetTaxRatesResult = DB_query($SQL,$ErrMsg);
+			$GetTaxRatesResult = DB_query($SQL, $ErrMsg);
 
 			$LineTaxAmount = 0;
 			$TaxTotals =array();
@@ -319,8 +319,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 				AND stkcode = '" . $RecurrOrderLineRow['stkcode'] . "'";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales order detail record could not be updated because');
-			$DbgMsg = _('The following SQL to update the sales order detail record was used');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			// Insert stock movements - with unit cost
 			$LocalCurrencyPrice= ($RecurrOrderLineRow['unitprice'] *(1- floatval($RecurrOrderLineRow['discountpercent'])))/ $CurrencyRate;
@@ -361,8 +360,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 						'" . $RecurrOrderLineRow['narrative'] . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the stock movement records was used');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/*Get the ID of the StockMove... */
 			$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -382,8 +380,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 							'" . $Tax['TaxOnTax'] . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Taxes and rates applicable to this invoice line item could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement tax detail records was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 			/*Insert Sales Analysis records */
 
@@ -421,8 +418,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 					salesanalysis.salesperson";
 
 			$ErrMsg = _('The count of existing Sales analysis records could not run because');
-			$DbgMsg = _('SQL to count the no of sales analysis records');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$MyRow = DB_fetch_row($Result);
 
@@ -480,8 +476,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 			}
 
 			$ErrMsg = _('Sales analysis record could not be added or updated because');
-			$DbgMsg = _('The following SQL to insert the sales analysis record was used');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			if ($_SESSION['CompanyRecord']['gllink_debtors']==1 AND $RecurrOrderLineRow['unitprice'] !=0){
 
@@ -508,8 +503,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 					)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales GL posting could not be inserted because');
-				$DbgMsg = '<br />' ._('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/* Don't care about COGS because it can only be a dummy items being invoiced ... no cost of sales to mess with */
 
@@ -535,8 +529,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 						)";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales discount GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				} /*end of if discount !=0 */
 
@@ -575,8 +568,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 											)";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The tax GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the tax GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 			}
 
@@ -602,8 +594,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 									)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The total debtor GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the total debtors control GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 
 			/*Could do with setting up a more flexible freight posting schema that looks at the sales type and area of the customer branch to determine where to post the freight recovery */
@@ -628,8 +619,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 									)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The freight GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 		} /*end of if Sales and GL integrated */
 
@@ -637,8 +627,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 		$SQL = "UPDATE salesorders SET comments = CONCAT(comments,' Inv ','" . $InvoiceNo . "') WHERE orderno= '" . $OrderNo . "'";
 
 		$ErrMsg = _('CRITICAL ERROR') . ' ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sales order header could not be updated with the invoice number');
-		$DbgMsg = _('The following SQL to update the sales order was used');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	/*Now insert the DebtorTrans */
 
@@ -678,11 +667,9 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 										'" . $RecurrOrderRow['shipvia'] . "')";
 
 		$ErrMsg =_('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction record could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the debtor transaction record was used');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$DebtorTransID = DB_Last_Insert_ID('debtortrans','id');
-
 
 		$SQL = "INSERT INTO debtortranstaxes (debtortransid,
 							taxauthid,
@@ -692,8 +679,7 @@ while ($RecurrOrderRow = DB_fetch_array($RecurrOrdersDueResult)){
 					'" . filter_number_format($Tax['FXAmount']/$CurrencyRate) . "')";
 
 		$ErrMsg =_('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction taxes records could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the debtor transaction taxes record was used');
- 		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		DB_Txn_Commit();
 

--- a/RegularPaymentsProcess.php
+++ b/RegularPaymentsProcess.php
@@ -151,13 +151,12 @@ if (isset($_POST['Add'])) {
 								)";
 
 		$ErrMsg = _('Cannot insert a bank transaction because');
-		$DbgMsg = _('Cannot insert a bank transaction using the SQL');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$SQL = "UPDATE regularpayments SET nextpayment='" . FormatDateForSQL($NextPaymentDate) . "',
 											completed='" . $Completed . "'
 										WHERE id='" . $ID . "'";
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		DB_Txn_Commit();
 
 		prnMsg(_('The regular payment has been processed'), 'success');

--- a/RegularPaymentsSetup.php
+++ b/RegularPaymentsSetup.php
@@ -17,8 +17,7 @@ echo '<p class="page_title_text" >
 if (isset($_GET['Complete'])) {
 	$SQL = "UPDATE regularpayments SET completed=1 WHERE id='" . $_GET['Payment'] . "'";
 	$ErrMsg = _('Cannot set regular payment as completed because');
-	$DbgMsg = _('Cannot set regular payment as completed using the SQL');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_error_no() == 0) {
 		prnMsg(_('The regular payment has been marked as complete and no further payments will be made'), 'success');
 	} else {
@@ -116,7 +115,6 @@ if (isset($_POST['Add']) or isset($_POST['Update'])) {
 												finalpayment='" . FormatDateForSQL($_POST['LastPaymentDate']) . "'
 											WHERE id='" . $_POST['ID'] . "'";
 			$ErrMsg = _('Cannot update regular payment because');
-			$DbgMsg = _('Cannot update regular payment using the SQL');
 		} else {
 			$SQL = "INSERT INTO regularpayments (frequency,
 												days,
@@ -143,9 +141,8 @@ if (isset($_POST['Add']) or isset($_POST['Update'])) {
 												'" . FormatDateForSQL($_POST['FirstPaymentDate']) . "'
 											)";
 			$ErrMsg = _('Cannot insert a new regular payment because');
-			$DbgMsg = _('Cannot insert a new regular payment using the SQL');
 		}
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		unset($_POST['ID']);
 		unset($_POST['Frequency']);
 		unset($_POST['Days']);
@@ -235,8 +232,7 @@ $SQL = "SELECT bankaccountname,
 			WHERE bankaccountusers.userid = '" . $_SESSION['UserID'] . "'
 			ORDER BY bankaccountname";
 $ErrMsg = _('The bank accounts could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve the bank accounts was');
-$AccountsResults = DB_query($SQL, $ErrMsg, $DbgMsg);
+$AccountsResults = DB_query($SQL, $ErrMsg);
 
 echo '<field>
 		<label for="BankAccount">', _('Bank Account'), ':</label>

--- a/RelatedItemsUpdate.php
+++ b/RelatedItemsUpdate.php
@@ -91,7 +91,7 @@ if (isset($_POST['submit'])) {
 							VALUES ('" . $Item . "',
 								'" . $_POST['Related'] . "')";
 		$ErrMsg = _('The new related item could not be added');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg($_POST['Related'] . ' ' . _('is now related to') . ' ' . $Item,'success');
 
@@ -109,7 +109,7 @@ if (isset($_POST['submit'])) {
 								VALUES ('" . $_POST['Related'] . "',
 									'" . $Item . "')";
 			$ErrMsg = _('The new related item could not be added');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg($Item . ' ' . _('is now related to') . ' ' . $_POST['Related'],'success');
 		}
 	}
@@ -125,7 +125,7 @@ if (isset($_POST['submit'])) {
 			WHERE (stockid = '". $Item ."' AND related ='". $_GET['Related'] ."')
 			OR (stockid = '". $_GET['Related'] ."' AND related ='". $Item ."')";
 	$ErrMsg = _('Could not delete this relationshop');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	prnMsg( _('This relationship has been deleted'),'success');
 
 }

--- a/ReprintGRN.php
+++ b/ReprintGRN.php
@@ -36,7 +36,7 @@ if (isset($_POST['Show'])) {
 	$SQL="SELECT count(orderno)
 				FROM purchorders
 				WHERE orderno='" . $_POST['PONumber'] ."'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_row($Result);
 	if ($MyRow[0]==0) {
 		echo '<br />';
@@ -64,7 +64,7 @@ if (isset($_POST['Show'])) {
 			LEFT JOIN stockmaster
 			ON grns.itemcode=stockmaster.stockid
 			WHERE purchorderdetails.orderno='" . $_POST['PONumber'] ."'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	if (DB_num_rows($Result)==0) {
 		echo '<br />';
 		prnMsg( _('There are no GRNs for this purchase order that can be reprinted.'), 'warn');

--- a/ReverseGRN.php
+++ b/ReverseGRN.php
@@ -54,9 +54,8 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 			WHERE grnno='" . $_GET['GRNNo'] . "'";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not get the details of the GRN selected for reversal because') . ' ';
-	$DbgMsg = _('The following SQL to retrieve the GRN details was used') . ':';
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$GRN = DB_fetch_array($Result);
 	$QtyToReverse = $GRN['qtyrecd'] - $GRN['quantityinv'];
@@ -126,8 +125,7 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 			WHERE purchorderdetails.podetailitem = '" . $GRN['podetailitem'] . "'";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The purchase order detail record could not be updated with the quantity reversed because');
-	$DbgMsg = _('The following SQL to update the purchase order detail record was used');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	/*Now the purchorder header status in case it was completed  - now incomplete - just printed */
 	$SQL = "UPDATE purchorders
@@ -136,8 +134,7 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 			WHERE orderno = '" . $GRN['orderno'] . "'";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The purchase order statusand status comment could not be changed because');
-	$DbgMsg = _('The following SQL to update the purchase order header record was used');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	/*Need to update or delete the existing GRN item */
 	if ($QtyToReverse == $GRN['qtyrecd']) { //then ok to delete the whole thing
@@ -148,15 +145,13 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GRN record could not be deleted because');
-		$DbgMsg = _('The following SQL to delete the GRN record was used');
-		$Result = DB_query("DELETE FROM grns WHERE grnno='" . $_GET['GRNNo'] . "'", $ErrMsg, $DbgMsg, true);
+		$Result = DB_query("DELETE FROM grns WHERE grnno='" . $_GET['GRNNo'] . "'", $ErrMsg, '', true);
 	} else {
 		$SQL = "UPDATE grns	SET qtyrecd = qtyrecd - " . $QtyToReverse . "
 				WHERE grns.grnno='" . $_GET['GRNNo'] . "'";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GRN record could not be updated') . '. ' . _('This reversal of goods received has not been processed because');
-		$DbgMsg = _('The following SQL to insert the GRN record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	}
 	/*If the GRN being reversed is an asset - reverse the fixedassettrans record */
 	if ($GRN['assetid'] != '0') {
@@ -177,15 +172,13 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 								'" . _('cost') . "',
 								'" . (-$GRN['stdcostunit'] * $QtyToReverse) . "')";
 		$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE The fixed asset transaction could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the fixed asset transaction record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*now reverse the cost put to fixedassets */
 		$SQL = "UPDATE fixedassets SET cost = cost - " . $GRN['stdcostunit'] * $QtyToReverse . "
 				WHERE assetid = '" . $GRN['assetid'] . "'";
 		$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE. The fixed asset cost addition could not be reversed:');
-		$DbgMsg = _('The following SQL was used to attempt the reduce the cost of the asset was:');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	} //end of if it is an asset
 	$SQL = "SELECT stockmaster.controlled
@@ -220,8 +213,7 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 				AND loccode = '" . $GRN['intostocklocation'] . "'";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-		$DbgMsg = _('The following SQL to update the location stock record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/* If its a stock item .... Insert stock movements - with unit cost */
 		$NewQtyOnHand = $QtyOnHandPrior - $QtyToReverse;
@@ -251,8 +243,7 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 										)";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the stock movement records was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$StkMoveNo = DB_Last_Insert_ID('stockmoves', 'stkmoveno');
 
@@ -307,8 +298,7 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 									'" . -($GRN['stdcostunit'] * $QtyToReverse) . "')";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The purchase GL posting could not be inserted for the reversal of the received item because');
-		$DbgMsg = _('The following SQL to insert the purchase GLTrans record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*now the GRN suspense entry*/
 		$SQL = "INSERT INTO gltrans (type,
@@ -329,8 +319,7 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 								)";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GRN suspense side of the GL posting could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the GRN Suspense GLTrans record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	} /* end of if GL and stock integrated*/
 
 	DB_Txn_Commit();
@@ -381,8 +370,7 @@ if (isset($_GET['GRNNo']) and isset($_POST['SupplierID'])) {
 				AND grns.deliverydate>='" . FormatDateForSQL($_POST['RecdAfterDate']) . "'";
 
 		$ErrMsg = _('An error occurred in the attempt to get the outstanding GRNs for') . ' ' . $_POST['SuppName'] . '. ' . _('The message was') . ':';
-		$DbgMsg = _('The SQL that failed was') . ':';
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($Result) == 0) {
 			prnMsg(_('There are no outstanding goods received yet to be invoiced for') . ' ' . $_POST['SuppName'] . '.<br />' . _('To reverse a GRN that has been invoiced first it must be credited'), 'warn');

--- a/SMTPServer.php
+++ b/SMTPServer.php
@@ -46,8 +46,7 @@ if (isset($_POST['submit']) AND $_POST['MailServerSetting']==1) {//If there are 
 				auth='".$_POST['Auth']."'";
 
 	$ErrMsg = _('The email setting information failed to update');
-	$DbgMsg = _('The SQL failed to update is ');
-	$Result1=DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result1 = DB_query($SQL, $ErrMsg);
 	unset($_POST['MailServerSetting']);
 	prnMsg(_('The settings for the SMTP server have been successfully updated'), 'success');
 	echo '<br />';
@@ -66,7 +65,6 @@ if (isset($_POST['submit']) AND $_POST['MailServerSetting']==1) {//If there are 
 						'".$_POST['Password']."',
 						'".$_POST['Auth']."')";
 	$ErrMsg = _('The email settings failed to be inserted');
-	$DbgMsg = _('The SQL failed to insert the email information is');
 	$Result2 = DB_query($SQL);
 	unset($_POST['MailServerSetting']);
 	prnMsg(_('The settings for the SMTP server have been successfully inserted'),'success');
@@ -85,10 +83,9 @@ if (isset($_POST['submit']) AND $_POST['MailServerSetting']==1) {//If there are 
 				auth
 			FROM emailsettings";
 		$ErrMsg = _('The email settings information cannot be retrieved');
-		$DbgMsg = _('The SQL that failed was');
 
-		$Result=DB_query($SQL,$ErrMsg,$DbgMsg);
-		if(DB_num_rows($Result)!=0){
+		$Result = DB_query($SQL, $ErrMsg);
+		if (DB_num_rows($Result)!=0){
 			$MailServerSetting = 1;
 			$MyRow=DB_fetch_array($Result);
 		}else{

--- a/SalesAnalReptCols.php
+++ b/SalesAnalReptCols.php
@@ -120,9 +120,8 @@ if (isset($_POST['submit'])) {
                                      reportid = '".$ReportID."' AND
                                      colno='". $SelectedCol ."'";
 		$ErrMsg = _('The report column could not be updated because');
-		$DbgMsg = _('The SQL used to update the report column was');
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('Column') . ' ' . $SelectedCol . ' ' . _('has been updated'),'info');
 		unset($SelectedCol);
@@ -178,8 +177,7 @@ if (isset($_POST['submit'])) {
                                        '" . $_POST['ValFormat'] . "')";
 
 		$ErrMsg = _('The column could not be added to the report because');
-		$DbgMsg = _('The SQL used to add the column to the report was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('Column') . ' ' . $_POST['ColID'] . ' ' . _('has been added to the database'),'info');
 
@@ -207,8 +205,7 @@ if (isset($_POST['submit'])) {
 	$SQL="DELETE FROM reportcolumns WHERE reportid='".$ReportID."' AND colno='".$SelectedCol."'";
 
 	$ErrMsg = _('The deletion of the column failed because');
-	$DbgMsg = _('The SQL used to delete this report column was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	prnMsg(_('Column') . ' ' . $SelectedCol . ' ' . _('has been deleted'),'info');
 
@@ -238,8 +235,7 @@ $SQL = "SELECT reportheaders.reportheading,
         ORDER BY reportcolumns.colno";
 
 $ErrMsg = _('The column definitions could not be retrieved from the database because');
-$DbgMsg = _('The SQL used to retrieve the columns for the report was');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($Result)!=0){
 
@@ -338,9 +334,8 @@ if (!isset($_GET['delete'])) {
 
 
 		$ErrMsg =  _('The column') . ' ' . $SelectedCol . ' ' . _('could not be retrieved because');
-		$DbgMsg =  _('The SQL used to retrieve the this column was');
 
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$MyRow = DB_fetch_array($Result);
 
@@ -410,7 +405,7 @@ if (!isset($_GET['delete'])) {
 				<select name="PeriodFrom">';
 		$SQL = "SELECT periodno, lastdate_in_period FROM periods ORDER BY periodno DESC";
 		$ErrMsg = _('Could not load periods table');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		while ($PeriodRow = DB_fetch_row($Result)){
 			if ($_POST['PeriodFrom']==$PeriodRow[0]){
 				echo  '<option selected="selected" value="' . $PeriodRow[0] . '">' . ConvertSQLDate($PeriodRow[1]) . '</option>';
@@ -426,7 +421,7 @@ if (!isset($_GET['delete'])) {
 				<select name="PeriodTo">';
 		$SQL = "SELECT periodno, lastdate_in_period FROM periods ORDER BY periodno DESC";
 		$ErrMsg = _('Could not load periods table');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		while ($PeriodRow = DB_fetch_row($Result)){
 			if ($_POST['PeriodTo']==$PeriodRow[0]){
 				echo  '<option selected="selected" value="' . $PeriodRow[0] . '">' . ConvertSQLDate($PeriodRow[1]) . '</option>';

--- a/SalesAnalRepts.php
+++ b/SalesAnalRepts.php
@@ -156,8 +156,7 @@ if (isset($_POST['submit'])) {
 				WHERE reportid = " . $SelectedReport;
 
 		$ErrMsg = _('The report could not be updated because');
-		$DbgMsg = _('The SQL used to update the report headers was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg( _('The') .' ' . $_POST['ReportHeading'] . ' ' . _('report has been updated'),'success', 'Report Updated');
 		unset($SelectedReport);
@@ -219,8 +218,7 @@ if (isset($_POST['submit'])) {
 					)";
 
 		$ErrMsg = _('The report could not be added because');
-		$DbgMsg = _('The SQL used to add the report header was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('The') . ' ' . $_POST['ReportHeading'] . ' ' . _('report has been added to the database'),'success','Report Added');
 
@@ -250,14 +248,12 @@ if (isset($_POST['submit'])) {
 
 	$SQL="DELETE FROM reportcolumns WHERE reportid='".$SelectedReport."'";
 	$ErrMsg = _('The deletion of the report column failed because');
-	$DbgMsg = _('The SQL used to delete the report column was');
 
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$SQL="DELETE FROM reportheaders WHERE reportid='".$SelectedReport."'";
 	$ErrMsg = _('The deletion of the report heading failed because');
-	$DbgMsg = _('The SQL used to delete the report headers was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	prnMsg(_('Report Deleted') ,'info');
 	unset($SelectedReport);
@@ -337,8 +333,7 @@ if (!isset($_GET['delete'])) {
 				WHERE reportid='".$SelectedReport."'";
 
 		$ErrMsg = _('The reports for display could not be retrieved because');
-		$DbgMsg = _('The SQL used to retrieve the report headers was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$MyRow = DB_fetch_array($Result);
 

--- a/SalesByTypePeriodInquiry.php
+++ b/SalesByTypePeriodInquiry.php
@@ -345,7 +345,7 @@ if (isset($_POST['ShowSales'])){
 		}
 
 	$ErrMsg = _('The sales data could not be retrieved because') . ' - ' . DB_error_msg();
-	$SalesResult = DB_query($SQL,$ErrMsg);
+	$SalesResult = DB_query($SQL, $ErrMsg);
 
 
 	echo '<table cellpadding="2" class="selection">';

--- a/SalesCategories.php
+++ b/SalesCategories.php
@@ -132,8 +132,7 @@ if (isset($_POST['Search']) or isset($_POST['Prev']) or isset($_POST['Next'])) {
 	$SQL = $SQL . ' LIMIT ' . $_SESSION['DisplayRecordsMax'] . ' OFFSET ' . strval($_SESSION['DisplayRecordsMax'] * $Offset);
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL used to get the part selection was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('There are no products available meeting the criteria specified'), 'info');

--- a/SalesCategoryPeriodInquiry.php
+++ b/SalesCategoryPeriodInquiry.php
@@ -156,7 +156,7 @@ if (isset($_POST['ShowSales'])){
 			ORDER BY netsalesvalue DESC";
 
 	$ErrMsg = _('The sales data could not be retrieved because') . ' - ' . DB_error_msg();
-	$SalesResult = DB_query($SQL,$ErrMsg);
+	$SalesResult = DB_query($SQL, $ErrMsg);
 
 	echo '<table cellpadding="2" class="selection">';
 

--- a/SalesInquiry.php
+++ b/SalesInquiry.php
@@ -772,7 +772,7 @@ function submit($PartNumber,$PartNumberOp,$DebtorNo,$DebtorNoOp,$DebtorName,$Deb
 		} // End of if($_POST['ReportType']
 		//echo "<br/>$SQL<br/>";
 		$ErrMsg = _('The SQL to find the parts selected failed with the message');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$ctr = 0;
 		echo '<pre>';
 		$TotalQty = 0;
@@ -1172,7 +1172,7 @@ function display()  //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_#####
 			<label for="Category">' . _('Stock Categories') . ':</label>
 			<select name="Category">';
 
-	$CategoryResult= DB_query("SELECT categoryid, categorydescription FROM stockcategory");
+	$CategoryResult = DB_query("SELECT categoryid, categorydescription FROM stockcategory");
 	echo '<option selected="selected" value="All">' . _('All Categories')  . '</option>';
 	while($MyRow = DB_fetch_array($CategoryResult)) {
 		echo '<option value="' . $MyRow['categoryid'] . '">' . $MyRow['categorydescription']  . '</option>';
@@ -1189,7 +1189,7 @@ function display()  //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_#####
 	}else{
 		echo '<select name="Salesman">';
 		$SQL="SELECT salesmancode, salesmanname FROM salesman";
-		$SalesmanResult= DB_query($SQL);
+		$SalesmanResult = DB_query($SQL);
 		echo '<option selected="selected" value="All">' . _('All Salespeople')  . '</option>';
 		while($MyRow = DB_fetch_array($SalesmanResult)) {
 			echo '<option value="' . $MyRow['salesmancode'] . '">' . $MyRow['salesmanname']  . '</option>';
@@ -1202,7 +1202,7 @@ function display()  //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_#####
 	echo '<field>
 			<label for="Area">' . _('For Sales Areas') . ':</label>
 			<select name="Area">';
-	$AreasResult= DB_query("SELECT areacode, areadescription FROM areas");
+	$AreasResult = DB_query("SELECT areacode, areadescription FROM areas");
 	echo '<option selected="selected" value="All">' . _('All Areas')  . '</option>';
 	while($MyRow = DB_fetch_array($AreasResult)) {
 		echo '<option value="' . $MyRow['areacode'] . '">' . $MyRow['areadescription']  . '</option>';
@@ -1260,7 +1260,7 @@ function TempStockmoves() {
 
 	$SQL = "CREATE TEMPORARY TABLE tempstockmoves LIKE stockmoves";
 	$ErrMsg = _('The SQL to the create temp stock moves table failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$SQL = "INSERT tempstockmoves
 	          SELECT * FROM stockmoves
@@ -1268,7 +1268,7 @@ function TempStockmoves() {
 	          AND stockmoves.trandate >='" . $FromDate .
 			  "' AND stockmoves.trandate <='" . $ToDate . "'";
 	$ErrMsg = _('The SQL to insert temporary stockmoves records failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$SQL = "UPDATE tempstockmoves, stockmoves
 	          SET tempstockmoves.reference = stockmoves.reference
@@ -1277,7 +1277,7 @@ function TempStockmoves() {
                 AND tempstockmoves.stockid = stockmoves.stockid
                 AND stockmoves.type ='10'";
 	$ErrMsg = _('The SQL to update tempstockmoves failed with the message');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 
 } // End of function TempStockmoves

--- a/SalesPeople.php
+++ b/SalesPeople.php
@@ -126,8 +126,7 @@ if (isset($_POST['submit'])) {
 	if ($InputError !=1) {
 		//run the SQL from either of the above possibilites
 		$ErrMsg = _('The insert or update of the salesperson failed because');
-		$DbgMsg = _('The SQL that was used and failed was');
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg($Msg , 'success');
 
@@ -170,7 +169,7 @@ $BookMark = 'SalespeopleDelete';
 
 				$SQL="DELETE FROM salesman WHERE salesmancode='". $SelectedSalesPerson."'";
 				$ErrMsg = _('The salesperson could not be deleted because');
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 
 				prnMsg(_('Salesperson') . ' ' . $SelectedSalesPerson . ' ' . _('has been deleted from the database'),'success');
 				unset ($SelectedSalesPerson);
@@ -363,8 +362,7 @@ if (! isset($_GET['delete'])) {
 			<select name="CommissionTypeID">';
 	$SQL = "SELECT commissiontypeid, commissiontypename FROM salescommissiontypes ORDER BY commissiontypename";
 	$ErrMsg = _('An error occurred in retrieving the sales commission types from the database');
-	$DbgMsg = _('The SQL that was used to retrieve the commission type information and that failed in the process was');
-	$CommissionTypeResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$CommissionTypeResult = DB_query($SQL, $ErrMsg);
 	if (!isset($_POST['CommissionTypeID']) or $_POST['CommissionTypeID'] == 0) {
 		echo '<option selected="selected" value="0">', _('No Commission'), '</option>';
 	} else {

--- a/SalesTopCustomersInquiry.php
+++ b/SalesTopCustomersInquiry.php
@@ -197,7 +197,7 @@ if (isset($_POST['ShowSales'])){
 	}
 
 	$ErrMsg = _('The sales data could not be retrieved because') . ' - ' . DB_error_msg();
-	$SalesResult = DB_query($SQL,$ErrMsg);
+	$SalesResult = DB_query($SQL, $ErrMsg);
 
 
 	echo '<table cellpadding="2" class="selection">

--- a/SalesTopItemsInquiry.php
+++ b/SalesTopItemsInquiry.php
@@ -210,7 +210,7 @@ if (isset($_POST['ShowSales'])){
 	}
 
 	$ErrMsg = _('The sales data could not be retrieved because') . ' - ' . DB_error_msg();
-	$SalesResult = DB_query($SQL,$ErrMsg);
+	$SalesResult = DB_query($SQL, $ErrMsg);
 
 
 	echo '<table cellpadding="2" class="selection">';

--- a/SalesTypes.php
+++ b/SalesTypes.php
@@ -134,7 +134,7 @@ if (isset($_POST['submit'])) {
 	       WHERE debtortrans.tpe='".$SelectedType."'";
 
 	$ErrMsg = _('The number of transactions using this customer/sales/pricelist type could not be retrieved');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_row($Result);
 	if ($MyRow[0]>0) {
@@ -145,7 +145,7 @@ if (isset($_POST['submit'])) {
 		$SQL = "SELECT COUNT(*) FROM debtorsmaster WHERE salestype='".$SelectedType."'";
 
 		$ErrMsg = _('The number of transactions using this Sales Type record could not be retrieved because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$MyRow = DB_fetch_row($Result);
 		if ($MyRow[0]>0) {
 			prnMsg (_('Cannot delete this sale type because customers are currently set up to use this sales type') . '<br />' . _('There are') . ' ' . $MyRow[0] . ' ' . _('customers with this sales type code'));
@@ -153,12 +153,12 @@ if (isset($_POST['submit'])) {
 
 			$SQL="DELETE FROM salestypes WHERE typeabbrev='" . $SelectedType . "'";
 			$ErrMsg = _('The Sales Type record could not be deleted because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg(_('Sales type') . ' / ' . _('price list') . ' ' . $SelectedType  . ' ' . _('has been deleted') ,'success');
 
 			$SQL ="DELETE FROM prices WHERE prices.typeabbrev='" . $SelectedType . "'";
 			$ErrMsg =  _('The Sales Type prices could not be deleted because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			prnMsg(' ...  ' . _('and any prices for this sales type / price list were also deleted'),'success');
 			unset ($SelectedType);

--- a/SelectAsset.php
+++ b/SelectAsset.php
@@ -231,8 +231,7 @@ if (isset($_POST['Search']) OR isset($_POST['Go']) OR isset($_POST['Next']) OR i
 	$SQL .= " ORDER BY fixedassets.assetid";
 
 	$ErrMsg = _('No assets were returned by the SQL because');
-	$DbgMsg = _('The SQL that returned an error was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('No assets were returned by this search please re-enter alternative criteria to try again'), 'info');

--- a/SelectCompletedOrder.php
+++ b/SelectCompletedOrder.php
@@ -227,8 +227,7 @@ if (isset($_POST['SearchParts']) AND $_POST['SearchParts']!=''){
 	} else {
 
 		$ErrMsg = _('No stock items were returned by the SQL because');
-		$DbgMsg = _('The SQL used to retrieve the searched parts was');
-		$StockItemsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$StockItemsResult = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($StockItemsResult)==1){
 		  	$MyRow = DB_fetch_row($StockItemsResult);

--- a/SelectContract.php
+++ b/SelectContract.php
@@ -140,7 +140,7 @@ if (isset($_POST['ContractRef']) AND $_POST['ContractRef'] !='') {
 } //end not contract ref selected
 
 $ErrMsg = _('No contracts were returned by the SQL because');
-$ContractsResult = DB_query($SQL,$ErrMsg);
+$ContractsResult = DB_query($SQL, $ErrMsg);
 
 /*show a table of the contracts returned by the SQL */
 

--- a/SelectCreditItems.php
+++ b/SelectCreditItems.php
@@ -41,7 +41,6 @@ if (isset($_GET['NewCredit'])){
 	}
 }
 
-
 if (!isset($_SESSION['CreditItems'.$identifier])){
 	 /* It must be a new credit note being created $_SESSION['CreditItems'.$identifier] would be set up from a previous call*/
 
@@ -65,7 +64,6 @@ if (isset($_POST['CancelCredit'])) {
 	$_SESSION['RequireCustomerSelection'] = 1;
 }
 
-
 if (isset($_POST['SearchCust']) AND $_SESSION['RequireCustomerSelection']==1){
 
 	if ($_POST['Keywords'] AND $_POST['CustCode']) {
@@ -75,10 +73,10 @@ if (isset($_POST['SearchCust']) AND $_SESSION['RequireCustomerSelection']==1){
 		  prnMsg( _('At least one Customer Name keyword OR an extract of a Customer Code must be entered for the search'), 'info' );
 	} else {
 		if (mb_strlen($_POST['Keywords'])>0) {
-		  //insert wildcard characters in spaces
+			//insert wildcard characters in spaces
 			$SearchString = '%' . str_replace(' ', '%', $_POST['Keywords']) . '%';
 
-			   $SQL = "SELECT	debtorsmaster.name,
+			$SQL = "SELECT	debtorsmaster.name,
 								custbranch.debtorno,
 								custbranch.brname,
 								custbranch.contactname,
@@ -91,9 +89,9 @@ if (isset($_POST['SearchCust']) AND $_SESSION['RequireCustomerSelection']==1){
 							WHERE custbranch.brname " . LIKE  . " '" . $SearchString . "'
 							AND custbranch.disabletrans='0'";
 
-		  } elseif (mb_strlen($_POST['CustCode'])>0){
+		} elseif (mb_strlen($_POST['CustCode'])>0){
 
-			   $SQL = "SELECT 	debtorsmaster.name,
+			$SQL = "SELECT 	debtorsmaster.name,
 								custbranch.debtorno,
 								custbranch.brname,
 								custbranch.contactname,
@@ -105,25 +103,22 @@ if (isset($_POST['SearchCust']) AND $_SESSION['RequireCustomerSelection']==1){
 							ON custbranch.debtorno=debtorsmaster.debtorno
 							WHERE custbranch.debtorno " . LIKE  . "'%" . $_POST['CustCode'] . "%'
 							AND custbranch.disabletrans='0'";
-		  }
+		}
 
-		  $ErrMsg = _('Customer branch records requested cannot be retrieved because');
-		  $DbgMsg = _('SQL used to retrieve the customer details was');
-		  $Result_CustSelect = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$ErrMsg = _('Customer branch records requested cannot be retrieved because');
+		$Result_CustSelect = DB_query($SQL, $ErrMsg);
 
+		if (DB_num_rows($Result_CustSelect)==1) {
+			$MyRow = DB_fetch_array($Result_CustSelect);
+			$SelectedCustomer = trim($MyRow['debtorno']);
+			$SelectedBranch = trim($MyRow['branchcode']);
+			$_POST['JustSelectedACustomer'] = true;
+		} elseif (DB_num_rows($Result_CustSelect)==0) {
+			prnMsg(_('Sorry') . ' ... ' . _('there are no customer branch records contain the selected text') . ' - ' . _('please alter your search criteria and try again'),'info');
+		}
 
-		  if (DB_num_rows($Result_CustSelect)==1){
-			    $MyRow=DB_fetch_array($Result_CustSelect);
-			    $SelectedCustomer = trim($MyRow['debtorno']);
-			    $SelectedBranch = trim($MyRow['branchcode']);
-			    $_POST['JustSelectedACustomer'] = true;
-		  } elseif (DB_num_rows($Result_CustSelect)==0){
-			    prnMsg(_('Sorry') . ' ... ' . _('there are no customer branch records contain the selected text') . ' - ' . _('please alter your search criteria and try again'),'info');
-		  }
-
-	 } /*one of keywords or custcode was more than a zero length string */
+	} /*one of keywords or custcode was more than a zero length string */
 } /*end of if search button for customers was hit*/
-
 
 if (isset($_POST['JustSelectedACustomer']) AND !isset($SelectedCustomer)){
 	/*Need to figure out the number of the form variable that the user clicked on */
@@ -180,8 +175,7 @@ will be booked back into. */
 				AND custbranch.debtorno = '" . $_SESSION['CreditItems'.$identifier]->DebtorNo . "'";
 
 	$ErrMsg = _('The customer branch record of the customer selected') . ': ' . $SelectedCustomer . ' ' . _('cannot be retrieved because');
-	$DbgMsg =  _('SQL used to retrieve the branch details was');
-	$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_array($Result);
 
@@ -379,7 +373,7 @@ if ($_SESSION['RequireCustomerSelection'] ==1
 		}
 
 		$ErrMsg = _('There is a problem selecting the part records to display because');
-		$SearchResult = DB_query($SQL,$ErrMsg);
+		$SearchResult = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($SearchResult)==0){
 			   prnMsg(_('There are no products available that match the criteria specified'),'info');
@@ -457,7 +451,7 @@ if ($_SESSION['RequireCustomerSelection'] ==1
 							WHERE  stockmaster.stockid = '". $_POST['NewItem'] . "'";
 
 				$ErrMsg =  _('There is a problem selecting the part because');
-				$Result1 = DB_query($SQL,$ErrMsg);
+				$Result1 = DB_query($SQL, $ErrMsg);
 
 		   		if ($MyRow = DB_fetch_array($Result1)){
 
@@ -625,8 +619,7 @@ if ($_SESSION['RequireCustomerSelection'] ==1
 							WHERE stockmaster.stockid = '". $_POST['NewItem'] . "'";
 
 				$ErrMsg = _('The item details could not be retrieved because');
-				$DbgMsg = _('The SQL used to retrieve the item details but failed was');
-				$Result1 = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$Result1 = DB_query($SQL, $ErrMsg);
 				$MyRow = DB_fetch_array($Result1);
 
 				$LineNumber = $_SESSION['CreditItems'.$identifier]->LineCounter;
@@ -1074,8 +1067,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 			WHERE custbranch.debtorno ='". $_SESSION['CreditItems'.$identifier]->DebtorNo . "'
 			AND custbranch.branchcode = '" . $_SESSION['CreditItems'.$identifier]->Branch . "'";
 	$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The area cannot be determined for this customer');
-	$DbgMsg = _('The following SQL to insert the customer credit note was used');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	 if ($MyRow = DB_fetch_row($Result)){
 	     $Area = $MyRow[0];
@@ -1136,8 +1128,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 									'" . $_SESSION['CreditItems' . $identifier]->SalesPerson . "' )";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The customer credit note transaction could not be added to the database because');
-	$DbgMsg = _('The following SQL to insert the customer credit note was used');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 	$CreditTransID = DB_Last_Insert_ID('debtortrans','id');
@@ -1153,8 +1144,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 						'" . -$TaxAmount/$_SESSION['CurrencyRate'] . "')";
 
 		$ErrMsg =_('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction taxes records could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the debtor transaction taxes record was used');
- 		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	}
 
 /* Insert stock movements for stock coming back in if the Credit is a return of goods */
@@ -1222,8 +1212,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 												'" . $CreditLine->Narrative . "')";
 
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement records for the purpose of display on the credit note was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			} else { //its a return or a write off need to record goods coming in first
 
@@ -1297,8 +1286,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 		    	}
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/*Get the stockmoveno from above - need to ref StockMoveTaxes and possibly SerialStockMoves */
 				$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -1318,8 +1306,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 								'" . $Tax->TaxOnTax . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Taxes and rates applicable to this credit note line item could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the stock movement tax detail records was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 
 
@@ -1335,8 +1322,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 								AND loccode='" . $_SESSION['CreditItems'.$identifier]->Location . "'
 								AND serialno='" . $Item->BundleRef . "'";
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The existence of the serial stock item record could not be determined because');
-						$DbgMsg = _('The following SQL to find out if the serial stock item record existed already was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 						$MyRow = DB_fetch_row($Result);
 
 						if ($MyRow[0]==0) {
@@ -1354,8 +1340,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 																)";
 
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The new serial stock item record could not be inserted because');
-							$DbgMsg = _('The following SQL to insert the new serial stock item record was used') ;
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						} else { /*Update the existing StockSerialItems record */
 							$SQL = "UPDATE stockserialitems SET quantity= quantity + " . $Item->BundleQty . "
 									WHERE stockid='" . $CreditLine->StockID . "'
@@ -1363,8 +1348,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 									AND serialno='" . $Item->BundleRef . "'";
 
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-							$DbgMsg = _('The following SQL to update the serial stock item record was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						}
 						/* now insert the serial stock movement */
 
@@ -1378,8 +1362,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 															'" . $Item->BundleRef . "',
 															'" . $Item->BundleQty . "')";
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the serial stock movement record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					}/* foreach serial item in the serialitems array */
 
@@ -1399,8 +1382,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 							AND locstock.loccode = '" . $_SESSION['CreditItems'.$identifier]->Location . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated because');
-					$DbgMsg = _('The following SQL to update the location stock record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				} else if ($CreditLine->MBflag=='A'){ /* its an assembly */
 					/*Need to get the BOM for this part and make stock moves
@@ -1420,8 +1402,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
                             AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 					$ErrMsg =  _('Could not retrieve assembly components from the database for') . ' ' . $CreditLine->StockID . ' ' . _('because');
-				 	$DbgMsg = _('The SQL that failed was');
-					$AssResult = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				 	$AssResult = DB_query($SQL, $ErrMsg, '', true);
 
 					while ($AssParts = DB_fetch_array($AssResult)){
 
@@ -1475,18 +1456,16 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 													)";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement records for the assembly components of') . ' ' . $CreditLine->StockID . ' ' . _('could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the assembly components stock movement records was used');
-				        $Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
-					  /*Update the stock quantities for the assembly components */
-					 $SQL = "UPDATE locstock
+					/*Update the stock quantities for the assembly components */
+					$SQL = "UPDATE locstock
 					   		SET locstock.quantity = locstock.quantity + " . $AssParts['quantity'] * $CreditLine->Quantity . "
 							WHERE locstock.stockid = '" . $AssParts['component'] . "'
 							AND locstock.loccode = '" . $_SESSION['CreditItems'.$identifier]->Location . "'";
 
 					$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Location stock record could not be updated for an assembly component because');
-  					$DbgMsg =  _('The following SQL to update the component location stock record was used');
-					$Result = DB_query($SQL,$ErrMsg, $DbgMsg,true);
+  					$Result = DB_query($SQL, $ErrMsg, '',true);
 				    } /* end of assembly explosion and updates */
 
 
@@ -1575,8 +1554,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 				}
 
      			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Stock movement record to write the stock off could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement to write off the stock was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				if (($CreditLine->MBflag=='M' OR $CreditLine->MBflag=='B') AND $CreditLine->Controlled==1){
 					/*Its a write off too still so need to process the serial items
@@ -1593,8 +1571,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 								AND serialno='" . $Item->BundleRef . "'";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated for the write off because');
-						$DbgMsg = _('The following SQL to update the serial stock item record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						/* now insert the serial stock movement */
 
@@ -1609,8 +1586,7 @@ if (isset($_POST['ProcessCredit']) AND $OKToProcess==true){
 															'" . -$Item->BundleQty . "'
 															)";
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record for the write off could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the serial stock movement write off record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					}/* foreach serial item in the serialitems array */
 
@@ -1651,8 +1627,7 @@ sales analysis needs to reflect the sales made before and after the changes*/
 							salesanalysis.salesperson";
 
 			$ErrMsg = _('The count to check for existing Sales analysis records could not run because');
-			$DbgMsg = _('SQL to count the no of sales analysis records');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$MyRow = DB_fetch_array($Result);
 
@@ -1761,8 +1736,7 @@ sales analysis needs to reflect the sales made before and after the changes*/
 			}
 
 			$ErrMsg = _('The sales analysis record for this credit note could not be added because');
-			$DbgMsg = _('The following SQL to insert the sales analysis record was used');
-			$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 /* If GLLink_Stock then insert GLTrans to either debit stock or an expense
@@ -1795,8 +1769,7 @@ at standard cost*/
 											'" . ($CreditLine->StandardCost * -$CreditLine->Quantity) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The cost of the stock credited GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 				if ($_POST['CreditType']=='WriteOff'){
@@ -1821,8 +1794,7 @@ then debit the expense account the stock is to written off to */
 										)";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The cost of the stock credited GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				    } else {
 
 /*the goods are coming back into stock so debit the stock account*/
@@ -1844,8 +1816,7 @@ then debit the expense account the stock is to written off to */
 											)";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock side (or write off) of the cost of sales GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				    }
 
 				} /* end of if GL and stock integrated and standard cost !=0 */
@@ -1874,8 +1845,7 @@ then debit the expense account the stock is to written off to */
 											)";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The credit note GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					if ($CreditLine->DiscountPercent !=0){
 
@@ -1897,8 +1867,7 @@ then debit the expense account the stock is to written off to */
 
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The credit note discount GL posting could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 					}/* end of if discount not equal to 0 */
 				} /*end of if sales integrated with debtors */
 		  } /*Quantity credited is more than 0 */
@@ -1925,8 +1894,7 @@ then debit the expense account the stock is to written off to */
 								'" . -(($_SESSION['CreditItems'.$identifier]->total + $_SESSION['CreditItems'.$identifier]->FreightCost + $TaxTotal)/$_SESSION['CurrencyRate']) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The total debtor GL posting for the credit note could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 		if ($_SESSION['CreditItems'.$identifier]->FreightCost !=0) {
 			$SQL = "INSERT INTO gltrans (type,
@@ -1945,8 +1913,7 @@ then debit the expense account the stock is to written off to */
 								'" . ($_SESSION['CreditItems'.$identifier]->FreightCost/$_SESSION['CurrencyRate']) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The freight GL posting for this credit note could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 		foreach ( $TaxTotals as $TaxAuthID => $TaxAmount){
 			if ($TaxAmount !=0 ){
@@ -1966,8 +1933,7 @@ then debit the expense account the stock is to written off to */
 											'" . ($TaxAmount/$_SESSION['CurrencyRate']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The tax GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			}
 		}
 

--- a/SelectOrderItems.php
+++ b/SelectOrderItems.php
@@ -163,7 +163,7 @@ if (isset($_GET['ModifyOrderNumber'])
 						WHERE salesorders.orderno = '" . $_GET['ModifyOrderNumber'] . "'";
 
 	$ErrMsg =  _('The order cannot be retrieved because');
-	$GetOrdHdrResult = DB_query($OrderHeaderSQL,$ErrMsg);
+	$GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg);
 
 	if (DB_num_rows($GetOrdHdrResult)==1) {
 
@@ -265,7 +265,7 @@ if (isset($_GET['ModifyOrderNumber'])
 								ORDER BY salesorderdetails.orderlineno";
 
 		$ErrMsg = _('The line items of the order cannot be retrieved because');
-		$LineItemsResult = DB_query($LineItemsSQL,$ErrMsg);
+		$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 		if (DB_num_rows($LineItemsResult)>0) {
 
 			while ($MyRow=DB_fetch_array($LineItemsResult)) {
@@ -378,7 +378,7 @@ if (isset($_POST['SearchCust'])
 					custbranch.branchcode";
 
 	$ErrMsg = _('The searched customer records requested cannot be retrieved because');
-	$Result_CustSelect = DB_query($SQL,$ErrMsg);
+	$Result_CustSelect = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result_CustSelect)==1){
 		$MyRow=DB_fetch_array($Result_CustSelect);
@@ -432,8 +432,7 @@ if (isset($SelectedCustomer)) {
 			WHERE debtorsmaster.debtorno = '" . $_SESSION['Items'.$identifier]->DebtorNo. "'";
 
 	$ErrMsg = _('The details of the customer selected') . ': ' .  $_SESSION['Items'.$identifier]->DebtorNo . ' ' . _('cannot be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the customer details and failed was') . ':';
-	$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_array($Result);
 	if ($MyRow[1] != 1){
@@ -535,8 +534,7 @@ if (isset($SelectedCustomer)) {
 			WHERE debtorsmaster.debtorno = '" . $_SESSION['Items'.$identifier]->DebtorNo . "'";
 
 	$ErrMsg = _('The details for the customer selected') . ': ' .$_SESSION['Items'.$identifier]->DebtorNo . ' ' . _('cannot be retrieved because');
-	$DbgMsg = _('SQL used to retrieve the customer details was') . ':<br />' . $SQL;
-	$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result) > 0) {
 		$MyRow = DB_fetch_array($Result);
@@ -685,11 +683,11 @@ if ($_SESSION['RequireCustomerSelection'] ==1
 
 				$SQL = "DELETE FROM salesorderdetails WHERE salesorderdetails.orderno ='" . $_SESSION['ExistingOrder' . $identifier] . "'";
 				$ErrMsg =_('The order detail lines could not be deleted because');
-				$DelResult=DB_query($SQL,$ErrMsg);
+				$DelResult = DB_query($SQL, $ErrMsg);
 
 				$SQL = "DELETE FROM salesorders WHERE salesorders.orderno='" . $_SESSION['ExistingOrder' . $identifier] . "'";
 				$ErrMsg = _('The order header could not be deleted because');
-				$DelResult=DB_query($SQL,$ErrMsg);
+				$DelResult = DB_query($SQL, $ErrMsg);
 
 				$_SESSION['ExistingOrder' . $identifier]=0;
 			}
@@ -812,9 +810,8 @@ if ($_SESSION['RequireCustomerSelection'] ==1
 		$SQL = $SQL . " LIMIT " . $_SESSION['DisplayRecordsMax'] . " OFFSET " . strval($_SESSION['DisplayRecordsMax'] * $Offset);
 
 		$ErrMsg = _('There is a problem selecting the part records to display because');
-		$DbgMsg = _('The SQL used to get the part selection was');
 
-		$SearchResult = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$SearchResult = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($SearchResult)==0 ){
 			prnMsg (_('There are no products available meeting the criteria specified'),'info');
@@ -902,9 +899,7 @@ if ($_SESSION['RequireCustomerSelection'] ==1
 					WHERE stockmaster.stockid='". $NewItem ."'";
 
 			$ErrMsg = _('Could not determine if the part being ordered was a kitset or not because');
-			$DbgMsg = _('The sql that was used to determine if the part being ordered was a kitset or not was ');
-			$KitResult = DB_query($SQL,$ErrMsg,$DbgMsg);
-
+			$KitResult = DB_query($SQL, $ErrMsg);
 
 			if (DB_num_rows($KitResult)==0){
 				prnMsg( _('The item code') . ' ' . $NewItem . ' ' . _('could not be retrieved from the database and has not been added to the order'),'warn');
@@ -918,7 +913,7 @@ if ($_SESSION['RequireCustomerSelection'] ==1
                             AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 					$ErrMsg =  _('Could not retrieve kitset components from the database because') . ' ';
-					$KitResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+					$KitResult = DB_query($SQL, $ErrMsg);
 
 					$ParentQty = $NewItemQty;
 					while ($KitParts = DB_fetch_array($KitResult)){
@@ -1211,7 +1206,7 @@ if ($_SESSION['RequireCustomerSelection'] ==1
 
 		$ErrMsg =  _('Could not determine if the part being ordered was a kitset or not because');
 
-		$KitResult = DB_query($SQL,$ErrMsg);
+		$KitResult = DB_query($SQL, $ErrMsg);
 
 		$NewItemQty = 1; /*By Default */
 		$Discount = 0; /*By default - can change later or discount category override */
@@ -1226,7 +1221,7 @@ if ($_SESSION['RequireCustomerSelection'] ==1
                         AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 				$ErrMsg = _('Could not retrieve kitset components from the database because');
-				$KitResult = DB_query($SQL,$ErrMsg);
+				$KitResult = DB_query($SQL, $ErrMsg);
 
 				$ParentQty = $NewItemQty;
 				while ($KitParts = DB_fetch_array($KitResult)){
@@ -1260,7 +1255,7 @@ if ($_SESSION['RequireCustomerSelection'] ==1
 
 				$ErrMsg =  _('Could not determine if the part being ordered was a kitset or not because');
 
-				$KitResult = DB_query($SQL,$ErrMsg);
+				$KitResult = DB_query($SQL, $ErrMsg);
 
 				//$NewItemQty = 1; /*By Default */
 				$Discount = 0; /*By default - can change later or discount category override */
@@ -1275,7 +1270,7 @@ if ($_SESSION['RequireCustomerSelection'] ==1
                                 AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 						$ErrMsg = _('Could not retrieve kitset components from the database because');
-						$KitResult = DB_query($SQL,$ErrMsg);
+						$KitResult = DB_query($SQL, $ErrMsg);
 
 						$ParentQty = $NewItemQty;
 						while ($KitParts = DB_fetch_array($KitResult)){
@@ -1853,7 +1848,6 @@ function GetCustBranchDetails($identifier) {
 					AND custbranch.debtorno = '" . $_SESSION['Items'.$identifier]->DebtorNo . "'";
 
 		$ErrMsg = _('The customer branch record of the customer selected') . ': ' . $_SESSION['Items'.$identifier]->DebtorNo . ' ' . _('cannot be retrieved because');
-		$DbgMsg = _('SQL used to retrieve the branch details was') . ':';
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		return $Result;
 }

--- a/SelectPickingLists.php
+++ b/SelectPickingLists.php
@@ -159,8 +159,7 @@ if (isset($_POST['SearchParts'])) {
 	}
 
 	$ErrMsg = _('No stock items were returned by the SQL because');
-	$DbgMsg = _('The SQL used to retrieve the searched parts was');
-	$StockItemsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$StockItemsResult = DB_query($SQL, $ErrMsg);
 }
 
 if (true or !isset($OrderNumber) or $OrderNumber == "") { //revisit later, right now always show all inputs

--- a/SelectProduct.php
+++ b/SelectProduct.php
@@ -542,8 +542,7 @@ if (isset($_POST['Search']) OR isset($_POST['Go']) OR isset($_POST['Next']) OR i
 	}
 	$SQL = GenerateStockmasterQuery($_POST);
 	$ErrMsg = _('No stock items were returned by the SQL because');
-	$DbgMsg = _('The SQL that returned an error was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('No stock items were returned by this search please re-enter alternative criteria to try again'), 'info');
 	}

--- a/SelectQASamples.php
+++ b/SelectQASamples.php
@@ -233,8 +233,7 @@ if (isset($_POST['submit'])) {
 
 		$Msg = _('QA Sample record for') . ' ' . $SelectedSampleID  . ' ' .  _('has been updated');
 		$ErrMsg = _('The update of the QA Sample failed because');
-		$DbgMsg = _('The SQL that was used and failed was');
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg($Msg , 'success');
 		if ( $_POST['Cert']==1) {
 			$Result = DB_query("SELECT prodspeckey, lotkey FROM qasamples
@@ -247,8 +246,7 @@ if (isset($_POST['submit'])) {
 						AND lotkey='" . $MyRow[1] . "'";
 				$Msg = _('All other samples for this Specification and Lot was marked as Cert=No');
 				$ErrMsg = _('The update of the QA Sample failed because');
-				$DbgMsg = _('The SQL that was used and failed was');
-				$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 				prnMsg($Msg , 'success');
 			}
 		}
@@ -281,10 +279,10 @@ if (isset($_POST['submit'])) {
 	} else {
 		$SQL="DELETE FROM sampleresults WHERE sampleid='" . $SelectedSampleID . "'";
 		$ErrMsg = _('The sample results could not be deleted because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		$SQL="DELETE FROM qasamples WHERE sampleid='" . $SelectedSampleID ."'";
 		$ErrMsg = _('The QA Sample could not be deleted because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		echo $SQL;
 		prnMsg(_('QA Sample') . ' ' . $SelectedSampleID . _('has been deleted from the database'),'success');
 		unset ($SelectedSampleID);
@@ -380,8 +378,7 @@ if (!isset($SelectedSampleID)) {
 		}
 
 		$ErrMsg = _('No stock items were returned by the SQL because');
-		$DbgMsg = _('The SQL used to retrieve the searched parts was');
-		$StockItemsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$StockItemsResult = DB_query($SQL, $ErrMsg);
 	}
 
 	if (true or !isset($LotNumber) or $LotNumber == '') { //revisit later, right now always show all inputs

--- a/SelectRecurringSalesOrder.php
+++ b/SelectRecurringSalesOrder.php
@@ -78,7 +78,7 @@ SUM(recurrsalesorderdetails.unitprice*recurrsalesorderdetails.quantity*(1-recurr
 				recurringsalesorders.frequency";
 
 	$ErrMsg = _('No recurring orders were returned by the SQL because');
-	$SalesOrdersResult = DB_query($SQL,$ErrMsg);
+	$SalesOrdersResult = DB_query($SQL, $ErrMsg);
 
 	/*show a table of the orders returned by the SQL */
 

--- a/SelectSalesOrder.php
+++ b/SelectSalesOrder.php
@@ -227,13 +227,12 @@ if (isset($_POST['PlacePO'])) { /*user hit button to place PO for selected order
 						if (DB_num_rows($AuthResult) > 0 AND $AuthRow['authlevel'] > $Order_Value) { //user has authority to authrorise as well as create the order
 							$StatusComment = date($_SESSION['DefaultDateFormat']) . ' - ' . _('Order Created and Authorised by') . ' ' . $UserDetails . ' - ' . _('Auto created from sales orders')  . '<br />';
 							$ErrMsg = _('Could not update purchase order status to Authorised');
-							$DbgMsg = _('The SQL that failed was');
 							$Result = DB_query("UPDATE purchorders SET allowprint = 1,
 												   status = 'Authorised',
 												   stat_comment = '" . $StatusComment . "'
 												WHERE orderno = '" . $PO_OrderNo . "'",
 												$ErrMsg,
-												$DbgMsg,
+												'',
 												true);
 						} else { // no authority to authorise this order
 							if (DB_num_rows($AuthResult) == 0) {
@@ -343,8 +342,7 @@ if (isset($_POST['PlacePO'])) { /*user hit button to place PO for selected order
 		  										0)";
 
 					$ErrMsg = _('The purchase order header record could not be inserted into the database because');
-					$DbgMsg = _('The SQL statement used to insert the purchase order header record and failed was');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} //end if it's a new supplier and PO to create
 
 				/*reminder we are in a loop of the total of each item to place a purchase order for based on a selection of sales orders */
@@ -370,9 +368,8 @@ if (isset($_POST['PlacePO'])) { /*user hit button to place PO for selected order
 			  							 '" . $ItemRow['suppliers_partno'] . "',
 			  							 '" . $ItemRow['conversionfactor']  . "')";
 				$ErrMsg =_('One of the purchase order detail records could not be inserted into the database because');
-				$DbgMsg =_('The SQL statement used to insert the purchase order detail record and failed was');
 
-				$Result =DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				$Order_Value  += ($ItemRow['price']*$ItemRow['orderqty'] / $ItemRow['conversionfactor']);
 			} /* end of the loop round the items on the sales order  that we wish to place purchase orders for */
 
@@ -395,13 +392,12 @@ if (isset($_POST['PlacePO'])) { /*user hit button to place PO for selected order
 				if (DB_num_rows($AuthResult) > 0 AND $AuthRow['authlevel'] > $Order_Value) { //user has authority to authrorise as well as create the order
 					$StatusComment = date($_SESSION['DefaultDateFormat']) . ' - ' . _('Order Created and Authorised by') . $UserDetails . ' - ' . _('Auto created from sales orders') . '<br />';
 					$ErrMsg = _('Could not update purchase order status to Authorised');
-					$DbgMsg = _('The SQL that failed was');
 					$Result = DB_query("UPDATE purchorders SET allowprint = 1,
 															status = 'Authorised',
 															stat_comment = '" . $StatusComment . "'
 												 WHERE orderno = '" . $PO_OrderNo . "'",
 												$ErrMsg,
-												$DbgMsg,
+												'',
 												true);
 				} else { // no authority to authorise this order
 					if (DB_num_rows($AuthResult) == 0) {
@@ -1119,8 +1115,7 @@ function GetSearchItems ($SqlConstraint = '') {
 						ORDER BY stockmaster.stockid";
 
 	$ErrMsg =  _('No stock items were returned by the SQL because');
-	$DbgMsg = _('The SQL used to retrieve the searched parts was');
-	$StockItemsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$StockItemsResult = DB_query($SQL, $ErrMsg);
 
 	return $StockItemsResult;
 }

--- a/SelectWorkOrder.php
+++ b/SelectWorkOrder.php
@@ -108,8 +108,7 @@ if (isset($_POST['SearchParts'])){
 	 }
 
 	$ErrMsg = _('No items were returned by the SQL because');
-	$DbgMsg = _('The SQL used to retrieve the searched parts was');
-	$StockItemsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$StockItemsResult = DB_query($SQL, $ErrMsg);
 }
 
 if (isset($_POST['StockID'])){

--- a/SellThroughSupport.php
+++ b/SellThroughSupport.php
@@ -81,8 +81,7 @@ if ((isset($_POST['AddRecord']) OR isset($_POST['UpdateRecord'])) AND isset($Sup
 							'" . FormatDateForSQL($_POST['EffectiveTo']) . "')";
 
 		$ErrMsg = _('The sell through support record could not be added to the database because');
-		$DbgMsg = _('The SQL that failed was');
-		$AddResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$AddResult = DB_query($SQL, $ErrMsg);
 		prnMsg(_('This sell through support has been added to the database'), 'success');
 	}
 	if ($InputError == 0 AND isset($_POST['UpdateRecord'])) {
@@ -97,8 +96,7 @@ if ((isset($_POST['AddRecord']) OR isset($_POST['UpdateRecord'])) AND isset($Sup
 							WHERE id='" . $_POST['SellSupportID'] . "'";
 
 		$ErrMsg = _('The sell through support record could not be updated because');
-		$DbgMsg = _('The SQL that failed was');
-		$UpdResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$UpdResult = DB_query($SQL, $ErrMsg);
 		prnMsg(_('Sell Through Support record has been updated'), 'success');
 		$Edit = false;
 
@@ -151,8 +149,7 @@ if (isset($_POST['SearchSupplier'])) {
 
 	} //one of keywords or SupplierCode was more than a zero length string
 	$ErrMsg = _('The suppliers matching the criteria entered could not be retrieved because');
-	$DbgMsg = _('The SQL to retrieve supplier details that failed was');
-	$SuppliersResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SuppliersResult = DB_query($SQL, $ErrMsg);
 
 	echo '<p class="page_title_text"><img src="' . $RootPath . '/css/' . $Theme . '/images/sales.png" title="' . $Title . '" alt="" />' . ' ' . $Title . '</p> ';
 
@@ -421,8 +418,7 @@ if (isset($SupplierID)) { //not selecting a supplier
 			WHERE supplierno ='" . $SupplierID . "'
 			AND preferred=1";
 	$ErrMsg = _('Could not retrieve the items that the supplier provides');
-	$DbgMsg = _('The SQL that was used to get the supplier items and failed was');
-	$ItemsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$ItemsResult = DB_query($SQL, $ErrMsg);
 
 	while ($ItemsRow = DB_fetch_array($ItemsResult)){
 		if ($ItemsRow['stockid'] == $_POST['StockID']){

--- a/ShipmentCosting.php
+++ b/ShipmentCosting.php
@@ -309,7 +309,6 @@ if (DB_num_rows($LineItemsResult) > 0) {
 				A nicety or important?? */
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The cost could not be updated because');
-				$DbgMsg = _('The following SQL to update the cost was used');
 
 				if ($TotalQuantityOnHand>0) {
 
@@ -321,7 +320,7 @@ if (DB_num_rows($LineItemsResult) > 0) {
 								lastcostupdate = CURRENT_DATE
 							WHERE stockid='" . $MyRow['itemcode'] . "'";
 
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg,'',TRUE);
+					$Result = DB_query($SQL, $ErrMsg, '','',TRUE);
 
 				} else {
 					$SQL = "UPDATE stockmaster
@@ -330,7 +329,7 @@ if (DB_num_rows($LineItemsResult) > 0) {
 								lastcostupdate = CURRENT_DATE
 							WHERE stockid='" . $MyRow['itemcode'] . "'";
 
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg,'',TRUE);
+					$Result = DB_query($SQL, $ErrMsg, '','',TRUE);
 
 				}
 				/* End of Weighted Average Costing Code */

--- a/Shipments.php
+++ b/Shipments.php
@@ -152,7 +152,7 @@ if (!isset($_SESSION['Shipment'])){
 		WHERE supplierid='" . $_SESSION['SupplierID'] . "'";
 
 	$ErrMsg = _('The supplier details for the shipment could not be retrieved because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$MyRow = DB_fetch_array($Result);
 
 	$_SESSION['Shipment']->SupplierID = $_SESSION['SupplierID'];

--- a/Shipt_Select.php
+++ b/Shipt_Select.php
@@ -267,7 +267,7 @@ Code	 Description	On Hand		 Orders Ostdg     Units		 Code	Description 	 On Hand 
 	} //end not order number selected
 
 	$ErrMsg = _('No shipments were returned by the SQL because');
-	$ShipmentsResult = DB_query($SQL,$ErrMsg);
+	$ShipmentsResult = DB_query($SQL, $ErrMsg);
 
 
 	if (DB_num_rows($ShipmentsResult)>0){

--- a/ShopParameters.php
+++ b/ShopParameters.php
@@ -165,13 +165,12 @@ if (isset($_POST['submit'])) {
 
 		}
 		$ErrMsg =  _('The shop configuration could not be updated because');
-		$DbgMsg = _('The SQL that failed was:');
 
 		if (sizeof($SQL) > 0 ) {
 
 			DB_Txn_Begin();
 			foreach ($SQL as $SqlLine) {
-				$Result = DB_query($SqlLine,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SqlLine, $ErrMsg, '', true);
 			}
 			DB_Txn_Commit();
 			prnMsg( _('Shop configuration updated'),'success');

--- a/SpecialOrder.php
+++ b/SpecialOrder.php
@@ -71,8 +71,7 @@ if (!isset($_SESSION['SPL'.$identifier]->SupplierID)){
 					ON suppliers.currcode=currencies.currabrev
 				WHERE supplierid='" . $_SESSION['SupplierID'] . "'";
 	$ErrMsg = _('The supplier record of the supplier selected') . ": " . $_SESSION['SupplierID']  . ' ' . _('cannot be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the supplier details and failed was');
-	$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_array($Result);
 	$_SESSION['SPL'.$identifier]->SupplierID = $_SESSION['SupplierID'];
@@ -95,8 +94,7 @@ if (!isset($_SESSION['SPL'.$identifier]->CustomerID)){
 			WHERE debtorsmaster.debtorno = '" . $_SESSION['CustomerID'] . "'";
 
 	$ErrMsg = _('The customer record for') . ' : ' . $_SESSION['CustomerID']  . ' ' . _('cannot be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the customer details and failed was');
-	$Result =DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_array($Result);
 	if ($MyRow['dissallowinvoices'] != 1){
@@ -294,7 +292,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 						WHERE userid='".$_SESSION['UserID']."'
 						AND currabrev='".$_SESSION['SPL'.$identifier]->SuppCurrCode."'";
 
-			$AuthResult=DB_query($AuthSQL);
+			$AuthResult = DB_query($AuthSQL);
 			$AuthRow=DB_fetch_array($AuthResult);
 
 			if (DB_num_rows($AuthResult) > 0
@@ -376,8 +374,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 
 
 		$ErrMsg = _('The purchase order header record could not be inserted into the database because');
-		$DbgMsg = _('The SQL statement used to insert the purchase order header record and failed was');
- 		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
  		$_SESSION['SPL'.$identifier]->PurchOrderNo = GetNextTransNo(18);
 
@@ -421,21 +418,18 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 
 
 			$ErrMsg = _('The item record for line') . ' ' . $SPLLine->LineNo . ' ' . _('could not be created because');
-			$DbgMsg = _('The SQL statement used to insert the item and failed was');
 
-			$Result =DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$SQL = "INSERT INTO locstock (loccode, stockid)
 					SELECT loccode,'" . $PartCode . "' FROM locations";
 			$ErrMsg = _('The item stock locations for the special order line') . ' ' . $SPLLine->LineNo . ' ' ._('could not be created because');
-			$DbgMsg = _('The SQL statement used to insert the location stock records and failed was');
-			$Result =DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/*need to get the stock category GL information */
 			$SQL = "SELECT stockact FROM stockcategory WHERE categoryid = '" . $SPLLine->StkCat . "'";
 			$ErrMsg = _('The item stock category information for the special order line') . ' ' . $SPLLine->LineNo . ' ' . _('could not be retrieved because');
-			$DbgMsg = _('The SQL statement used to get the category information and that failed was');
-			$Result =DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$StkCatGL=DB_fetch_row($Result);
 			$GLCode = $StkCatGL[0];
@@ -459,8 +453,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 					'" . $SPLLine->Quantity . "')";
 
 			$ErrMsg = _('One of the purchase order detail records could not be inserted into the database because');
-			$DbgMsg = _('The SQL statement used to insert the purchase order detail record and failed was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		} /* end of the loop round the detail line items on the order */
 
@@ -487,8 +480,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 				AND custbranch.branchcode = '" . $_SESSION['SPL'.$identifier]->BranchCode . "'";
 
 		$ErrMsg = _('The delivery and sales type for the customer could not be retrieved for this special order') . ' ' . $SPLLine->LineNo . ' ' . _('because');
-		$DbgMsg = _('The SQL statement used to get the delivery details and that failed was');
-		$Result =DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$BranchDetails=DB_fetch_array($Result);
 		$SalesOrderNo=GetNextTransNo (30);
@@ -530,7 +522,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 							'" . $OrderDate . "')";
 
 		$ErrMsg = _('The sales order cannot be added because');
-		$InsertQryResult = DB_query($HeaderSQL,$ErrMsg, $DbgMsg);
+		$InsertQryResult = DB_query($HeaderSQL, $ErrMsg);
 
 		$StartOf_LineItemsSQL = "INSERT INTO salesorderdetails (orderno,
 																stkcode,
@@ -548,7 +540,7 @@ if (isset($_POST['Commit'])){ /*User wishes to commit the order to the database 
 							'". $StockItem->Price . "',
 							'" . $StockItem->Quantity . "',
 							'" . $StockItem->LineNo . "')";
-			$Ins_LineItemResult = DB_query($LineItemsSQL,$ErrMsg);
+			$Ins_LineItemResult = DB_query($LineItemsSQL, $ErrMsg);
 
 		} /* inserted line items into sales order details */
 
@@ -700,8 +692,7 @@ echo '<field>
 
 $SQL = "SELECT categoryid, categorydescription FROM stockcategory";
 $ErrMsg = _('The stock categories could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve stock categories and failed was');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 while ($MyRow=DB_fetch_array($Result)){
 	if (isset($_POST['StkCat']) and $MyRow['categoryid']==$_POST['StkCat']){

--- a/StockAdjustments.php
+++ b/StockAdjustments.php
@@ -133,9 +133,8 @@ if (isset($_POST['CheckCode'])) {
 				FROM stockmaster
 				WHERE stockid " . LIKE  . " '%" . $_POST['StockCode'] ."%'";
 	}
-	$ErrMsg=_('The stock information cannot be retrieved because');
-	$DbgMsg=_('The SQL to get the stock description was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$ErrMsg = _('The stock information cannot be retrieved because');
+	$Result = DB_query($SQL, $ErrMsg);
 	echo '<table class="selection">
 			<tr>
 				<th>' . _('Stock Code') . '</th>
@@ -179,7 +178,7 @@ if (isset($_POST['EnterAdjustment']) AND $_POST['EnterAdjustment']!= ''){
 		$SQL = "SELECT quantity FROM locstock
 				WHERE stockid='" . $_SESSION['Adjustment' . $identifier]->StockID . "'
 				AND loccode='" . $_SESSION['Adjustment' . $identifier]->StockLocation . "'";
-		$CheckNegResult=DB_query($SQL);
+		$CheckNegResult = DB_query($SQL);
 		$CheckNegRow = DB_fetch_array($CheckNegResult);
 		if ($CheckNegRow['quantity']+$_SESSION['Adjustment' . $identifier]->Quantity <0){
 			$InputError=true;
@@ -236,8 +235,7 @@ if (isset($_POST['EnterAdjustment']) AND $_POST['EnterAdjustment']!= ''){
 										'')";
 
 		$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock movement record cannot be inserted because');
-		$DbgMsg =  _('The following SQL to insert the stock movement record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 /*Get the ID of the StockMove... */
 		$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -256,7 +254,7 @@ if (isset($_POST['EnterAdjustment']) AND $_POST['EnterAdjustment']!= ''){
 						AND loccode='" . $_SESSION['Adjustment' . $identifier]->StockLocation . "'
 						AND serialno='" . $Item->BundleRef . "'";
 				$ErrMsg = _('Unable to determine if the serial item exists');
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 				$SerialItemExistsRow = DB_fetch_row($Result);
 
 				if ($SerialItemExistsRow[0]==1){
@@ -267,8 +265,7 @@ if (isset($_POST['EnterAdjustment']) AND $_POST['EnterAdjustment']!= ''){
 							AND serialno='" . $Item->BundleRef . "'";
 
 					$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-					$DbgMsg =  _('The following SQL to update the serial stock item record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} else {
 					/*Need to insert a new serial item record */
 					$SQL = "INSERT INTO stockserialitems (stockid,
@@ -285,10 +282,8 @@ if (isset($_POST['EnterAdjustment']) AND $_POST['EnterAdjustment']!= ''){
 											'" . FormatDateForSQL($Item->ExpiryDate) ."')";
 
 					$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-					$DbgMsg =  _('The following SQL to update the serial stock item record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
-
 
 				/* now insert the serial stock movement */
 
@@ -301,8 +296,7 @@ if (isset($_POST['EnterAdjustment']) AND $_POST['EnterAdjustment']!= ''){
 											'" . $Item->BundleRef . "',
 											'" . $Item->BundleQty . "')";
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-				$DbgMsg =  _('The following SQL to insert the serial stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			}/* foreach controlled item in the serialitems array */
 		} /*end if the adjustment item is a controlled item */
@@ -312,8 +306,7 @@ if (isset($_POST['EnterAdjustment']) AND $_POST['EnterAdjustment']!= ''){
 				AND loccode='" . $_SESSION['Adjustment' . $identifier]->StockLocation . "'";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' ._('The location stock record could not be updated because');
-		$DbgMsg = _('The following SQL to update the stock record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		if ($_SESSION['CompanyRecord']['gllink_stock']==1 AND $_SESSION['Adjustment' . $identifier]->StandardCost > 0){
 
@@ -336,8 +329,7 @@ if (isset($_POST['EnterAdjustment']) AND $_POST['EnterAdjustment']!= ''){
 										$_SESSION['Adjustment' . $identifier]->StandardCost . " " . $_SESSION['Adjustment' . $identifier]->Narrative, 0, 200) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction entries could not be added because');
-			$DbgMsg = _('The following SQL to insert the GL entries was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 			InsertGLTags($_POST['tag']);
 
 			$SQL = "INSERT INTO gltrans (type,
@@ -357,8 +349,7 @@ if (isset($_POST['EnterAdjustment']) AND $_POST['EnterAdjustment']!= ''){
 									)";
 
 			$Errmsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction entries could not be added because');
-			$DbgMsg = _('The following SQL to insert the GL entries was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '',true);
 		}
 
 		EnsureGLEntriesBalance(17, $AdjustmentNumber);
@@ -405,7 +396,7 @@ if (!isset($_SESSION['Adjustment' . $identifier])) {
 			FROM stockmaster
 			WHERE stockid='".$StockID."'";
 
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	if (DB_num_rows($Result) > 0) {
 		$MyRow=DB_fetch_array($Result);
 		$_SESSION['Adjustment' . $identifier]->PartUnit=$MyRow['units'];

--- a/StockCategories.php
+++ b/StockCategories.php
@@ -43,9 +43,9 @@ if (isset($_GET['DeleteProperty'])){
 
 	$ErrMsg = _('Could not delete the property') . ' ' . $_GET['DeleteProperty'] . ' ' . _('because');
 	$SQL = "DELETE FROM stockitemproperties WHERE stkcatpropid='" . $_GET['DeleteProperty'] . "'";
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	$SQL = "DELETE FROM stockcatproperties WHERE stkcatpropid='" . $_GET['DeleteProperty'] . "'";
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	prnMsg(_('Deleted the property') . ' ' . $_GET['DeleteProperty'],'success');
 }
 
@@ -105,7 +105,7 @@ if (isset($_POST['submit'])) {
 									 WHERE
 									 categoryid = '" . $SelectedCategory. "'";
 		$ErrMsg = _('Could not update the stock category') . $_POST['CategoryDescription'] . _('because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		if ($_POST['PropertyCounter']==0 and $_POST['PropLabel0']!='') {
 			$_POST['PropertyCounter']=0;
@@ -148,7 +148,7 @@ if (isset($_POST['submit'])) {
 													'" . $_POST['PropNumeric' .$i] . "',
 													" . $_POST['PropReqSO' .$i] . ')';
 				$ErrMsg = _('Could not insert a new category property for') . $_POST['PropLabel' . $i];
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 			} elseif ($_POST['PropID' .$i] !='NewProperty') { //we could be amending existing properties
 				$SQL = "UPDATE stockcatproperties SET label ='" . $_POST['PropLabel' . $i] . "',
 													  controltype = " . $_POST['PropControlType' . $i] . ",
@@ -159,7 +159,7 @@ if (isset($_POST['submit'])) {
 													  reqatsalesorder = " . $_POST['PropReqSO' .$i] . "
 												WHERE stkcatpropid =" . $_POST['PropID' .$i];
 				$ErrMsg = _('Updated the stock category property for') . ' ' . $_POST['PropLabel' . $i];
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 			}
 
 		} //end of loop round properties
@@ -192,7 +192,7 @@ if (isset($_POST['submit'])) {
 											$_POST['MaterialUseageVarAc'] . "','" .
 											$_POST['WIPAct'] . "')";
 		$ErrMsg = _('Could not insert the new stock category') . $_POST['CategoryDescription'] . _('because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg(_('A new stock category record has been added for') . ' ' . $_POST['CategoryDescription'],'success');
 
 	}

--- a/StockCategorySalesInquiry.php
+++ b/StockCategorySalesInquiry.php
@@ -110,7 +110,7 @@ if (isset($_POST['ShowSales'])){
 					salesvalue DESC";
 
 	$ErrMsg = _('The sales data could not be retrieved because') . ' - ' . DB_error_msg();
-	$SalesResult = DB_query($SQL,$ErrMsg);
+	$SalesResult = DB_query($SQL, $ErrMsg);
 
 	echo '<table cellpadding="2" class="selection">';
 

--- a/StockCheck.php
+++ b/StockCheck.php
@@ -229,7 +229,7 @@ if (isset($_POST['PrintPDF'])){
 	$SQL = "SELECT locations.loccode, locationname FROM locations
 			INNER JOIN locationusers ON locationusers.loccode=locations.loccode AND locationusers.userid='" .  $_SESSION['UserID'] . "' AND locationusers.canupd=1
 			ORDER BY locationname";
-	$LocnResult=DB_query($SQL);
+	$LocnResult = DB_query($SQL);
 
 	while ($MyRow=DB_fetch_array($LocnResult)){
 			  echo '<option value="' . $MyRow['loccode'] . '">' . $MyRow['locationname'] . '</option>';

--- a/StockClone.php
+++ b/StockClone.php
@@ -329,12 +329,10 @@ if (isset($_POST['submit'])) {
 								'" . filter_number_format($_POST['Pansize']) . "')";
 
 				$ErrMsg =  _('The item could not be added because');
-				$DbgMsg = _('The SQL that was used to add the item failed was');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg,'',true);
+				$Result = DB_query($SQL, $ErrMsg, '', '', true);
 				if (DB_error_no() ==0) {
 					//now insert the language descriptions
 					$ErrMsg = _('Could not update the language description because');
-					$DbgMsg = _('The SQL that was used to update the language description and failed was');
 					if (count($ItemDescriptionLanguagesArray)>0){
 						foreach ($ItemDescriptionLanguagesArray as $LanguageId) {
 							if ($LanguageId!=''){
@@ -346,7 +344,7 @@ if (isset($_POST['submit'])) {
 																$LanguageId . "', '" .
 																$_POST['Description_' . str_replace('.','_',$LanguageId)]  . "', '" .
 																$_POST['LongDescription_' . str_replace('.','_',$LanguageId)].
-																"')",$ErrMsg,$DbgMsg,true);
+																"')", $ErrMsg, '', true);
 							}
 						}
 					}
@@ -374,7 +372,7 @@ if (isset($_POST['submit'])) {
 														'" . $_POST['PropID' . $i] . "',
 														'" . $_POST['PropValue' . $i] . "')",
 										$ErrMsg,
-										$DbgMsg,
+										'',
 										true);
 					} //end of loop around properties defined for the category
 
@@ -387,8 +385,7 @@ if (isset($_POST['submit'])) {
 										FROM locations";
 
 					$ErrMsg =  _('The locations for the item') . ' ' . $_POST['StockID'] .  ' ' . _('could not be added because');
-					$DbgMsg = _('NB Locations records can be added by opening the utility page') . ' <i>Z_MakeStockLocns.php</i> ' . _('The SQL that was used to add the location records that failed was');
-					$InsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+					$InsResult = DB_query($SQL, $ErrMsg);
 					DB_Txn_Commit();
 					//check for any purchase data
 					$SQL = "SELECT purchdata.supplierno,
@@ -441,8 +438,7 @@ if (isset($_POST['submit'])) {
 									'" . $MyRow['minorderqty'] . "',
 									'" . $MyRow['preferred'] . "')";
 								$ErrMsg = _('The cloned supplier purchasing details could not be added to the database because');
-								$DbgMsg = _('The SQL that failed was');
-								$AddResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+								$AddResult = DB_query($SQL, $ErrMsg);
 						}
 					}
 
@@ -491,7 +487,7 @@ if (isset($_POST['submit'])) {
 									'" . $MyRow['enddate']. "',
 									'" . $MyRow['price'] . "')";
 								 $ErrMsg = _('The cloned pricing could not be added');
-								 $Result = DB_query($SQL,$ErrMsg);
+								 $Result = DB_query($SQL, $ErrMsg);
 						  }
 					}
 					//What about cost data?
@@ -503,7 +499,7 @@ if (isset($_POST['submit'])) {
 							FROM stockmaster
 							WHERE stockmaster.stockid='".$_POST['OldStockID']."'";
 						$ErrMsg = _('The entered item code does not exist');
-						$OldResult = DB_query($SQL,$ErrMsg);
+						$OldResult = DB_query($SQL, $ErrMsg);
 						$OldRow = DB_fetch_array($OldResult);
 
 					//now update cloned item costs
@@ -516,8 +512,7 @@ if (isset($_POST['submit'])) {
 									lastcostupdate = CURRENT_DATE
 								WHERE stockid='" . $_POST['StockID'] . "'";
 						$ErrMsg = _('The cost details for the cloned stock item could not be updated because');
-						$DbgMsg = _('The SQL that failed was');
-						$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 						DB_Txn_Commit();
 
 					//finish up
@@ -765,8 +760,7 @@ if ( (!isset($_POST['UpdateCategories']) AND ($InputError!=1))  OR $_POST['New']
 
 	$SQL = "SELECT categoryid, categorydescription FROM stockcategory";
 	$ErrMsg = _('The stock categories could not be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve stock categories and failed was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	while ($MyRow=DB_fetch_array($Result)){
 		if (!isset($_POST['CategoryID']) OR  $MyRow['categoryid']==$_POST['CategoryID']){

--- a/StockCostUpdate.php
+++ b/StockCostUpdate.php
@@ -40,7 +40,7 @@ if (isset($_POST['UpdateData'])){
 					overheadcost,
 					mbflag";
 	$ErrMsg = _('The entered item code does not exist');
-	$OldResult = DB_query($SQL,$ErrMsg);
+	$OldResult = DB_query($SQL, $ErrMsg);
 	$OldRow = DB_fetch_array($OldResult);
 	$_POST['QOH'] = $OldRow['totalqoh'];
 	$_POST['OldMaterialCost'] = $OldRow['materialcost'];
@@ -76,8 +76,7 @@ if (isset($_POST['UpdateData'])){
 				WHERE stockid='" . $StockID . "'";
 
 		$ErrMsg = _('The cost details for the stock item could not be updated because');
-		$DbgMsg = _('The SQL that failed was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		DB_Txn_Commit();
 		UpdateCost($StockID); //Update any affected BOMs
@@ -86,7 +85,6 @@ if (isset($_POST['UpdateData'])){
 }
 
 $ErrMsg = _('The cost details for the stock item could not be retrieved because');
-$DbgMsg = _('The SQL that failed was');
 
 $Result = DB_query("SELECT description,
 							units,
@@ -113,8 +111,7 @@ $Result = DB_query("SELECT description,
 							overheadcost,
 							mbflag,
 							stocktype",
-							$ErrMsg,
-							$DbgMsg);
+							$ErrMsg);
 
 
 $MyRow = DB_fetch_array($Result);

--- a/StockCounts.php
+++ b/StockCounts.php
@@ -82,8 +82,7 @@ if ($_GET['Action'] == 'Enter') {
 								WHERE stockmaster.barcode='". $_POST[$BarCode] ."'";
 
 				$ErrMsg = _('Could not determine if the part being ordered was a kitset or not because');
-				$DbgMsg = _('The sql that was used to determine if the part being ordered was a kitset or not was ');
-				$KitResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$KitResult = DB_query($SQL, $ErrMsg);
 				$MyRow=DB_fetch_array($KitResult);
 
 				$_POST[$StockID] = strtoupper($MyRow['stockid']);
@@ -112,7 +111,7 @@ if ($_GET['Action'] == 'Enter') {
 									'" . $_POST[$Reference] . "')";
 
 					$ErrMsg = _('The stock count line number') . ' ' . $i . ' ' . _('could not be entered because');
-					$EnterResult = DB_query($SQL,$ErrMsg);
+					$EnterResult = DB_query($SQL, $ErrMsg);
 				}
 			}
 		} // end of loop
@@ -213,8 +212,7 @@ if ($_GET['Action'] == 'Enter') {
 									'" . $MyRow[2] . "')";
 
 				$ErrMsg = _('The stock count line number') . ' ' . $Row . ' ' . _('could not be entered because');
-				$DbgMsg = _('The SQL that was used to add the item failed was');
-				$EnterResult = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$EnterResult = DB_query($SQL, $ErrMsg, '', true);
 
 				if (DB_error_no() != 0) {
 					$InputError = 1;
@@ -359,7 +357,7 @@ if ($_GET['Action'] == 'Enter') {
 				$id = (int)$id;
 				$SQL = "DELETE FROM stockcounts WHERE id='".$id."'";
 				$ErrMsg = _('Failed to delete StockCount ID #').' '.$i;
-				$EnterResult = DB_query($SQL,$ErrMsg);
+				$EnterResult = DB_query($SQL, $ErrMsg);
 				prnMsg( _('Deleted Id #') . ' ' . $id, 'success');
 			}
 		}

--- a/StockDispatch.php
+++ b/StockDispatch.php
@@ -39,7 +39,7 @@ if (isset($_POST['PrintPDF'])) {
 	// from location
 	$ErrMsg = _('Could not retrieve location name from the database');
 	$SQLfrom="SELECT locationname FROM `locations` WHERE loccode='" . $_POST['FromLocation'] . "'";
-	$Result = DB_query($SQLfrom,$ErrMsg);
+	$Result = DB_query($SQLfrom, $ErrMsg);
 	$Row = DB_fetch_row($Result);
 	$FromLocation=$Row['0'];
 
@@ -49,7 +49,7 @@ if (isset($_POST['PrintPDF'])) {
 					cashsalebranch
 			FROM `locations`
 			WHERE loccode='" . $_POST['ToLocation'] . "'";
-	$Resultto = DB_query($SQLto,$ErrMsg);
+	$Resultto = DB_query($SQLto, $ErrMsg);
 	$RowTo = DB_fetch_row($Resultto);
 	$ToLocation=$RowTo['0'];
 	$ToCustomer=$RowTo['1'];
@@ -62,7 +62,7 @@ if (isset($_POST['PrintPDF'])) {
 				FROM debtorsmaster, currencies
 				WHERE debtorsmaster.currcode = currencies.currabrev
 					AND debtorsmaster.debtorno ='" . $ToCustomer . "'";
-		$ResultPrices = DB_query($SqlPrices,$ErrMsg);
+		$ResultPrices = DB_query($SqlPrices, $ErrMsg);
 		$RowPrices = DB_fetch_row($ResultPrices);
 		$ToCurrency=$RowPrices['0'];
 		$ToPriceList=$RowPrices['1'];
@@ -73,7 +73,7 @@ if (isset($_POST['PrintPDF'])) {
 	// more than one category
 	if ($_POST['StockCat'] != 'All') {
 		$CategorySQL="SELECT categorydescription FROM stockcategory WHERE categoryid='".$_POST['StockCat']."'";
-		$CategoryResult=DB_query($CategorySQL);
+		$CategoryResult = DB_query($CategorySQL);
 		$CategoryRow=DB_fetch_array($CategoryResult);
 		$CategoryDescription=$CategoryRow['categorydescription'];
 		$WhereCategory = " AND stockmaster.categoryid ='" . $_POST['StockCat'] . "' ";
@@ -156,7 +156,7 @@ if (isset($_POST['PrintPDF'])) {
 							WHERE stockid='" . $MyRow['stockid'] . "'
 								AND shiploc='".$_POST['FromLocation']."'
 								AND pendingqty>0";
-			$InTransitResult=DB_query($InTransitSQL);
+			$InTransitResult = DB_query($InTransitSQL);
 			$InTransitRow=DB_fetch_array($InTransitResult);
 			$InTransitQuantityAtFrom=$InTransitRow['intransit'];
 		}
@@ -170,7 +170,7 @@ if (isset($_POST['PrintPDF'])) {
 						WHERE stockid='" . $MyRow['stockid'] . "'
 							AND recloc='".$_POST['ToLocation']."'
 							AND pendingqty>0";
-		$InTransitResult=DB_query($InTransitSQL);
+		$InTransitResult = DB_query($InTransitSQL);
 		$InTransitRow=DB_fetch_array($InTransitResult);
 		$InTransitQuantityAtTo=$InTransitRow['intransit'];
 

--- a/StockLocStatus.php
+++ b/StockLocStatus.php
@@ -167,9 +167,7 @@ if(isset($_POST['ShowStatus'])) {
 	}
 
 	$ErrMsg = _('The stock held at each location cannot be retrieved because');
-	$DbgMsg = _('The SQL that failed was');
-	$LocStockResult = DB_query($SQL, $ErrMsg, $DbgMsg);
-
+	$LocStockResult = DB_query($SQL, $ErrMsg);
 
 	echo '<table cellpadding="5" cellspacing="4" class="selection">
 			<thead>

--- a/StockLocTransfer.php
+++ b/StockLocTransfer.php
@@ -70,7 +70,7 @@ if (isset($_POST['Submit']) OR isset($_POST['EnterMoreItems'])){
 									WHERE stockid='" . $StockID . "'
 										AND shiploc='".$_POST['FromStockLocation']."'
 										AND pendingqty>0";
-					$InTransitResult=DB_query($InTransitSQL);
+					$InTransitResult = DB_query($InTransitSQL);
 					$InTransitRow=DB_fetch_array($InTransitResult);
 					$InTransitQuantity=$InTransitRow['intransit'];
 					// Only if stock exists at this location
@@ -137,7 +137,7 @@ if (isset($_POST['Submit']) OR isset($_POST['EnterMoreItems'])){
 										WHERE stockid='" . $_POST['StockID' . $i] . "'
 											AND shiploc='".$_POST['FromStockLocation']."'
 											AND pendingqty>0";
-						$InTransitResult=DB_query($InTransitSQL);
+						$InTransitResult = DB_query($InTransitSQL);
 						$InTransitRow=DB_fetch_array($InTransitResult);
 						$InTransitQuantity=$InTransitRow['intransit'];
 						// Only if stock exists at this location

--- a/StockLocTransferReceive.php
+++ b/StockLocTransferReceive.php
@@ -108,8 +108,7 @@ if(isset($_POST['ProcessTransfer'])) {
 					)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock movement record cannot be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock movement record was used');
-				$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/*Get the ID of the StockMove... */
 				$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -142,8 +141,7 @@ if(isset($_POST['ProcessTransfer'])) {
 								AND serialno='" . $Item->BundleRef . "'";
 
 							$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-							$DbgMsg = _('The following SQL to update the serial stock item record was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						} else {
 							/*Need to insert a new serial item record */
 							$SQL = "INSERT INTO stockserialitems (stockid,
@@ -158,8 +156,7 @@ if(isset($_POST['ProcessTransfer'])) {
 								'')";
 
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item for the stock being transferred out of the existing location could not be inserted because');
-							$DbgMsg = _('The following SQL to update the serial stock item record was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						}
 
 
@@ -177,8 +174,7 @@ if(isset($_POST['ProcessTransfer'])) {
 								'" . -$Item->BundleQty . "'
 							)";
 						$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-						$DbgMsg =  _('The following SQL to insert the serial stock movement records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					}/* foreach controlled item in the serialitems array */
 				} /*end if the transferred item is a controlled item */
@@ -214,8 +210,7 @@ if(isset($_POST['ProcessTransfer'])) {
 										FROM stockmaster
 										WHERE stockmaster.stockid ='" . $TrfLine->StockID . "'";
 					$ErrMsg = _('The standard cost of the item cannot be retrieved because');
-					$DbgMsg = _('The SQL that failed was');
-					$MyRow = DB_fetch_array(DB_query($SQLstandardcost,$ErrMsg,$DbgMsg));
+					$MyRow = DB_fetch_array(DB_query($SQLstandardcost, $ErrMsg));
 					$StandardCost = $MyRow['standardcost'];// QUESTION: Standard cost for: Assembly (value="A") and Manufactured (value="M") items ?
 					// Insert record:
 					$SQL = "INSERT INTO gltrans (
@@ -235,8 +230,7 @@ if(isset($_POST['ProcessTransfer'])) {
 							mb_substr($_SESSION['Transfer']->StockLocationFrom.' - '.$TrfLine->StockID.' x '.$TrfLine->Quantity.' @ '. $StandardCost, 0, 200) . "','" .
 							-$TrfLine->Quantity * $StandardCost . "')";
 					$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The outgoing inventory GL transacction record could not be inserted because');
-					$DbgMsg =  _('The following SQL to insert records was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 
 				// Insert the stock movement for the stock coming into the to location
@@ -264,9 +258,7 @@ if(isset($_POST['ProcessTransfer'])) {
 						)";
 
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock movement record for the incoming stock cannot be added because');
-				$DbgMsg =  _('The following SQL to insert the stock movement record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
-
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/*Get the ID of the StockMove... */
 				$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -298,8 +290,7 @@ if(isset($_POST['ProcessTransfer'])) {
 								AND serialno='" . $Item->BundleRef . "'";
 
 							$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated for the quantity coming in because');
-							$DbgMsg =  _('The following SQL to update the serial stock item record was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						} else {
 							/*Need to insert a new serial item record */
 							$SQL = "INSERT INTO stockserialitems (stockid,
@@ -314,10 +305,8 @@ if(isset($_POST['ProcessTransfer'])) {
 								'')";
 
 							$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record for the stock coming in could not be added because');
-							$DbgMsg =  _('The following SQL to update the serial stock item record was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						}
-
 
 						/* now insert the serial stock movement */
 
@@ -331,8 +320,7 @@ if(isset($_POST['ProcessTransfer'])) {
 									'" . $Item->BundleRef . "',
 									'" . $Item->BundleQty . "')";
 						$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-						$DbgMsg =  _('The following SQL to insert the serial stock movement records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					}/* foreach controlled item in the serialitems array */
 				} /*end if the transfer item is a controlled item */
@@ -343,8 +331,7 @@ if(isset($_POST['ProcessTransfer'])) {
 					AND loccode='" . $_SESSION['Transfer']->StockLocationFrom . "'";
 
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-				$DbgMsg =  _('The following SQL to update the stock record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "UPDATE locstock
 					SET quantity = quantity + '" . round($TrfLine->Quantity, $TrfLine->DecimalPlaces) . "'
@@ -352,8 +339,7 @@ if(isset($_POST['ProcessTransfer'])) {
 					AND loccode='" . $_SESSION['Transfer']->StockLocationTo . "'";
 
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-				$DbgMsg =  _('The following SQL to update the stock record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				// Insert incoming inventory GL transaction if any of the locations has a GL account code:
 				if(($_SESSION['Transfer']->StockLocationFromAccount !='' OR $_SESSION['Transfer']->StockLocationToAccount !='') AND
@@ -370,8 +356,7 @@ if(isset($_POST['ProcessTransfer'])) {
 										FROM stockmaster
 										WHERE stockmaster.stockid ='" . $TrfLine->StockID . "'";
 					$ErrMsg = _('The standard cost of the item cannot be retrieved because');
-					$DbgMsg = _('The SQL that failed was');
-					$MyRow = DB_fetch_array(DB_query($SQLstandardcost,$ErrMsg,$DbgMsg));
+					$MyRow = DB_fetch_array(DB_query($SQLstandardcost, $ErrMsg));
 					$StandardCost = $MyRow['standardcost'];// QUESTION: Standard cost for: Assembly (value="A") and Manufactured (value="M") items ?
 					// Insert record:
 					$SQL = "INSERT INTO gltrans (
@@ -391,8 +376,7 @@ if(isset($_POST['ProcessTransfer'])) {
 							mb_substr($_SESSION['Transfer']->StockLocationTo.' - '.$TrfLine->StockID.' x '.$TrfLine->Quantity.' @ '. $StandardCost, 0, 200) . "','" .
 							$TrfLine->Quantity * $StandardCost . "')";
 					$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The incoming inventory GL transacction record could not be inserted because');
-					$DbgMsg =  _('The following SQL to insert records was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 
 				prnMsg(_('A stock transfer for item code'). ' - '  . $TrfLine->StockID . ' ' . $TrfLine->ItemDescription . ' '. _('has been created from').' ' . $_SESSION['Transfer']->StockLocationFromName . ' '. _('to'). ' ' . $_SESSION['Transfer']->StockLocationToName . ' ' . _('for a quantity of'). ' '. $TrfLine->Quantity,'success');
@@ -411,7 +395,7 @@ if(isset($_POST['ProcessTransfer'])) {
 						AND stockid = '".  $TrfLine->StockID."'";
 				}
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('Unable to update the Location Transfer Record');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				unset ($_SESSION['Transfer']->LineItem[$i]);
 				unset ($_POST['Qty' . $i]);
 			} /*end if Quantity >= 0 */
@@ -420,7 +404,7 @@ if(isset($_POST['ProcessTransfer'])) {
 						WHERE reference = '". $_SESSION['Transfer']->TrfID . "'
 						AND stockid = '".  $TrfLine->StockID."'";
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('Unable to set the quantity received to the quantity shipped to cancel the balance on this transfer line');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				// send an email to the inventory manager about this cancellation (as can lead to employee fraud)
 				if($_SESSION['InventoryManagerEmail']!='') {
 					$ConfirmationText = _('Cancelled balance of transfer'). ': ' . $_SESSION['Transfer']->TrfID .
@@ -481,8 +465,7 @@ if(isset($_GET['Trf_ID'])) {
 
 
 	$ErrMsg = _('The details of transfer number') . ' ' . $_GET['Trf_ID'] . ' ' . _('could not be retrieved because') .' ';
-	$DbgMsg = _('The SQL to retrieve the transfer was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if(DB_num_rows($Result) == 0) {
 		echo '<h3>' . _('Transfer') . ' #' . $_GET['Trf_ID'] . ' '. _('Does Not Exist') . '</h3><br />';
@@ -694,7 +677,5 @@ function RecordItemCancelledInTransfer($TransferReference, $StockID, $CancelQty)
 			'" . Date('Y-m-d H:i:s') . "',
 			'" . $_SESSION['UserID'] . "')";
 	$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The transfer cancellation record could not be inserted because');
-	$DbgMsg =  _('The following SQL to insert records was used');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
-
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 }

--- a/StockMovements.php
+++ b/StockMovements.php
@@ -126,9 +126,8 @@ $SQL = "SELECT stockmoves.stockid,
 		ORDER BY stkmoveno DESC";
 
 $ErrMsg = _('The stock movements for the selected criteria could not be retrieved because') . ' - ';
-$DbgMsg = _('The SQL that failed was') . ' ';
 
-$MovtsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+$MovtsResult = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($MovtsResult) > 0) {
 	$MyRow = DB_fetch_array($MovtsResult);

--- a/StockQuantityByDate.php
+++ b/StockQuantityByDate.php
@@ -115,9 +115,8 @@ if (isset($_POST['ShowStatus']) and is_date($_POST['OnHandDate'])) {
 	}
 
 	$ErrMsg = _('The stock items in the category selected cannot be retrieved because');
-	$DbgMsg = _('The SQL that failed was');
 
-	$StockResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$StockResult = DB_query($SQL, $ErrMsg);
 
 	$SQLOnHandDate = FormatDateForSQL($_POST['OnHandDate']);
 

--- a/StockReorderLevel.php
+++ b/StockReorderLevel.php
@@ -41,9 +41,9 @@ $SQL = "SELECT locstock.loccode,
 		ORDER BY locations.locationname";
 
 $ErrMsg = _('The stock held at each location cannot be retrieved because');
-$DbgMsg = _('The SQL that failed was');
 
-$LocStockResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+
+$LocStockResult = DB_query($SQL, $ErrMsg);
 
 echo '<table class="selection">
 	<thead>

--- a/StockStatus.php
+++ b/StockStatus.php
@@ -100,8 +100,7 @@ $SQL = "SELECT locstock.loccode,
 		ORDER BY locations.locationname";
 
 $ErrMsg = _('The stock held at each location cannot be retrieved because');
-$DbgMsg = _('The SQL that was used to update the stock item and failed was');
-$LocStockResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+$LocStockResult = DB_query($SQL, $ErrMsg);
 
 echo '<table class="selection">';
 	echo '<thead>';
@@ -139,7 +138,7 @@ while ($MyRow=DB_fetch_array($LocStockResult)) {
 						FROM loctransfers
 						WHERE stockid='" . $StockID . "'
 							AND shiploc='".$MyRow['loccode']."'";
-		$InTransitResult=DB_query($InTransitSQL);
+		$InTransitResult = DB_query($InTransitSQL);
 		$InTransitRow=DB_fetch_array($InTransitResult);
 		if ($InTransitRow['intransit']!='') {
 			$InTransitQuantityOut=-$InTransitRow['intransit'];
@@ -151,7 +150,7 @@ while ($MyRow=DB_fetch_array($LocStockResult)) {
 						FROM loctransfers
 						WHERE stockid='" . $StockID . "'
 							AND recloc='".$MyRow['loccode']."'";
-		$InTransitResult=DB_query($InTransitSQL);
+		$InTransitResult = DB_query($InTransitSQL);
 		$InTransitRow=DB_fetch_array($InTransitResult);
 		if ($InTransitRow['intransit']!='') {
 			$InTransitQuantityIn=-$InTransitRow['intransit'];
@@ -232,9 +231,8 @@ if ($DebtorNo) { /* display recent pricing history for this debtor and this stoc
 	/* only show pricing history for sales invoices - type=10 */
 
 	$ErrMsg = _('The stock movements for the selected criteria could not be retrieved because') . ' - ';
-	$DbgMsg = _('The SQL that failed was');
 
-	$MovtsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$MovtsResult = DB_query($SQL, $ErrMsg);
 
 	$k=1;
 	while ($MyRow=DB_fetch_array($MovtsResult)) {

--- a/StockTransfers.php
+++ b/StockTransfers.php
@@ -41,8 +41,7 @@ if(isset($_POST['CheckCode'])) {
 			  WHERE stockid " . LIKE . " '%" . $_POST['StockCode']."%'";
 	}
 	$ErrMsg=_('The stock information cannot be retrieved because');
-	$DbgMsg=_('The SQL to get the stock description was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	echo '<table class="selection">
 		<thead>
 			<tr>
@@ -258,8 +257,7 @@ if(isset($_POST['EnterTransfer']) ) {
 				AND loccode= '" . $_SESSION['Transfer']->StockLocationFrom . "'";
 
 		$ErrMsg =  _('Could not retrieve the QOH at the sending location because');
-		$DbgMsg =  _('The SQL that failed was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		if(DB_num_rows($Result)==1) {
 			$LocQtyRow = DB_fetch_row($Result);
@@ -289,8 +287,7 @@ if(isset($_POST['EnterTransfer']) ) {
 								FROM stockmaster
 								WHERE stockmaster.stockid ='" . $_SESSION['Transfer']->TransferItem[0]->StockID . "'";
 			$ErrMsg = _('The standard cost of the item cannot be retrieved because');
-			$DbgMsg = _('The SQL that failed was');
-			$ResultStandardCost = DB_query($SQLstandardcost,$ErrMsg,$DbgMsg);
+			$ResultStandardCost = DB_query($SQLstandardcost, $ErrMsg);
 			$MyRow = DB_fetch_array($ResultStandardCost);
 			$StandardCost = $MyRow['standardcost'];// QUESTION: Standard cost for: Assembly (value="A") and Manufactured (value="M") items ?
 			// Insert record:
@@ -311,8 +308,7 @@ if(isset($_POST['EnterTransfer']) ) {
 					mb_substr($_SESSION['Transfer']->StockLocationFrom.' - '.$_SESSION['Transfer']->TransferItem[0]->StockID.' x '.$_SESSION['Transfer']->TransferItem[0]->Quantity.' @ '. $StandardCost, 0, 200) . "','" .
 					-$_SESSION['Transfer']->TransferItem[0]->Quantity * $StandardCost . "')";
 					$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The outgoing inventory GL transacction record could not be inserted because');
-					$DbgMsg =  _('The following SQL to insert records was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 		// Insert the stock movement for the stock going out of the from location
 		$SQL = "INSERT INTO stockmoves(stockid,
@@ -339,8 +335,7 @@ if(isset($_POST['EnterTransfer']) ) {
 						)";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock movement record cannot be inserted because');
-		$DbgMsg =  _('The following SQL to insert the stock movement record was used');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*Get the ID of the StockMove... */
 		$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -361,7 +356,7 @@ if(isset($_POST['EnterTransfer']) ) {
 						AND serialno='" . $Item->BundleRef . "'";
 
 				$ErrMsg =  _('The entered item code does not exist');
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 				$SerialItemExistsRow = DB_fetch_row($Result);
 
 				if($SerialItemExistsRow[0]==1) {
@@ -374,8 +369,7 @@ if(isset($_POST['EnterTransfer']) ) {
 							AND serialno='" . $Item->BundleRef . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-					$DbgMsg = _('The following SQL to update the serial stock item record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} else {
 					/*Need to insert a new serial item record */
 					$SQL = "INSERT INTO stockserialitems (stockid,
@@ -390,10 +384,8 @@ if(isset($_POST['EnterTransfer']) ) {
 						'" . -$Item->BundleQty . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be added because');
-					$DbgMsg = _('The following SQL to insert the serial stock item record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
-
 
 				/* now insert the serial stock movement */
 
@@ -410,8 +402,7 @@ if(isset($_POST['EnterTransfer']) ) {
 							)";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			}/* foreach controlled item in the serialitems array */
 		} /*end if the transferred item is a controlled item */
@@ -423,7 +414,7 @@ if(isset($_POST['EnterTransfer']) ) {
 				WHERE locstock.stockid='" . $_SESSION['Transfer']->TransferItem[0]->StockID . "'
 				AND loccode= '" . $_SESSION['Transfer']->StockLocationTo . "'";
 		$ErrMsg = _('Could not retrieve QOH at the destination because');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '',true);
 		if(DB_num_rows($Result)==1) {
 			$LocQtyRow = DB_fetch_row($Result);
 			$QtyOnHandPrior = $LocQtyRow[0];
@@ -446,8 +437,7 @@ if(isset($_POST['EnterTransfer']) ) {
 								FROM stockmaster
 								WHERE stockmaster.stockid ='" . $_SESSION['Transfer']->TransferItem[0]->StockID . "'";
 			$ErrMsg = _('The standard cost of the item cannot be retrieved because');
-			$DbgMsg = _('The SQL that failed was');
-			$ResultStandardCost = DB_query($SQLstandardcost,$ErrMsg,$DbgMsg);
+			$ResultStandardCost = DB_query($SQLstandardcost, $ErrMsg);
 			$MyRow = DB_fetch_array($ResultStandardCost);
 			$StandardCost = $MyRow['standardcost'];// QUESTION: Standard cost for: Assembly (value="A") and Manufactured (value="M") items ?
 			// Insert record:
@@ -468,8 +458,7 @@ if(isset($_POST['EnterTransfer']) ) {
 					mb_substr($_SESSION['Transfer']->StockLocationTo.' - '.$_SESSION['Transfer']->TransferItem[0]->StockID.' x '.$_SESSION['Transfer']->TransferItem[0]->Quantity.' @ '. $StandardCost, 0, 200) . "','" .
 					$_SESSION['Transfer']->TransferItem[0]->Quantity * $StandardCost . "')";
 			$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The incoming inventory GL transacction record could not be inserted because');
-			$DbgMsg =  _('The following SQL to insert records was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 		// Insert the stock movement for the stock coming into the to location
 		$SQL = "INSERT INTO stockmoves (stockid,
@@ -494,8 +483,7 @@ if(isset($_POST['EnterTransfer']) ) {
 					'" . round($QtyOnHandPrior + $_SESSION['Transfer']->TransferItem[0]->Quantity,$_SESSION['Transfer']->TransferItem[0]->DecimalPlaces) . "')";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock movement record cannot be inserted because');
-		$DbgMsg = _('The following SQL to insert the stock movement record was used');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*Get the ID of the StockMove... */
 		$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -515,7 +503,7 @@ if(isset($_POST['EnterTransfer']) ) {
 						AND serialno='" . $Item->BundleRef . "'";
 
 				$ErrMsg = _('Could not determine if the serial item exists in the transfer to location');
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 				$SerialItemExistsRow = DB_fetch_row($Result);
 
 				if($SerialItemExistsRow[0]==1) {
@@ -528,8 +516,7 @@ if(isset($_POST['EnterTransfer']) ) {
 							AND serialno='" . $Item->BundleRef . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be updated because');
-					$DbgMsg = _('The following SQL to update the serial stock item record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} else {
 					/*Need to insert a new serial item record */
 					$SQL = "INSERT INTO stockserialitems (stockid,
@@ -546,10 +533,8 @@ if(isset($_POST['EnterTransfer']) ) {
 								'')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be added because');
-					$DbgMsg = _('The following SQL to insert the serial stock item record was used:');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
-
 
 				/* now insert the serial stock movement */
 
@@ -562,20 +547,17 @@ if(isset($_POST['EnterTransfer']) ) {
 								'" . $Item->BundleRef . "',
 								'" . $Item->BundleQty . "')";
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			}/* foreach controlled item in the serialitems array */
 		} /*end if the transfer item is a controlled item */
-
 
 		$SQL = "UPDATE locstock SET quantity = quantity - '" . round($_SESSION['Transfer']->TransferItem[0]->Quantity,$_SESSION['Transfer']->TransferItem[0]->DecimalPlaces) . "'
 				WHERE stockid='" . $_SESSION['Transfer']->TransferItem[0]->StockID . "'
 				AND loccode='" . $_SESSION['Transfer']->StockLocationFrom . "'";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-		$DbgMsg = _('The following SQL to update the location stock record was used');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$SQL = "UPDATE locstock
 				SET quantity = quantity + '" . round($_SESSION['Transfer']->TransferItem[0]->Quantity,$_SESSION['Transfer']->TransferItem[0]->DecimalPlaces) . "'
@@ -583,8 +565,7 @@ if(isset($_POST['EnterTransfer']) ) {
 				AND loccode='" . $_SESSION['Transfer']->StockLocationTo . "'";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-		$DbgMsg = _('The following SQL to update the location stock record was used');
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		DB_Txn_Commit();
 

--- a/Stocks.php
+++ b/Stocks.php
@@ -443,21 +443,19 @@ if (isset($_POST['submit'])) {
 					WHERE stockid='" . $StockID . "'";
 
 				$ErrMsg = _('The stock item could not be updated because');
-				$DbgMsg = _('The SQL that was used to update the stock item and failed was');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$ErrMsg = _('Could not update the language description because');
-				$DbgMsg = _('The SQL that was used to update the language description and failed was');
 
 				if (count($ItemDescriptionLanguagesArray) > 0) {
 					foreach ($ItemDescriptionLanguagesArray as $LanguageId) {
 						if ($LanguageId != '') {
-							$Result = DB_query("DELETE FROM stockdescriptiontranslations WHERE stockid='" . $StockID . "' AND language_id='" . $LanguageId . "'", $ErrMsg, $DbgMsg, true);
+							$Result = DB_query("DELETE FROM stockdescriptiontranslations WHERE stockid='" . $StockID . "' AND language_id='" . $LanguageId . "'", $ErrMsg, '', true);
 							$Result = DB_query("INSERT INTO stockdescriptiontranslations (stockid,
 																						language_id,
 																						descriptiontranslation,
 																						longdescriptiontranslation)
-												VALUES('" . $StockID . "','" . $LanguageId . "', '" . $_POST['Description_' . str_replace('.', '_', $LanguageId) ] . "', '" . $_POST['LongDescription_' . str_replace('.', '_', $LanguageId) ] . "')", $ErrMsg, $DbgMsg, true);
+												VALUES('" . $StockID . "','" . $LanguageId . "', '" . $_POST['Description_' . str_replace('.', '_', $LanguageId) ] . "', '" . $_POST['LongDescription_' . str_replace('.', '_', $LanguageId) ] . "')", $ErrMsg, '', true);
 						}
 					}
 					/*
@@ -467,7 +465,7 @@ if (isset($_POST['submit'])) {
 							$SQL = "UPDATE stockdescriptiontranslations " .
 									"SET descriptiontranslation='" . $DescriptionTranslation . "' " .
 									"WHERE stockid='" . $StockID . "' AND (language_id='" . $LanguageId. "')";
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 					}
 					*/
 
@@ -479,12 +477,11 @@ if (isset($_POST['submit'])) {
 						SET needsrevision = '0'
 						WHERE stockid='" . $StockID . "'";
 					$ErrMsg = _('The stock description translations could not be updated because');
-					$DbgMsg = _('The SQL that was used to set the flag for translation revision failed was');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 
 				//delete any properties for the item no longer relevant with the change of category
-				$Result = DB_query("DELETE FROM stockitemproperties WHERE stockid ='" . $StockID . "'", $ErrMsg, $DbgMsg, true);
+				$Result = DB_query("DELETE FROM stockitemproperties WHERE stockid ='" . $StockID . "'", $ErrMsg, '', true);
 
 				//now insert any item properties
 				for ($i = 0;$i < $_POST['PropertyCounter'];$i++) {
@@ -506,7 +503,7 @@ if (isset($_POST['submit'])) {
 																		value)
 														VALUES ('" . $StockID . "',
 																'" . $_POST['PropID' . $i] . "',
-																'" . $_POST['PropValue' . $i] . "')", $ErrMsg, $DbgMsg, true);
+																'" . $_POST['PropValue' . $i] . "')", $ErrMsg, '', true);
 				} //end of loop around properties defined for the category
 				if ($OldStockAccount != $NewStockAct and $_SESSION['CompanyRecord']['gllink_stock'] == 1) {
 					/*Then we need to make a journal to transfer the cost to the new stock account */
@@ -526,8 +523,7 @@ if (isset($_POST['submit'])) {
 												'" . mb_substr($StockID . ' ' . _('Change stock category'), 0, 200) . "',
 												'" . ($UnitCost * $StockQtyRow[0]) . "')";
 					$ErrMsg = _('The stock cost journal could not be inserted because');
-					$DbgMsg = _('The SQL that was used to create the stock cost journal and failed was');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					$SQL = "INSERT INTO gltrans (type,
 												typeno,
 												trandate,
@@ -542,7 +538,7 @@ if (isset($_POST['submit'])) {
 												'" . $OldStockAccount . "',
 												'" . mb_substr($StockID . ' ' . _('Change stock category'), 0, 200) . "',
 												'" . (-$UnitCost * $StockQtyRow[0]) . "')";
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				} /* end if the stock category changed and forced a change in stock cost account */
 				if ($OldWIPAccount != $NewWIPAct and $_SESSION['CompanyRecord']['gllink_stock'] == 1) {
@@ -579,8 +575,7 @@ if (isset($_POST['submit'])) {
 													'" . mb_substr($StockID . ' ' . _('Change stock category'), 0, 200) . "',
 													'" . $WIPValue . "')";
 						$ErrMsg = _('The WIP cost journal could not be inserted because');
-						$DbgMsg = _('The SQL that was used to create the WIP cost journal and failed was');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 						$SQL = "INSERT INTO gltrans (type,
 													typeno,
 													trandate,
@@ -595,7 +590,7 @@ if (isset($_POST['submit'])) {
 													'" . $OldWIPAccount . "',
 													'" . mb_substr($StockID . ' ' . _('Change stock category'), 0, 200) . "',
 													'" . (-$WIPValue) . "')";
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 					}
 				} /* end if the stock category changed and forced a change in WIP account */
 				DB_Txn_Commit();
@@ -658,12 +653,10 @@ if (isset($_POST['submit'])) {
 								'" . filter_number_format($_POST['Pansize']) . "')";
 
 				$ErrMsg = _('The item could not be added because');
-				$DbgMsg = _('The SQL that was used to add the item failed was');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, '', true);
+				$Result = DB_query($SQL, $ErrMsg, '', '', true);
 				if (DB_error_no() == 0) {
 					//now insert the language descriptions
 					$ErrMsg = _('Could not update the language description because');
-					$DbgMsg = _('The SQL that was used to update the language description and failed was');
 					if (count($ItemDescriptionLanguagesArray) > 0) {
 						foreach ($ItemDescriptionLanguagesArray as $LanguageId) {
 							if ($LanguageId != '' and $_POST['Description_' . str_replace('.', '_', $LanguageId) ] != '') {
@@ -671,7 +664,7 @@ if (isset($_POST['submit'])) {
 																							language_id,
 																							descriptiontranslation,
 																							longdescriptiontranslation)
-													VALUES('" . $StockID . "','" . $LanguageId . "', '" . $_POST['Description_' . str_replace('.', '_', $LanguageId) ] . "', '" . $_POST['longDescription_' . str_replace('.', '_', $LanguageId) ] . "')", $ErrMsg, $DbgMsg, true);
+													VALUES('" . $StockID . "','" . $LanguageId . "', '" . $_POST['Description_' . str_replace('.', '_', $LanguageId) ] . "', '" . $_POST['longDescription_' . str_replace('.', '_', $LanguageId) ] . "')", $ErrMsg, '', true);
 							}
 						}
 					}
@@ -697,7 +690,7 @@ if (isset($_POST['submit'])) {
 													value)
 													VALUES ('" . $StockID . "',
 														'" . $_POST['PropID' . $i] . "',
-														'" . $_POST['PropValue' . $i] . "')", $ErrMsg, $DbgMsg, true);
+														'" . $_POST['PropValue' . $i] . "')", $ErrMsg, '', true);
 					} //end of loop around properties defined for the category
 					//Add data to locstock
 					$SQL = "INSERT INTO locstock (loccode,
@@ -707,8 +700,7 @@ if (isset($_POST['submit'])) {
 										FROM locations";
 
 					$ErrMsg = _('The locations for the item') . ' ' . $StockID . ' ' . _('could not be added because');
-					$DbgMsg = _('NB Locations records can be added by opening the utility page') . ' <i>Z_MakeStockLocns.php</i> ' . _('The SQL that was used to add the location records that failed was');
-					$InsResult = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$InsResult = DB_query($SQL, $ErrMsg, '', true);
 					DB_Txn_Commit();
 					if (DB_error_no() == 0) {
 						prnMsg(_('New Item') . ' ' . '<a href="SelectProduct.php?StockID=' . $StockID . '">' . $StockID . '</a> ' . _('has been added to the database') . '<br />' . _('NB: The item cost and pricing must also be setup') . '<br />' . '<a target="_blank" href="StockCostUpdate.php?StockID=' . $StockID . '">' . _('Enter Item Cost') . '</a>
@@ -1088,8 +1080,7 @@ echo '<field>
 
 $SQL = "SELECT categoryid, categorydescription FROM stockcategory";
 $ErrMsg = _('The stock categories could not be retrieved because');
-$DbgMsg = _('The SQL used to retrieve stock categories and failed was');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 while ($MyRow = DB_fetch_array($Result)) {
 	if (!isset($_POST['CategoryID']) or $MyRow['categoryid'] == $_POST['CategoryID']) {

--- a/SuppLoginSetup.php
+++ b/SuppLoginSetup.php
@@ -99,8 +99,7 @@ if (isset($_POST['submit'])) {
 							'" . $_POST['Theme'] . "',
 							'". $_POST['UserLanguage'] ."')";
 		$ErrMsg = _('The user could not be added because');
-		$DbgMsg = _('The SQL that was used to insert the new user and failed was');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg( _('A new supplier login has been created'), 'success' );
 		include('includes/footer.php');
 		exit();

--- a/SuppPaymentRun.php
+++ b/SuppPaymentRun.php
@@ -281,7 +281,7 @@ if ((isset($_POST['PrintPDF']) OR isset($_POST['PrintPDFAndProcess']))
 			<select name="Currency">';
 
 	$SQL = "SELECT currency, currabrev FROM currencies";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 
 	while ($MyRow=DB_fetch_array($Result)){
 	if ($MyRow['currabrev'] == $_SESSION['CompanyRecord']['currencydefault']){

--- a/SupplierAllocations.php
+++ b/SupplierAllocations.php
@@ -115,9 +115,8 @@ if (isset($_POST['UpdateDatabase'])){
 				$SQL = "DELETE FROM suppallocs WHERE id = '" . $AllocnItem->PrevAllocRecordID . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The existing allocation for') . ' ' . $AllocnItem->TransType .' ' . $AllocnItem->TypeNo . ' ' . _('could not be deleted because');
-				$DbgMsg = _('The following SQL to delete the allocation record was used');
 
-				$Result=DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', True);
 			 }
 
 			 if ($AllocnItem->OrigAlloc != $AllocnItem->AllocAmt){
@@ -136,10 +135,9 @@ if (isset($_POST['UpdateDatabase'])){
 												'" . $_SESSION['Alloc']->AllocTrans . "',
 												'" . $AllocnItem->ID . "')";
 
-						  $ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' .  _('The supplier allocation record for') . ' ' . $AllocnItem->TransType . ' ' .  $AllocnItem->TypeNo . ' ' ._('could not be inserted because');
-						  $DbgMsg = _('The following SQL to insert the allocation record was used');
+						 $ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' .  _('The supplier allocation record for') . ' ' . $AllocnItem->TransType . ' ' .  $AllocnItem->TypeNo . ' ' ._('could not be inserted because');
 
-					     $Result=DB_query($SQL, $ErrMsg, $DbgMsg, True);
+					     $Result = DB_query($SQL, $ErrMsg, '', True);
 				     }
 				     $NewAllocTotal = $AllocnItem->PrevAlloc + $AllocnItem->AllocAmt;
 
@@ -154,11 +152,9 @@ if (isset($_POST['UpdateDatabase'])){
 												settled = '" . $Settled . "'
 							WHERE id = '" . $AllocnItem->ID . "'";
 
-					  $ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction record could not be modified for the allocation against it because');
+					 $ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The debtor transaction record could not be modified for the allocation against it because');
 
-					  $DbgMsg = _('The following SQL to update the debtor transaction record was used');
-
-				     $Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+					 $Result = DB_query($SQL, $ErrMsg, '', True);
 
 			 } /*end if the new allocation is different to what it was before */
 
@@ -181,9 +177,7 @@ if (isset($_POST['UpdateDatabase'])){
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' .
 					 _('The supplier payment or credit note transaction could not be modified for the new allocation and exchange difference because');
 
-		$DbgMsg = _('The following SQL to update the payment or credit note was used');
-
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+		$Result = DB_query($SQL, $ErrMsg, '', True);
 
 		/*Almost there ... if there is a change in the total diff on exchange
 		 and if the GLLink to debtors is active - need to post diff on exchange to GL */
@@ -213,10 +207,8 @@ if (isset($_POST['UpdateDatabase'])){
 							'" . $MovtInDiffOnExch . "')";
 
 		      $ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL entry for the difference on exchange arising out of this allocation could not be inserted because');
-		      $DbgMsg = _('The following SQL to insert the GLTrans record was used');
 
-		      $Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
-
+		      $Result = DB_query($SQL, $ErrMsg, '', True);
 
 		      $SQL = "INSERT INTO gltrans (type,
 							typeno,
@@ -236,9 +228,7 @@ if (isset($_POST['UpdateDatabase'])){
 		      $ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ' : ' .
 		      			 _('The GL entry for the difference on exchange arising out of this allocation could not be inserted because');
 
-		      $DbgMsg = _('The following SQL to insert the GLTrans record was used');
-
-		      $Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+		      $Result = DB_query($SQL, $ErrMsg, '', True);
 
 		   }
 
@@ -358,9 +348,7 @@ if (isset($_GET['AllocTrans'])){
 
 	$ErrMsg = _('There was a problem retrieving the transactions available to allocate to');
 
-	$DbgMsg = _('The SQL that was used to retrieve the transaction information was');
-
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	while ($MyRow=DB_fetch_array($Result)){
 		$_SESSION['Alloc']->add_to_AllocsAllocn ($MyRow['id'],
@@ -401,9 +389,7 @@ if (isset($_GET['AllocTrans'])){
 
 	$ErrMsg = _('There was a problem retrieving the previously allocated transactions for modification');
 
-	$DbgMsg = _('The SQL that was used to retrieve the previously allocated transaction information was');
-
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	while ($MyRow = DB_fetch_array($Result)){
 

--- a/SupplierBalsAtPeriodEnd.php
+++ b/SupplierBalsAtPeriodEnd.php
@@ -145,7 +145,7 @@ $BookMark = '';
 			ORDER BY periodno DESC";
 
 	$ErrMsg = _('Could not retrieve period data because');
-	$Periods = DB_query($SQL,$ErrMsg);
+	$Periods = DB_query($SQL, $ErrMsg);
 
 	while ($MyRow = DB_fetch_array($Periods)){
 		echo '<option value="' . $MyRow['lastdate_in_period'] . '" selected="selected" >' . MonthAndYearFromSQLDate($MyRow['lastdate_in_period'],'M',-1) . '</option>';

--- a/SupplierContacts.php
+++ b/SupplierContacts.php
@@ -93,9 +93,8 @@ if (isset($_POST['submit'])) {
 	//run the SQL from either of the above possibilites
 	if ($InputError != 1) {
 		$ErrMsg = _('The supplier contact could not be inserted or updated because');
-		$DbgMsg = _('The SQL that was used but failed was');
 
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg($Msg,'success');
 
@@ -114,9 +113,8 @@ if (isset($_POST['submit'])) {
 			AND supplierid = '".$SupplierID."'";
 
 	$ErrMsg = _('The supplier contact could not be deleted because');
-	$DbgMsg = _('The SQL that was used but failed was');
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<br />' . _('Supplier contact has been deleted') . '<p />';
 

--- a/SupplierCredit.php
+++ b/SupplierCredit.php
@@ -88,9 +88,8 @@ if (isset($_GET['SupplierID']) and $_GET['SupplierID']!=''){
 				WHERE suppliers.supplierid = '" . $_GET['SupplierID'] . "'";
 
 	$ErrMsg = _('The supplier record selected') . ': ' . $_GET['SupplierID'] . ' ' ._('cannot be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the supplier details and failed was');
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_array($Result);
 
@@ -724,9 +723,7 @@ then do the updates and inserts to process the credit note entered */
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added because');
 
-				$DbgMsg = _('The following SQL to insert the GL transaction was used');
-
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', True);
 				InsertGLTags($EnteredGLCode->Tag);
 
 				$LocalTotal += ($EnteredGLCode->Amount/$_SESSION['SuppTrans']->ExRate);
@@ -753,9 +750,8 @@ then do the updates and inserts to process the credit note entered */
 									'" . -$ShiptChg->Amount/$_SESSION['SuppTrans']->ExRate . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the shipment') . ' ' . $ShiptChg->ShiptRef . ' ' . _('could not be added because');
-				$DbgMsg = _('The following SQL to insert the GL transaction was used');
 
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$LocalTotal += $ShiptChg->Amount/$_SESSION['SuppTrans']->ExRate;
 
@@ -778,8 +774,7 @@ then do the updates and inserts to process the credit note entered */
 										'" . mb_substr($_SESSION['SuppTrans']->SupplierID . ' ' . _('Asset Credit') . ' ' . $AssetAddition->AssetID . ': '  . $AssetAddition->Description, 0, 200) . "',
 										'" . -$AssetAddition->Amount/ $_SESSION['SuppTrans']->ExRate . "')";
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the asset addition could not be added because');
- 				$DbgMsg = _('The following SQL to insert the GL transaction was used');
- 				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+ 				$Result = DB_query($SQL, $ErrMsg, '', True);
 
  				$LocalTotal += $AssetAddition->Amount/ $_SESSION['SuppTrans']->ExRate;
 			}
@@ -813,9 +808,7 @@ then do the updates and inserts to process the credit note entered */
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the contract') . ' ' . $Contract->ContractRef . ' ' . _('could not be added because');
 
-				$DbgMsg = _('The following SQL to insert the GL transaction was used');
-
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', True);
 
 				$LocalTotal += ($Contract->Amount/ $_SESSION['SuppTrans']->ExRate);
 
@@ -847,12 +840,9 @@ then do the updates and inserts to process the credit note entered */
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added because');
 
-						$DbgMsg = _('The following SQL to insert the GL transaction was used');
-
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+						$Result = DB_query($SQL, $ErrMsg, '', True);
 
 					}
-
 
 				  $PurchPriceVar = $EnteredGRN->This_QuantityInv * (($EnteredGRN->ChgPrice  / $_SESSION['SuppTrans']->ExRate) - $EnteredGRN->StdCostUnit);
 					/*Yes but where to post this difference to - if its a stock item the variance account must be retrieved from the stock category record
@@ -906,10 +896,8 @@ then do the updates and inserts to process the credit note entered */
 															'" . (-$WriteOffToVariances) . "')";
 
 									$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added for the price variance of the stock item because');
-									$DbgMsg = _('The following SQL to insert the GL transaction was used');
 
-
-									$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+									$Result = DB_query($SQL, $ErrMsg, '', True);
 								}
 								/*Now post any remaining price variance to stock rather than price variances */
 
@@ -931,9 +919,8 @@ then do the updates and inserts to process the credit note entered */
 												'" . (-($PurchPriceVar - $WriteOffToVariances)) . "')";
 
 								$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added for the price variance of the stock item because');
-								$DbgMsg = _('The following SQL to insert the GL transaction was used');
 
-								$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+								$Result = DB_query($SQL, $ErrMsg, '', True);
 
 								/*Now to update the stock cost with the new weighted average */
 
@@ -943,7 +930,6 @@ then do the updates and inserts to process the credit note entered */
 
 
 								$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The cost could not be updated because');
-								$DbgMsg = _('The following SQL to update the cost was used');
 
 								if ($TotalQuantityOnHand>0) {
 
@@ -953,11 +939,11 @@ then do the updates and inserts to process the credit note entered */
 																	materialcost=materialcost-" . $CostIncrement . "
 											WHERE stockid='" . $EnteredGRN->ItemCode . "'";
 
-									$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+									$Result = DB_query($SQL, $ErrMsg, '', True);
 								} else {
 									$SQL = "UPDATE stockmaster SET lastcost=materialcost+overheadcost+labourcost,
 																	materialcost=" . ($EnteredGRN->ChgPrice  / $_SESSION['SuppTrans']->ExRate) . " WHERE stockid='" . $EnteredGRN->ItemCode . "'";
-									$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+									$Result = DB_query($SQL, $ErrMsg, '', True);
 								}
 								/* End of Weighted Average Costing Code */
 
@@ -979,9 +965,8 @@ then do the updates and inserts to process the credit note entered */
 														'" . (-$PurchPriceVar) . "')";
 
 								$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added for the price variance of the stock item because');
-								$DbgMsg = _('The following SQL to insert the GL transaction was used');
 
-								$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+								$Result = DB_query($SQL, $ErrMsg, '', True);
 							}
 						} else {
 
@@ -1019,8 +1004,7 @@ then do the updates and inserts to process the credit note entered */
 											'" . (-$PurchPriceVar) . "')";
 
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added for the price variance of the stock item because');
-							$DbgMsg = _('The following SQL to insert the GL transaction was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+							$Result = DB_query($SQL, $ErrMsg, '', True);
 						}
 					}
 				} else {
@@ -1045,8 +1029,7 @@ then do the updates and inserts to process the credit note entered */
 								)";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added because');
-					$DbgMsg = _('The following SQL to insert the GL transaction was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+					$Result = DB_query($SQL, $ErrMsg, '', True);
 				}
 
 				$LocalTotal += ($EnteredGRN->ChgPrice * $EnteredGRN->This_QuantityInv / $_SESSION['SuppTrans']->ExRate);
@@ -1077,9 +1060,7 @@ then do the updates and inserts to process the credit note entered */
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the tax could not be added because');
 
-					$DbgMsg = _('The following SQL to insert the GL transaction was used');
-
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+					$Result = DB_query($SQL, $ErrMsg, '', True);
 				}/* if the tax is not 0 */
 			} /*end of loop to post the tax */
 			/* Now the control account */
@@ -1100,8 +1081,7 @@ then do the updates and inserts to process the credit note entered */
 						'" . ($LocalTotal + ($TaxTotal / $_SESSION['SuppTrans']->ExRate)) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the control total could not be added because');
-			$DbgMsg = _('The following SQL to insert the GL transaction was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 
 		} /*Thats the end of the GL postings */
 
@@ -1132,8 +1112,7 @@ then do the updates and inserts to process the credit note entered */
 					'" . $_SESSION['SuppTrans']->Comments . "')";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The supplier credit note transaction could not be added to the database because');
-		$DbgMsg = _('The following SQL to insert the supplier credit note was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$SuppTransID = DB_Last_Insert_ID('supptrans','id');
 
@@ -1148,8 +1127,7 @@ then do the updates and inserts to process the credit note entered */
 											'" . -$TaxTotals->TaxOvAmount . "')";
 
 			$ErrMsg =_('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The supplier transaction taxes records could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the supplier transaction taxes record was used:');
- 			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 
 		/* Now update the GRN and PurchOrderDetails records for amounts invoiced
@@ -1161,15 +1139,13 @@ then do the updates and inserts to process the credit note entered */
 					WHERE podetailitem = '" . $EnteredGRN->PODetailItem ."'";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The quantity credited of the purchase order line could not be updated because');
-			$DbgMsg = _('The following SQL to update the purchase order details was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 
 			$SQL = "UPDATE grns SET quantityinv = quantityinv - " .
 					 $EnteredGRN->This_QuantityInv . " WHERE grnno = '" . $EnteredGRN->GRNNo . "'";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The quantity credited off the goods received record could not be updated because');
-			$DbgMsg = _('The following SQL to update the GRN quantity credited was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 
 			/*Update the shipment's accum value for the total local cost of shipment items being credited
 			the total value credited against shipments is apportioned between all the items on the shipment
@@ -1190,9 +1166,8 @@ then do the updates and inserts to process the credit note entered */
 													'" . (-$EnteredGRN->This_QuantityInv * $EnteredGRN->ChgPrice / $_SESSION['SuppTrans']->ExRate) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The shipment charge record for the shipment') . ' ' . $EnteredGRN->ShiptRef . ' ' . _('could not be added because');
-				$DbgMsg = _('The following SQL to insert the Shipment charge record was used');
 
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', True);
 			}
 			if ($EnteredGRN->AssetID!=0) { //then it is an asset
 				$PurchPriceVar = $EnteredGRN->This_QuantityInv * (($EnteredGRN->ChgPrice  / $_SESSION['SuppTrans']->ExRate) - $EnteredGRN->StdCostUnit);
@@ -1215,15 +1190,13 @@ then do the updates and inserts to process the credit note entered */
 											'cost',
 											'" . -($PurchPriceVar) . "')";
 					$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE The fixed asset transaction could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the fixed asset transaction record was used');
-					$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					/*Now update the asset cost in fixedassets table */
 					$SQL = "UPDATE fixedassets SET cost = cost - " . $PurchPriceVar  . "
 							WHERE assetid = '" . $EnteredGRN->AssetID . "'";
 					$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE. The fixed asset cost was not able to be updated because:');
-					$DbgMsg = _('The following SQL was used to attempt the update of the fixed asset cost:');
-					$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} //end if there is a cost difference on invoice compared to purchase order for the fixed asset
 			}//the line is a fixed asset
 		} /* end of the loop to do the updates for the quantity of order items the supplier has credited */
@@ -1244,8 +1217,7 @@ then do the updates and inserts to process the credit note entered */
 							)";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The shipment charge record for the shipment') . ' ' . $ShiptChg->ShiptRef . ' ' . _('could not be added because');
-			$DbgMsg = _('The following SQL to insert the Shipment charge record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 		}
 
 		/*Add contract charges records as necessary */
@@ -1272,8 +1244,7 @@ then do the updates and inserts to process the credit note entered */
 												'" . $Anticipated . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The contract charge record for contract') . ' ' . $Contract->ContractRef . ' ' . _('could not be added because');
-			$DbgMsg = _('The following SQL to insert the contract charge record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 		} //end of loop around contracts on credit note
 
 
@@ -1303,15 +1274,13 @@ then do the updates and inserts to process the credit note entered */
 											'cost',
 											'" . (-$AssetAddition->Amount  / $_SESSION['SuppTrans']->ExRate)  . "')";
 			$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE The fixed asset transaction could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the fixed asset transaction record was used');
-			$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/*Now update the asset cost in fixedassets table */
 			$SQL = "UPDATE fixedassets SET cost = cost - " . ($AssetAddition->Amount  / $_SESSION['SuppTrans']->ExRate) . "
 					WHERE assetid = '" . $AssetAddition->AssetID . "'";
 			$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE. The fixed asset cost  was not able to be updated because:');
-			$DbgMsg = _('The following SQL was used to attempt the update of the asset cost:');
-			$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		} //end of non-gl fixed asset stuff
 
 		DB_Txn_Commit();

--- a/SupplierGRNAndInvoiceInquiry.php
+++ b/SupplierGRNAndInvoiceInquiry.php
@@ -73,7 +73,7 @@ if (isset($_POST['Submit'])) {
 		LEFT JOIN suppinvstogrn ON grns.grnno=suppinvstogrn.grnno
 		WHERE supplierid='" . $SupplierID . "'" . $Where;
 	$ErrMsg = _('Failed to retrieve supplier invoice and grn data');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result)>0) {
 		echo '<table class="selection">
 			<thead>

--- a/SupplierInquiry.php
+++ b/SupplierInquiry.php
@@ -75,8 +75,7 @@ $SQL = "SELECT suppliers.suppname,
       			paymentterms.daysbeforedue,
       			paymentterms.dayinfollowingmonth";
 $ErrMsg = _('The supplier details could not be retrieved by the SQL because');
-$DbgMsg = _('The SQL that failed was');
-$SupplierResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+$SupplierResult = DB_query($SQL, $ErrMsg);
 
 if(DB_num_rows($SupplierResult) == 0) {
 
@@ -96,9 +95,8 @@ if(DB_num_rows($SupplierResult) == 0) {
 			WHERE suppliers.supplierid = '" . $SupplierID . "'";
 
 	$ErrMsg = _('The supplier details could not be retrieved by the SQL because');
-	$DbgMsg = _('The SQL that failed was');
 
-	$SupplierResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SupplierResult = DB_query($SQL, $ErrMsg);
 
 } else {
 	$NIL_BALANCE = False;
@@ -132,8 +130,7 @@ if(isset($_GET['HoldType']) AND isset($_GET['HoldTrans'])) {
 				AND transno='" . $_GET['HoldTrans'] . "'";
 	}
 	$ErrMsg = _('The Supplier Transactions could not be updated because');
-	$DbgMsg = _('The SQL that failed was');
-	$UpdateResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$UpdateResult = DB_query($SQL, $ErrMsg);
 }
 
 echo '<table class="selection">
@@ -187,8 +184,7 @@ $SQL = "SELECT supptrans.id,
 		AND supptrans.trandate >= '" . $DateAfterCriteria . "'
 		ORDER BY supptrans.trandate";
 $ErrMsg = _('No transactions were returned by the SQL because');
-$DbgMsg = _('The SQL that failed was');
-$TransResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+$TransResult = DB_query($SQL, $ErrMsg);
 
 if(DB_num_rows($TransResult) == 0) {
 	echo '<br /><div class="centre">' . _('There are no transactions to display since') . ' ' . $_POST['TransAfterDate'];

--- a/SupplierInvoice.php
+++ b/SupplierInvoice.php
@@ -81,9 +81,8 @@ if (isset($_GET['SupplierID']) AND $_GET['SupplierID'] != '') {
 				AND suppliers.supplierid = '" . $_GET['SupplierID'] . "'";
 
 	$ErrMsg = _('The supplier record selected') . ': ' . $_GET['SupplierID'] . ' ' . _('cannot be retrieved because');
-	$DbgMsg = _('The SQL used to retrieve the supplier details and failed was');
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	$MyRow = DB_fetch_array($Result);
 
@@ -189,8 +188,7 @@ if (isset($_GET['ReceivePO']) AND $_GET['ReceivePO'] != '') {
 									FROM stockmaster
 									WHERE stockid='" . $OrderLine->StockID . "'";
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The standard cost of the item being received cannot be retrieved because');
-						$DbgMsg = _('The following SQL to retrieve the standard cost was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						$MyRow = DB_fetch_row($Result);
 						$CurrentStandardCost = $MyRow[0];
@@ -229,8 +227,7 @@ if (isset($_GET['ReceivePO']) AND $_GET['ReceivePO'] != '') {
 												WHERE podetailitem = '" . $OrderLine->PODetailRec . "'";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The purchase order detail record could not be updated with the quantity received because');
-					$DbgMsg = _('The following SQL to update the purchase order detail record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					if ($OrderLine->StockID != '') { /*Its a stock item so use the standard cost for the journals */
 						$UnitCost = $CurrentStandardCost;
@@ -259,8 +256,7 @@ if (isset($_GET['ReceivePO']) AND $_GET['ReceivePO'] != '') {
 										'" . $CurrentStandardCost . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('A GRN record could not be inserted') . '. ' . _('This receipt of goods has not been processed because');
-					$DbgMsg = _('The following SQL to insert the GRN record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					if ($OrderLine->StockID != '') { /* if the order line is in fact a stock item */
 
@@ -288,8 +284,7 @@ if (isset($_GET['ReceivePO']) AND $_GET['ReceivePO'] != '') {
 								AND loccode = '" . $_SESSION['PO' . $identifier]->Location . "'";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-						$DbgMsg = _('The following SQL to update the location stock record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						/* Insert stock movements - with unit cost */
 
@@ -322,8 +317,7 @@ if (isset($_GET['ReceivePO']) AND $_GET['ReceivePO'] != '') {
 												)";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('stock movement records could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the stock movement records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					} /*end of its a stock item - updates to locations and insert movements*/
 
@@ -356,8 +350,7 @@ if (isset($_GET['ReceivePO']) AND $_GET['ReceivePO'] != '') {
 													'" . _('cost') . "',
 													'" . $CurrentStandardCost * $OrderLine->ReceiveQty . "')";
 							$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE The fixed asset transaction could not be inserted because');
-							$DbgMsg = _('The following SQL to insert the fixed asset transaction record was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 
 							/*Now get the correct cost GL account from the asset category */
 							$AssetRow = DB_fetch_array($CheckAssetExistsResult);
@@ -379,8 +372,7 @@ if (isset($_GET['ReceivePO']) AND $_GET['ReceivePO'] != '') {
 											WHERE assetid = '" . $OrderLine->AssetID . "'";
 							}
 							$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE. The fixed asset cost and date purchased was not able to be updated because:');
-							$DbgMsg = _('The following SQL was used to attempt the update of the cost and the date the asset was purchased');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						} //assetid provided doesn't exist so ignore it and treat as a normal nominal item
 
@@ -408,8 +400,7 @@ if (isset($_GET['ReceivePO']) AND $_GET['ReceivePO'] != '') {
 												)";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The purchase GL posting could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the purchase GLTrans record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						/* If the CurrentStandardCost != UnitCost (the standard at the time the first delivery was booked in,  and its a stock item, then the difference needs to be booked in against the purchase price variance account */
 
@@ -431,8 +422,7 @@ if (isset($_GET['ReceivePO']) AND $_GET['ReceivePO'] != '') {
 												)";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GRN suspense side of the GL posting could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the GRN Suspense GLTrans record was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					} /* end of if GL and stock integrated and standard cost !=0 */
 				} /*end of OrderLine loop */
@@ -1061,8 +1051,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 				AND supptrans.suppreference='" . $_POST['SuppReference'] . "'";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The sql to check for the previous entry of the same invoice failed');
-		$DbgMsg = _('The following SQL to test for a previous invoice with the same reference from the same supplier was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+		$Result = DB_query($SQL, $ErrMsg, '', True);
 
 		$MyRow = DB_fetch_row($Result);
 		if ($MyRow[0] == 1) { /*Transaction reference already entered */
@@ -1134,9 +1123,8 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 										'" . $EnteredGLCode->Amount / $_SESSION['SuppTrans']->ExRate . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added because');
-				$DbgMsg = _('The following SQL to insert the GL transaction was used');
 
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				InsertGLTags($EnteredGLCode->Tag);
 
 				$LocalTotal += $EnteredGLCode->Amount / $_SESSION['SuppTrans']->ExRate;
@@ -1164,9 +1152,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the shipment') . ' ' . $ShiptChg->ShiptRef . ' ' . _('could not be added because');
 
-				$DbgMsg = _('The following SQL to insert the GL transaction was used');
-
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$LocalTotal += $ShiptChg->Amount / $_SESSION['SuppTrans']->ExRate;
 
@@ -1189,8 +1175,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 									'" . mb_substr($_SESSION['SuppTrans']->SupplierID . ' ' . _('Asset Addition') . ' ' . $AssetAddition->AssetID . ': ' . $AssetAddition->Description, 0, 200) . "',
 									'" . ($AssetAddition->Amount / $_SESSION['SuppTrans']->ExRate) . "')";
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the asset addition could not be added because');
-				$DbgMsg = _('The following SQL to insert the GL transaction was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', True);
 
 				$LocalTotal += ($AssetAddition->Amount / $_SESSION['SuppTrans']->ExRate);
 			}
@@ -1221,8 +1206,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 											'" . mb_substr($_SESSION['SuppTrans']->SupplierID . ' ' . _('Contract charge against') . ' ' . $Contract->ContractRef, 0, 200) . "',
 											'" . ($Contract->Amount / $_SESSION['SuppTrans']->ExRate) . "')";
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the contract') . ' ' . $Contract->ContractRef . ' ' . _('could not be added because');
-				$DbgMsg = _('The following SQL to insert the GL transaction was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', True);
 				$LocalTotal += ($Contract->Amount / $_SESSION['SuppTrans']->ExRate);
 			}
 
@@ -1252,8 +1236,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 								 	'" . ($EnteredGRN->StdCostUnit * $EnteredGRN->This_QuantityInv) . "')";
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added because');
-						$DbgMsg = _('The following SQL to insert the GL transaction was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+						$Result = DB_query($SQL, $ErrMsg, '', True);
 					}
 
 					$PurchPriceVar = $EnteredGRN->This_QuantityInv * (($EnteredGRN->ChgPrice / $_SESSION['SuppTrans']->ExRate) - $EnteredGRN->StdCostUnit);
@@ -1310,9 +1293,8 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 															'" . $WriteOffToVariances . "')";
 
 									$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added for the price variance of the stock item because');
-									$DbgMsg = _('The following SQL to insert the GL transaction was used');
 
-									$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+									$Result = DB_query($SQL, $ErrMsg, '', True);
 								} // end if the quantity being invoiced here is greater than the current stock on hand
 								/*Now post any remaining price variance to stock rather than price variances */
 
@@ -1332,9 +1314,8 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 													'" . ($PurchPriceVar - $WriteOffToVariances) . "')";
 
 								$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added for the price variance of the stock item because');
-								$DbgMsg = _('The following SQL to insert the GL transaction was used');
 
-								$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+								$Result = DB_query($SQL, $ErrMsg, '', True);
 
 							}
 							else { //It must be Standard Costing
@@ -1354,8 +1335,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 														'" . $PurchPriceVar . "')";
 
 								$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added for the price variance of the stock item because');
-								$DbgMsg = _('The following SQL to insert the GL transaction was used');
-								$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+								$Result = DB_query($SQL, $ErrMsg, '', True);
 							}
 						}
 						else {
@@ -1391,8 +1371,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added for the price variance of the stock item because');
 
-							$DbgMsg = _('The following SQL to insert the GL transaction was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+							$Result = DB_query($SQL, $ErrMsg, '', True);
 						}
 					}
 
@@ -1416,8 +1395,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 											'" . (($EnteredGRN->ChgPrice * $EnteredGRN->This_QuantityInv) / $_SESSION['SuppTrans']->ExRate) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction could not be added because');
-					$DbgMsg = _('The following SQL to insert the GL transaction was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+					$Result = DB_query($SQL, $ErrMsg, '', True);
 				}
 				$LocalTotal += ($EnteredGRN->ChgPrice * $EnteredGRN->This_QuantityInv) / $_SESSION['SuppTrans']->ExRate;
 			} /* end of GRN postings */
@@ -1446,8 +1424,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 												'" . ($Tax->TaxOvAmount / $_SESSION['SuppTrans']->ExRate) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the tax could not be added because');
-					$DbgMsg = _('The following SQL to insert the GL transaction was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+					$Result = DB_query($SQL, $ErrMsg, '', True);
 				}
 
 			} /*end of loop to post the tax */
@@ -1469,8 +1446,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 									'" . -($LocalTotal + ($TaxTotal / $_SESSION['SuppTrans']->ExRate)) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The general ledger transaction for the control total could not be added because');
-			$DbgMsg = _('The following SQL to insert the GL transaction was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 
 			EnsureGLEntriesBalance(20, $InvoiceNo);
 		} /*Thats the end of the GL postings */
@@ -1502,8 +1478,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 								'" . Date('Y-m-d') . "')";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The supplier invoice transaction could not be added to the database because');
-		$DbgMsg = _('The following SQL to insert the supplier invoice was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+		$Result = DB_query($SQL, $ErrMsg, '', True);
 		$SuppTransID = DB_Last_Insert_ID('supptrans', 'id');
 
 		/* Insert the tax totals for each tax authority where tax was charged on the invoice */
@@ -1518,8 +1493,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 										'" . $TaxTotals->TaxOvAmount . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The supplier transaction taxes records could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the supplier transaction taxes record was used:');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		}
 
 		/* Now update the GRN and PurchOrderDetails records for amounts invoiced  - can't use the other loop through the GRNs as this was only where the GL link to credtors is active */
@@ -1537,24 +1511,20 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The quantity invoiced of the purchase order line could not be updated because');
 
-			$DbgMsg = _('The following SQL to update the purchase order details was used');
-
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 
 			$SQL = "UPDATE grns
 					SET quantityinv = quantityinv + " . $EnteredGRN->This_QuantityInv . "
 					WHERE grnno = '" . $EnteredGRN->GRNNo . "'";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The quantity invoiced off the goods received record could not be updated because');
-			$DbgMsg = _('The following SQL to update the GRN quantity invoiced was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 
 			$SQL = "INSERT INTO suppinvstogrn VALUES ('" . $InvoiceNo . "',
 									'" . $EnteredGRN->GRNNo . "')";
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The invoice could not be mapped to the
 					goods received record because');
-			$DbgMsg = _('The following SQL to map the invoice to the GRN was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			if (mb_strlen($EnteredGRN->ShiptRef) > 0 AND $EnteredGRN->ShiptRef != '0') {
 				/* insert the shipment charge records */
@@ -1571,8 +1541,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 											'" . ($EnteredGRN->This_QuantityInv * $EnteredGRN->ChgPrice) / $_SESSION['SuppTrans']->ExRate . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The shipment charge record for the shipment') . ' ' . $EnteredGRN->ShiptRef . ' ' . _('could not be added because');
-				$DbgMsg = _('The following SQL to insert the Shipment charge record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+				$Result = DB_query($SQL, $ErrMsg, '', True);
 
 			} //end of adding GRN shipment charges
 			else {
@@ -1603,7 +1572,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 											AND loccode='" . $LocCode . "'
 											AND transno='" . $EnteredGRN->GRNBatchNo . "'";
 
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+						$Result = DB_query($SQL, $ErrMsg, '', True);
 
 						if ($_SESSION['WeightedAverageCosting'] == 1) {
 							/*
@@ -1666,7 +1635,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 																			AND area='" . $SalesAnalRow['area'] . "'
 																			AND salesperson='" . $SalesAnalRow['salesperson'] . "'
 																			AND stkcategory='" . $SalesAnalRow['stkcategory'] . "'
-																			AND budgetoractual=1", $ErrMsg, $DbgMsg, True);
+																			AND budgetoractual=1", $ErrMsg, '', True);
 										}
 									} //end if there were sales in that period
 									$PeriodAllocated--; //decrement the period
@@ -1698,7 +1667,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 										if ($StkMoveRow['type'] == 10) { //its a sales invoice
 											$Result = DB_query("UPDATE stockmoves
 																SET standardcost = '" . $ActualCost . "'
-																WHERE stkmoveno = '" . $StkMoveRow['stkmoveno'] . "'", $ErrMsg, $DbgMsg, True);
+																WHERE stkmoveno = '" . $StkMoveRow['stkmoveno'] . "'", $ErrMsg, '', True);
 										}
 									}
 									else { //Only $QuantityVarianceAllocated left to allocate so need need to apportion cost using weighted average
@@ -1707,7 +1676,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 
 											$UpdStkMovesResult = DB_query("UPDATE stockmoves
 																SET standardcost = '" . $WACost . "'
-																WHERE stkmoveno = '" . $StkMoveRow['stkmoveno'] . "'", $ErrMsg, $DbgMsg, True);
+																WHERE stkmoveno = '" . $StkMoveRow['stkmoveno'] . "'", $ErrMsg, '', True);
 										}
 									}
 									$QuantityVarianceAllocated += $StkMoveRow['qty'];
@@ -1720,7 +1689,6 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 							A nicety or important?? */
 
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The cost could not be updated because');
-							$DbgMsg = _('The following SQL to update the cost was used');
 
 							if ($TotalQuantityOnHand > 0) {
 
@@ -1730,7 +1698,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 										SET lastcost=materialcost+overheadcost+labourcost,
 										materialcost=materialcost+" . $CostIncrement . "
 										WHERE stockid='" . $EnteredGRN->ItemCode . "'";
-								$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+								$Result = DB_query($SQL, $ErrMsg, '', True);
 							}
 							else {
 								/* if stock is negative then update the cost to this cost */
@@ -1738,7 +1706,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 										SET lastcost=materialcost+overheadcost+labourcost,
 											materialcost='" . $ActualCost . "'
 										WHERE stockid='" . $EnteredGRN->ItemCode . "'";
-								$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+								$Result = DB_query($SQL, $ErrMsg, '', True);
 							}
 						} /* End if it is weighted average costing we are working with */
 					} /*Its a stock item */
@@ -1764,16 +1732,14 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 													'cost',
 													'" . ($PurchPriceVar) . "')";
 					$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE The fixed asset transaction could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the fixed asset transaction record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					/*Now update the asset cost in fixedassets table */
 					$SQL = "UPDATE fixedassets SET cost = cost + " . ($PurchPriceVar) . "
 							WHERE assetid = '" . $EnteredGRN->AssetID . "'";
 
 					$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE. The fixed asset cost could not be updated because:');
-					$DbgMsg = _('The following SQL was used to attempt the update of the asset cost:');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				} //end if there was a difference in the cost
 
 			} //the item was an asset received on a purchase order
@@ -1794,9 +1760,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The shipment charge record for the shipment') . ' ' . $ShiptChg->ShiptRef . ' ' . _('could not be added because');
 
-			$DbgMsg = _('The following SQL to insert the Shipment charge record was used');
-
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 
 		}
 		/*Add contract charges records as necessary */
@@ -1823,8 +1787,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 										'" . $Anticipated . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The contract charge record for contract') . ' ' . $Contract->ContractRef . ' ' . _('could not be added because');
-			$DbgMsg = _('The following SQL to insert the contract charge record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, True);
+			$Result = DB_query($SQL, $ErrMsg, '', True);
 		}
 
 		foreach ($_SESSION['SuppTrans']->Assets as $AssetAddition) {
@@ -1853,8 +1816,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 											'" . _('cost') . "',
 											'" . ($AssetAddition->Amount / $_SESSION['SuppTrans']->ExRate) . "')";
 			$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE The fixed asset transaction could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the fixed asset transaction record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/*Now update the asset cost in fixedassets table */
 			$Result = DB_query("SELECT datepurchased
@@ -1868,8 +1830,7 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 			}
 			$SQL .= " WHERE assetid = '" . $AssetAddition->AssetID . "'";
 			$ErrMsg = _('CRITICAL ERROR! NOTE DOWN THIS ERROR AND SEEK ASSISTANCE. The fixed asset cost and date purchased was not able to be updated because:');
-			$DbgMsg = _('The following SQL was used to attempt the update of the cost and the date the asset was purchased');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		} //end of non-gl fixed asset stuff
 		DB_Txn_Commit();
 

--- a/SupplierPriceList.php
+++ b/SupplierPriceList.php
@@ -214,8 +214,7 @@ if(isset($_POST['Search']) OR isset($_POST['Go']) OR isset($_POST['Next']) OR is
 		}
 	}
 	$ErrMsg = _('No stock items were returned by the SQL because');
-	$DbgMsg = _('The SQL that returned an error was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 	if(DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('No stock items were returned by this search please re-enter alternative criteria to try again'), 'info');
 	}
@@ -316,7 +315,7 @@ foreach ($_POST as $key=>$Value) {
 			$Preferred = 1;
 			$PreferredSQL = "UPDATE purchdata SET preferred=0
 									WHERE stockid='" . $StockID . "'";
-			$PreferredResult=DB_query($PreferredSQL);
+			$PreferredResult = DB_query($PreferredSQL);
 		} else {
 			$Preferred = 0;
 		}
@@ -334,7 +333,7 @@ foreach ($_POST as $key=>$Value) {
 									minorderqty='" . $MinOrderQty . "'
 								WHERE supplierno='" . $_POST['SupplierID'] . "'
 								AND stockid='" . $StockID . "'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 	}
 	if(mb_substr($key,0,6)=='Insert') {
 		if(isset($_POST['Preferred0'])) {
@@ -366,7 +365,7 @@ foreach ($_POST as $key=>$Value) {
 									'" . $_POST['SupplierPartNo0'] . "',
 									'" . $_POST['MinOrderQty0'] . "'
 								)";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 	}
 }
 
@@ -379,8 +378,7 @@ if(isset($_GET['SupplierID'])) {
 if(isset($SupplierID) AND $SupplierID != '' AND !isset($_POST['SearchSupplier'])) { /*NOT EDITING AN EXISTING BUT SUPPLIER selected OR ENTERED*/
 	$SQL = "SELECT suppliers.suppname, suppliers.currcode FROM suppliers WHERE supplierid='".$SupplierID."'";
 	$ErrMsg = _('The supplier details for the selected supplier could not be retrieved because');
-	$DbgMsg = _('The SQL that failed was');
-	$SuppSelResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SuppSelResult = DB_query($SQL, $ErrMsg);
 	if(DB_num_rows($SuppSelResult) == 1) {
 		$MyRow = DB_fetch_array($SuppSelResult);
 		$SuppName = $MyRow['suppname'];
@@ -449,8 +447,7 @@ if(isset($_POST['SearchSupplier'])) {
 			WHERE suppliers.supplierid " . LIKE . " '%" . $_POST['SupplierCode'] . "%'";
 	} //one of keywords or SupplierCode was more than a zero length string
 	$ErrMsg = _('The suppliers matching the criteria entered could not be retrieved because');
-	$DbgMsg = _('The SQL to retrieve supplier details that failed was');
-	$SuppliersResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SuppliersResult = DB_query($SQL, $ErrMsg);
 } //end of if search
 
 if(isset($SuppliersResult)) {
@@ -514,7 +511,7 @@ if(isset($_POST['SupplierID'])) {
 			ON purchdata.stockid=stockmaster.stockid
 			WHERE supplierno='".$_POST['SupplierID']."'
 			ORDER BY purchdata.stockid, effectivefrom DESC";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 
 	$UOMSQL = "SELECT unitid,
 						unitname

--- a/SupplierTenderCreate.php
+++ b/SupplierTenderCreate.php
@@ -804,8 +804,7 @@ if (isset($_POST['Search'])) { /*ie seach for stock items */
 	}
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL statement that failed was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult) == 0 and $Debug == 1) {
 		prnMsg(_('There are no products to display matching the criteria provided'), 'warn');

--- a/SupplierTenders.php
+++ b/SupplierTenders.php
@@ -23,7 +23,7 @@ if (empty($_GET['identifier'])) {
 
 if (!isset($_POST['SupplierID'])) {
 	$SQL="SELECT supplierid FROM www_users WHERE userid='" . $_SESSION['UserID'] . "'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow=DB_fetch_array($Result);
 	if ($MyRow['supplierid']=='') {
 		prnMsg(_('This functionality can only be accessed via a supplier login.'), 'warning');
@@ -44,7 +44,7 @@ $SQL="SELECT suppname,
 			currcode
 		FROM suppliers
 		WHERE supplierid='" . $_POST['SupplierID'] . "'";
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 $MyRow=DB_fetch_array($Result);
 $Supplier=$MyRow['suppname'];
 $Currency=$MyRow['currcode'];
@@ -56,7 +56,7 @@ if (isset($_POST['Confirm'])) {
 			SET responded=1
 			WHERE supplierid='" . $_SESSION['offer'.$identifier]->SupplierID . "'
 			AND tenderid='" . $_SESSION['offer'.$identifier]->TenderID . "'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 }
 
 if (isset($_POST['Process'])) {
@@ -104,10 +104,10 @@ if (isset($_POST['Process'])) {
 					ON tenders.location=locations.loccode
 					WHERE closed=0
 					AND tenderid='".$_SESSION['offer'.$identifier]->TenderID."'";
-	$LocationResult=DB_query($LocationSQL);
+	$LocationResult = DB_query($LocationSQL);
 	$MyLocationRow=DB_fetch_row($LocationResult);
 	$CurrencySQL="SELECT decimalplaces from currencies WHERE currabrev='".$_SESSION['offer'.$identifier]->CurrCode."'";
-	$CurrencyResult=DB_query($CurrencySQL);
+	$CurrencyResult = DB_query($CurrencySQL);
 	$CurrencyRow=DB_fetch_array($CurrencyResult);
 	echo '<tr>
 			<td valign="top" style="background-color:#cccce5">' . _('Deliver To') . ':</td>
@@ -191,7 +191,7 @@ if (isset($_POST['NewItem']) AND !isset($_POST['Refresh'])) {
 			$UOM=$_POST['uom'.$Index];
 			if (isset($UOM) AND $Quantity>0) {
 				$SQL="SELECT description, decimalplaces FROM stockmaster WHERE stockid='".$StockID."'";
-				$Result=DB_query($SQL);
+				$Result = DB_query($SQL);
 				$MyRow=DB_fetch_array($Result);
 				$_SESSION['offer'.$identifier]->add_to_offer($_SESSION['offer'.$identifier]->LinesOnOffer,
 												$StockID,
@@ -299,7 +299,7 @@ if (isset($_POST['TenderType']) AND $_POST['TenderType']==1 AND !isset($_POST['R
 				ON offers.stockid=stockmaster.stockid
 			WHERE offers.supplierid='" . $_POST['SupplierID'] . "'
 				AND offers.expirydate >= CURRENT_DATE";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$_SESSION['offer'.$identifier]=new Offer($_POST['SupplierID']);
 	$_SESSION['offer'.$identifier]->CurrCode=$Currency;
 	while ($MyRow=DB_fetch_array($Result)) {
@@ -460,7 +460,7 @@ if (isset($_POST['TenderType'])
 			AND tenders.closed=0
 			AND tendersuppliers.responded=0
 			ORDER BY tendersuppliers.tenderid";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	echo '<table class="selection">';
 	echo '<tr>
 			<th colspan="13"><font size="3" color="#616161">' . _('Outstanding Tenders Waiting For Offer') . '</font></th>
@@ -483,7 +483,7 @@ if (isset($_POST['TenderType'])
 						ON tenders.location=locations.loccode
 						WHERE closed=0
 						AND tenderid='".$MyRow[0]."'";
-		$LocationResult=DB_query($LocationSQL);
+		$LocationResult = DB_query($LocationSQL);
 		$MyLocationRow=DB_fetch_row($LocationResult);
 		echo '<tr>
 				<td valign="top" style="background-color:#cccce5">' . _('Deliver To') . ':</td>
@@ -516,7 +516,7 @@ if (isset($_POST['TenderType'])
 					LEFT JOIN tenders
 					ON tenders.tenderid=tenderitems.tenderid
 					WHERE tenderitems.tenderid='" . $MyRow[0] . "'";
-		$ItemResult=DB_query($ItemSQL);
+		$ItemResult = DB_query($ItemSQL);
 		echo '<tr>
 				<th>' . stripslashes($_SESSION['CompanyRecord']['coyname']) . '<br />' . _('Item Code') . '</th>
 				<th>' . _('Item Description') . '</th>
@@ -658,8 +658,7 @@ if (isset($_POST['Search'])){  /*ie seach for stock items */
 	}
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL statement that failed was');
-	$SearchResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult)==0 AND $Debug==1){
 		prnMsg( _('There are no products to display matching the criteria provided'),'warn');

--- a/SupplierTransInquiry.php
+++ b/SupplierTransInquiry.php
@@ -108,7 +108,6 @@ if (isset($_POST['ShowResults']) && $_POST['TransType'] != ''){
 
    $TransResult = DB_query($SQL);
    $ErrMsg = _('The supplier transactions for the selected criteria could not be retrieved because') . ' - ' . DB_error_msg();
-   $DbgMsg =  _('The SQL that failed was');
 
    echo '<table class="selection">';
 

--- a/Suppliers.php
+++ b/Suppliers.php
@@ -513,9 +513,8 @@ if (isset($_POST['submit'])) {
 			}
 
 			$ErrMsg = _('The supplier could not be updated because');
-			$DbgMsg = _('The SQL that was used to update the supplier but failed was');
 			// echo $SQL;
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			prnMsg(_('The supplier master record for') . ' ' . $SupplierID . ' ' . _('has been updated'), 'success');
 
@@ -582,9 +581,8 @@ if (isset($_POST['submit'])) {
 									'" . $_POST['DefaultGL'] . "'
 								)";
 			$ErrMsg = _('The supplier') . ' ' . $_POST['SuppName'] . ' ' . _('could not be added because');
-			$DbgMsg = _('The SQL that was used to insert the supplier but failed was');
 
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			prnMsg(_('A new supplier for') . ' ' . $_POST['SuppName'] . ' ' . _('has been added to the database'), 'success');
 

--- a/SystemParameters.php
+++ b/SystemParameters.php
@@ -401,11 +401,11 @@ if (isset($_POST['submit'])) {
 		if (sizeof($SQL) > 1 ) {
 			DB_Txn_Begin();
 			foreach ($SQL as $Line) {
-				$Result = DB_query($Line,$ErrMsg);
+				$Result = DB_query($Line, $ErrMsg);
 			}
 			DB_Txn_Commit();
 		} elseif(sizeof($SQL)==1) {
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 		}
 
 		prnMsg( _('System configuration updated'),'success');
@@ -733,7 +733,7 @@ echo '<field>
 // DefaultPriceList
 $SQL = "SELECT typeabbrev, sales_type FROM salestypes ORDER BY sales_type";
 $ErrMsg = _('Could not load price lists');
-$Result = DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 echo '<field>
 		<label for="X_DefaultPriceList">' . _('Default Price List') . ':</label>
 		<select name="X_DefaultPriceList">';
@@ -751,7 +751,7 @@ echo '</select>
 // Default_Shipper
 $SQL = "SELECT shipper_id, shippername FROM shippers ORDER BY shippername";
 $ErrMsg = _('Could not load shippers');
-$Result = DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 echo '<field>
 		<label for="X_Default_Shipper">' . _('Default Shipper') . ':</label>
 		<select name="X_Default_Shipper">';
@@ -818,7 +818,7 @@ echo '</select>
 //==HJ== drop down list for tax category
 $SQL = "SELECT taxcatid, taxcatname FROM taxcategories ORDER BY taxcatname";
 $ErrMsg = _('Could not load tax categories table');
-$Result = DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 echo '<field>
 		<label for="X_DefaultTaxCategory">' . _('Default Tax Category') . ':</label>
 		<select name="X_DefaultTaxCategory">';
@@ -1159,7 +1159,7 @@ echo '<field>
 		<select name="X_ProhibitPostingsBefore">';
 $SQL = "SELECT lastdate_in_period FROM periods ORDER BY periodno DESC";
 $ErrMsg = _('Could not load periods table');
-$Result = DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 if ($_SESSION['ProhibitPostingsBefore']=='' OR $_SESSION['ProhibitPostingsBefore']=='1900-01-01' OR !isset($_SESSION['ProhibitPostingsBefore'])){
 	echo '<option selected="selected" value="1900-01-01">' . ConvertSQLDate('1900-01-01') . '</option>';
 }
@@ -1279,7 +1279,7 @@ echo '<field>
 
 $SQL = "SELECT loccode,locationname FROM locations";
 $ErrMsg = _('Could not load locations table');
-$Result = DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 while ($LocationRow = DB_fetch_array($Result)){
 	if ($_SESSION['DefaultFactoryLocation']==$LocationRow['loccode']){
 		echo  '<option selected="selected" value="' . $LocationRow['loccode'] . '">' . $LocationRow['locationname'] . '</option>';

--- a/TaxAuthorities.php
+++ b/TaxAuthorities.php
@@ -42,7 +42,7 @@ if(isset($_POST['submit'])) {
 				WHERE taxid = '" . $SelectedTaxAuthID . "'";
 
 		$ErrMsg = _('The update of this tax authority failed because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$Msg = _('The tax authority for record has been updated');
 
@@ -69,7 +69,7 @@ if(isset($_POST['submit'])) {
 				)";
 
 		$Errmsg = _('The addition of this tax authority failed because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		$Msg = _('The new tax authority record has been added to the database');
 
@@ -136,8 +136,7 @@ if(!isset($SelectedTaxAuthID)) {
 			FROM taxauthorities";
 
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The defined tax authorities could not be retrieved because');
-	$DbgMsg = _('The following SQL to retrieve the tax authorities was used');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 		<thead>

--- a/TaxCategories.php
+++ b/TaxCategories.php
@@ -61,7 +61,7 @@ if(isset($_POST['submit'])) {
 						SET taxcatname='" . $_POST['TaxCategoryName'] . "'
 						WHERE taxcatname ".LIKE." '".$OldTaxCategoryName."'";
 				$ErrMsg = _('The tax category could not be updated');
-				$Result = DB_query($SQL,$ErrMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 			} else {
 				$InputError = 1;
 				prnMsg( _('The tax category no longer exists'),'error');
@@ -85,7 +85,7 @@ if(isset($_POST['submit'])) {
 						'" . $_POST['TaxCategoryName'] ."'
 						)";
 			$ErrMsg = _('The new tax category could not be added');
-			$Result = DB_query($SQL,$ErrMsg,true);
+			$Result = DB_query($SQL, $ErrMsg,true);
 
 			$LastTaxCatID = DB_Last_Insert_ID('taxcategories','taxcatid');
 
@@ -96,7 +96,7 @@ if(isset($_POST['submit'])) {
  					taxprovinces.taxprovinceid,
 					'" . $LastTaxCatID . "'
 				FROM taxauthorities CROSS JOIN taxprovinces";
-			$Result = DB_query($SQL,$ErrMsg,true);
+			$Result = DB_query($SQL, $ErrMsg,true);
 
 			DB_Txn_Commit();
 		}
@@ -160,7 +160,7 @@ if(isset($_POST['submit'])) {
 			ORDER BY taxcatid";
 
 	$ErrMsg = _('Could not get tax categories because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 		<thead>

--- a/TaxGroups.php
+++ b/TaxGroups.php
@@ -81,7 +81,7 @@ if(isset($_POST['submit']) OR isset($_GET['remove']) OR isset($_GET['add']) ) {
 	}
 	// Need to exec the query
 	if(isset($SQL) AND $InputError != 1 ) {
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		if( $Result ) {
 			prnMsg( $SuccessMsg,'success');
 		}

--- a/TaxProvinces.php
+++ b/TaxProvinces.php
@@ -157,7 +157,7 @@ or deletion of the records*/
 			ORDER BY taxprovinceid";
 
 	$ErrMsg = _('Could not get tax categories because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 		<thead>

--- a/TestPlanResults.php
+++ b/TestPlanResults.php
@@ -119,8 +119,7 @@ if (isset($_GET['CopyResults']) OR isset($_POST['CopyResults'])) {
 			}
 
 			$ErrMsg = _('No stock items were returned by the SQL because');
-			$DbgMsg = _('The SQL used to retrieve the searched parts was');
-			$StockItemsResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$StockItemsResult = DB_query($SQL, $ErrMsg);
 		}
 
 		if (true or !isset($LotNumber) or $LotNumber == "") { //revisit later, right now always show all inputs
@@ -334,8 +333,7 @@ if (isset($_GET['CopyResults']) OR isset($_POST['CopyResults'])) {
 					WHERE sampleresults.sampleid='" .$SelectedSampleID. "'";
 		$Msg = _('Test Results have been copied to sample') . ' ' . $_POST['CopyToSampleID']  . ' from sample' . ' ' . $SelectedSampleID ;
 		$ErrMsg = _('The insert of the test results failed because');
-		$DbgMsg = _('The SQL that was used and failed was');
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		while ($MyRow = DB_fetch_array($Result)) {
 			$Result2 = DB_query("SELECT count(testid) FROM prodspecs
@@ -413,8 +411,7 @@ if (isset($_GET['CopyResults']) OR isset($_POST['CopyResults'])) {
 								AND resultid='".$MyRow2[0]."'";
 					$Msg = _('Test Results have been overwritten to sample') . ' ' . $_POST['CopyToSampleID']  . _(' from sample') . ' ' . $SelectedSampleID  . _(' for test ') . $MyRow['testid'];
 					$ErrMsg = _('The insert of the test results failed because');
-					$DbgMsg = _('The SQL that was used and failed was');
-					$UpdResult = DB_query($UpdSQLl,$ErrMsg, $DbgMsg);
+					$UpdResult = DB_query($UpdSQLl, $ErrMsg);
 					prnMsg($Msg , 'success');
 				} else {
 					$Msg = _('Test Results have NOT BEEN overwritten for Result ID ') . $MyRow2[0];
@@ -454,8 +451,7 @@ if (isset($_GET['CopyResults']) OR isset($_POST['CopyResults'])) {
 								)";
 				$Msg = _('Test Results have been copied to') . ' ' . $_POST['CopyToSampleID'] . ' ' . _('from') . ' ' . $SelectedSampleID . ' ' . _('for') . ' ' . $MyRow['testid'];
 				$ErrMsg = _('The insert of the test results failed because');
-				$DbgMsg = _('The SQL that was used and failed was');
-				$insresult = DB_query($InsSQL,$ErrMsg, $DbgMsg);
+				$insresult = DB_query($InsSQL, $ErrMsg);
 				prnMsg($Msg , 'success');
 			}
 		} //while loop on myrow
@@ -591,8 +587,7 @@ if (isset($_POST['AddTests'])) {
 						FROM qatests WHERE testid='" .$_POST['AddTestID' .$i]. "'";
 			$Msg = _('A Sample Result record has been added for Test ID') . ' ' . $_POST['AddTestID' .$i]  . ' for ' . ' ' . $KeyValue ;
 			$ErrMsg = _('The insert of the Sample Result failed because');
-			$DbgMsg = _('The SQL that was used and failed was');
-			$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg($Msg , 'success');
 		} //if on
 	} //for
@@ -644,8 +639,7 @@ if (isset($_POST['submit'])) {
 
 		$Msg = _('Sample Results were updated for Result ID') . ' ' . $_POST['ResultID' .$i] ;
 		$ErrMsg = _('The updated of the sampleresults failed because');
-		$DbgMsg = _('The SQL that was used and failed was');
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg($Msg , 'success');
 	} //for
 	//check to see all values are in spec or at least entered
@@ -661,8 +655,7 @@ if (isset($_POST['submit'])) {
 				WHERE sampleid = '".$SelectedSampleID."'";
 		$Msg = _('Test Results have not all been entered.  This Lot is not able to be used for a a Certificate of Analysis');
 		$ErrMsg = _('The update of the QA Sample failed because');
-		$DbgMsg = _('The SQL that was used and failed was');
-		$Result = DB_query($SQL,$ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg($Msg , 'error');
 	}
 }
@@ -676,7 +669,7 @@ if (isset($_GET['Delete'])) {
 	} else {
 		$SQL="DELETE FROM sampleresults WHERE resultid='". $_GET['ResultID']."'";
 		$ErrMsg = _('The sample results could not be deleted because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('Result QA Sample') . ' ' . $_GET['ResultID'] . _('has been deleted from the database'),'success');
 		unset($_GET['ResultID']);

--- a/Timesheets.php
+++ b/Timesheets.php
@@ -421,8 +421,7 @@ if(isset($_POST['ApproveTimesheet'])) {
 									'" .  _('Timesheet for the week ending') . ' ' . $_POST['WeekEnding'] . ': ' . $WeekTimeRow['firstname'] . ' ' . $WeekTimeRow['surname'] . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('labour stock movement records could not be inserted when processing the timesheet because');
-				$DbgMsg =  _('The following SQL to insert the labour stock movement records was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 				if ($_SESSION['CompanyRecord']['gllink_stock']==1 AND ($WeekTimeRow['labourcost'] * $WeekTimeRow['totalweekhours']) != 0) {
@@ -454,8 +453,7 @@ if(isset($_POST['ApproveTimesheet'])) {
 								'" . ($WeekTimeRow['labourcost'] * $WeekTimeRow['totalweekhours']) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The labour cost posting to a work order GL posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the work order issue GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				/*now the credit labour recovery entry - the GetSockGLCode actually returns the labour recovery GL account for labour type stock categories */
 				$ItemGLAccounts = GetStockGLCode($WeekTimeRow['issueitem']);
@@ -476,20 +474,18 @@ if(isset($_POST['ApproveTimesheet'])) {
 								'" . -($WeekTimeRow['labourcost'] * $WeekTimeRow['totalweekhours']) . "')";
 
 					$ErrMsg =   _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The labour recovery account credit on the approval of a timesheet GL posting could not be inserted because');
-					$DbgMsg =  _('The following SQL to insert the labour gltrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				} /* end of if GL and stock integrated and standard cost !=0 */
 
 
 				//update the wo with new cost issued
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' ._('Could not update the work order labour cost because');
-				$DbgMsg = _('The following SQL was used to update the work order');
-				$UpdateWOResult =DB_query("UPDATE workorders
+				$UpdateWOResult = DB_query("UPDATE workorders
 											SET costissued=costissued+" . ($WeekTimeRow['labourcost'] * $WeekTimeRow['totalweekhours']) . "
 											WHERE wo='" . $WeekTimeRow['wo'] . "'",
 											$ErrMsg,
-											$DbgMsg,
+											'',
 											true);
 			} //end loop through the WOs entered on this timesheet
 

--- a/UnitsOfMeasure.php
+++ b/UnitsOfMeasure.php
@@ -164,7 +164,7 @@ if (isset($_POST['Submit'])) {
 			ORDER BY unitid";
 
 	$ErrMsg = _('Could not get unit of measures because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 		<thead>

--- a/UserSettings.php
+++ b/UserSettings.php
@@ -74,8 +74,7 @@ if(isset($_POST['Modify'])) {
 						pdflanguage='" . $_POST['PDFLanguage'] . "'
 					WHERE userid = '" . $_SESSION['UserID'] . "'";
 			$ErrMsg = _('The user alterations could not be processed because');
-			$DbgMsg = _('The SQL that was used to update the user and failed was');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg( _('The user settings have been updated') . '. ' . _('Be sure to remember your password for the next time you login'),'success');
 		} else {
 			$SQL = "UPDATE www_users
@@ -89,8 +88,7 @@ if(isset($_POST['Modify'])) {
 						password='" . CryptPass($_POST['Password']) . "'
 					WHERE userid = '" . $_SESSION['UserID'] . "'";
 			$ErrMsg = _('The user alterations could not be processed because');
-			$DbgMsg = _('The SQL that was used to update the user and failed was');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 			prnMsg(_('The user settings have been updated'),'success');
 		}
 		// Update the session variables to reflect user changes on-the-fly:

--- a/WOCanBeProducedNow.php
+++ b/WOCanBeProducedNow.php
@@ -37,7 +37,7 @@ function submit($RootPath, $Location) {
 			;
 
 	$ErrMsg = _('The SQL to find the WO items to produce ');
-	$ResultItems = DB_query($SQL,$ErrMsg);
+	$ResultItems = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($ResultItems) != 0){
 
 		echo '<p class="page_title_text" align="center"><strong>' . "Items in WO to be produced now in " . $Location . " with available stock" . '</strong></p>';
@@ -99,7 +99,7 @@ function submit($RootPath, $Location) {
                         AND bom.effectiveto > '" . date('Y-m-d') . "'";
 
 			$ErrMsg = _('The bill of material could not be retrieved because');
-			$BOMResult = DB_query($SQLBOM,$ErrMsg);
+			$BOMResult = DB_query($SQLBOM, $ErrMsg);
 			$ItemCanBeproduced = TRUE;
 
 			while ($MyComponent = DB_fetch_array($BOMResult)) {
@@ -189,7 +189,7 @@ function display()  //####DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_DISPLAY_#####
 					AND locationusers.canview=1
 				WHERE locations.usedforwo = 1";
 
-	$LocnResult=DB_query($SQL);
+	$LocnResult = DB_query($SQL);
 
 	while ($MyRow=DB_fetch_array($LocnResult)){
 		echo '<option value="' . $MyRow['loccode'] . '">' . $MyRow['locationname'] . '</option>';

--- a/WOSerialNos.php
+++ b/WOSerialNos.php
@@ -44,8 +44,6 @@ echo '<p class="page_title_text">
 		<img src="'.$RootPath.'/css/'.$Theme.'/images/transactions.png" title="" alt="" />' . ' ' . _('For Work Order Number') . ' ' . $WO . ' ' . _('and output item') . ' ' . $StockID . ' - ' . $Description . '
 	</p>';
 
-$DbgMsg = _('The SQL that failed was');
-
 if (isset($_POST['AddControlledItems'])){
 	if (isset($_POST['NumberToAdd'])){ // Must be adding serial numbers automatically
 		if (!is_numeric(filter_number_format($_POST['NumberToAdd']))){
@@ -93,7 +91,7 @@ if (isset($_POST['AddControlledItems'])){
 			}
 			$NextSerialNo = $NextItemNumber + 1;
 			$ErrMsg = _('Unable to add the serial numbers requested');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 			// update the nextserialno in the stockmaster for the item
 			$Result = DB_query("UPDATE stockmaster
 								SET nextserialno='" . $NextSerialNo . "'
@@ -102,7 +100,7 @@ if (isset($_POST['AddControlledItems'])){
 								WHERE stockid='" . $StockID . "'
 								AND wo='" . $WO . "'",
 								$ErrMsg,
-								$DbgMsg,
+								'',
 								true);
 			DB_Txn_Commit();
 		}
@@ -140,7 +138,7 @@ if (isset($_POST['AddControlledItems'])){
 									WHERE stockid='" . $StockID . "'
 									AND wo='" . $WO . "'",
 									$ErrMsg,
-									$DbgMsg,
+									'',
 									true);
 				$SQL = "INSERT INTO woserialnos (stockid,
 												 wo,
@@ -154,7 +152,7 @@ if (isset($_POST['AddControlledItems'])){
 											 '" . $_POST['Reference'] . "')";
 
 				$ErrMsg = _('Unable to add the batch or serial number requested');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				DB_Txn_Commit();
 			}
@@ -224,13 +222,13 @@ if (isset($_POST['UpdateItems'])){
 	if (sizeof($SQL)>0){
 		DB_Txn_Begin();
 		foreach ($SQL as $SQLStatement){
-				$Result = DB_query($SQLStatement,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQLStatement, $ErrMsg, '', true);
 		}
 		$Result = DB_query("UPDATE woitems SET qtyreqd = '" . $WOQuantityTotal . "'
 							WHERE wo = '" .$WO . "'
 							AND stockid='" . $StockID . "'",
 							$ErrMsg,
-							$DbgMsg,
+							'',
 							true);
 		DB_Txn_Commit();
 	}
@@ -291,7 +289,7 @@ $SQL = "SELECT serialno,
 		AND stockid='" . $StockID . "'";
 
 $ErrMsg = _('Could not get the work order serial/batch items');
-$WOSerialNoResult = DB_query($SQL,$ErrMsg);
+$WOSerialNoResult = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($WOSerialNoResult)==0){
 	prnMsg(_('There are no serial items or batches yet defined for this work order item. Create new items first'),'info');

--- a/WWW_Access.php
+++ b/WWW_Access.php
@@ -77,7 +77,7 @@ if (isset($_POST['submit']) OR isset($_GET['remove']) OR isset($_GET['add']) ) {
 	}
 	// Need to exec the query
 	if (isset($SQL) AND $InputError != 1 ) {
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		if( $Result ) {
 			prnMsg( $ResMsg,'success');
 		}

--- a/WWW_Users.php
+++ b/WWW_Users.php
@@ -133,8 +133,7 @@ if(isset($_POST['submit'])) {
 				AND custbranch.branchcode='" . ($_POST['BranchCode'] ?? '') . "'";
 
 		$ErrMsg = _('The check on validity of the customer code and branch failed because');
-		$DbgMsg = _('The SQL that was used to check the customer code and branch was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 		if(DB_num_rows($Result)==0) {
 			prnMsg(_('The entered Branch Code is not valid for the entered Customer Code'), 'error');
@@ -206,8 +205,7 @@ if(isset($_POST['submit'])) {
 					WHERE userid = '". $SelectedUser . "'";
 
 		$ErrMsg = _('The user alterations could not be processed because');
-		$DbgMsg = _('The SQL that was used to update the user and failed was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg(_('The selected user record has been updated'), 'success' );
 
 		$_SESSION['ShowPageHelp'] = $_POST['ShowPageHelp'];
@@ -264,8 +262,7 @@ if(isset($_POST['submit'])) {
 					'" . $_POST['Department'] . "')";
 
 		$ErrMsg = _('The user insertion could not be processed because');
-		$DbgMsg = _('The SQL that was used to insert the user and failed was');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		prnMsg(_('A new user record has been inserted'), 'success');
 
 		$LocationSql = "INSERT INTO locationusers (loccode,
@@ -280,8 +277,7 @@ if(isset($_POST['submit'])) {
 												)";
 
 		$ErrMsg = _('The default user locations could not be processed because');
-		$DbgMsg = _('The SQL that was used to create the user locations and failed was');
-		$Result = DB_query($LocationSql, $ErrMsg, $DbgMsg);
+		$Result = DB_query($LocationSql, $ErrMsg);
 		prnMsg(_('User has been authorized to use and update only his / her default location'), 'success' );
 
 		$GLAccountsSql = "INSERT INTO glaccountusers (userid, accountcode, canview, canupd)
@@ -289,8 +285,7 @@ if(isset($_POST['submit'])) {
 						 FROM chartmaster;	";
 
 		$ErrMsg = _('The default user GL Accounts could not be processed because');
-		$DbgMsg = _('The SQL that was used to create the user GL Accounts and failed was');
-		$Result = DB_query($GLAccountsSql, $ErrMsg, $DbgMsg);
+		$Result = DB_query($GLAccountsSql, $ErrMsg);
 		prnMsg(_('User has been authorized to use and update all GL accounts'), 'success' );
 	}
 
@@ -350,11 +345,11 @@ if(isset($_POST['submit'])) {
 
 			$SQL = "DELETE FROM sessions WHERE userid = '" . $SelectedUser . "'";
 			$ErrMsg = _('The Sessions User could not be deleted because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			$SQL = "DELETE FROM session_data WHERE userid = '" . $SelectedUser . "'";
 			$ErrMsg = _('The Session Data User could not be deleted because');
-			$Result = DB_query($SQL,$ErrMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			$SQL = "DELETE FROM www_users WHERE userid='" . $SelectedUser . "'";
 			$ErrMsg = _('The User could not be deleted because');
@@ -862,7 +857,7 @@ $SQL = "SELECT departmentid,
 		FROM departments
 		ORDER BY description";
 
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 echo '<select name="Department">';
 if((isset($_POST['Department']) AND $_POST['Department']=='0') OR !isset($_POST['Department'])) {
 	echo '<option selected="selected" value="0">' . _('Any Internal Department') . '</option>';

--- a/WhereUsedInquiry.php
+++ b/WhereUsedInquiry.php
@@ -68,7 +68,7 @@ if (isset($StockID)) {
 			ORDER BY stockmaster.discontinued, bom.parent";
 
 	$ErrMsg = _('The parents for the selected part could not be retrieved because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result)==0){
 		prnMsg(_('The selected item') . ' ' . $StockID . ' ' . _('is not used as a component of any other parts'),'error');
 	} else {

--- a/WorkOrderCosting.php
+++ b/WorkOrderCosting.php
@@ -384,10 +384,8 @@ if (isset($_POST['Close'])) {
 										'" .round((-$TotalCostVar*$ShareProportion*(1-$ProportionOnHand)),$_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL posting for the work order variance could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
-
 
 				$SQL = "INSERT INTO gltrans (type,
 							typeno,
@@ -405,8 +403,7 @@ if (isset($_POST['Close'])) {
 							'" . round((-$TotalCostVar*$ShareProportion*$ProportionOnHand),$_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL posting for the work order variance could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "INSERT INTO gltrans (type,
 							typeno,
@@ -424,8 +421,7 @@ if (isset($_POST['Close'])) {
 							'" . round(($TotalCostVar*$ShareProportion),$_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL posting for the WIP side of the work order variance posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			}
 			if ($TotalOnHand>0) {//to avoid negative quantity make cost data abnormal
@@ -443,8 +439,7 @@ if (isset($_POST['Close'])) {
 					WHERE stockid='" . $WORow['stockid'] . "'";
 
 			$ErrMsg = _('The cost details for the stock item could not be updated because');
-			$DbgMsg = _('The SQL that failed was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		} else { //we are standard costing post the variances
 			if ($_SESSION['CompanyRecord']['gllink_stock']==1 AND $TotalUsageVar!=0){
@@ -465,8 +460,7 @@ if (isset($_POST['Close'])) {
 							'" . round((-$TotalUsageVar*$ShareProportion),$_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL posting for the material usage variance could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "INSERT INTO gltrans (type,
 											typeno,
@@ -484,8 +478,7 @@ if (isset($_POST['Close'])) {
 							'" . round(($TotalUsageVar*$ShareProportion),$_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL posting for the WIP side of the usage variance posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			}//end if gl-stock linked and a usage variance exists
 
@@ -507,8 +500,7 @@ if (isset($_POST['Close'])) {
 							'" . round((-$TotalCostVar*$ShareProportion),$_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL posting for the cost variance could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "INSERT INTO gltrans (type,
 											typeno,
@@ -526,14 +518,13 @@ if (isset($_POST['Close'])) {
 							'" . round(($TotalCostVar*$ShareProportion),$_SESSION['CompanyRecord']['decimalplaces']) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL posting for the WIP side of the cost variance posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			} //end of if gl-stock integrated and there's a cost variance
 		} //end of standard costing section
 	} // end loop around the items on the work order
 
-	$CloseWOResult =DB_query("UPDATE workorders SET closed=1, closecomments = '". $_POST['CloseComments'] ."' WHERE wo='" .$_POST['WO'] . "'",
+	$CloseWOResult = DB_query("UPDATE workorders SET closed=1, closecomments = '". $_POST['CloseComments'] ."' WHERE wo='" .$_POST['WO'] . "'",
 				_('Could not update the work order to closed because:'),
 				_('The SQL used to close the work order was:'),
 				true);

--- a/WorkOrderEntry.php
+++ b/WorkOrderEntry.php
@@ -245,21 +245,20 @@ if (isset($_POST['delete'])) {
 	if ($CancelDelete == false) { //ie all tests proved ok to delete
 		DB_Txn_Begin();
 		$ErrMsg = _('The work order could not be deleted');
-		$DbgMsg = _('The SQL used to delete the work order was');
 		//delete the worequirements
 		$SQL = "DELETE FROM worequirements WHERE wo='" . $_POST['WO'] . "'";
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		//delete the items on the work order
 		$SQL = "DELETE FROM woitems WHERE wo='" . $_POST['WO'] . "'";
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		//delete the controlled items defined in wip
 		$SQL = "DELETE FROM woserialnos WHERE wo='" . $_POST['WO'] . "'";
 		$ErrMsg = _('The work order serial numbers could not be deleted');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		// delete the actual work order
 		$SQL = "DELETE FROM workorders WHERE wo='" . $_POST['WO'] . "'";
 		$ErrMsg = _('The work order could not be deleted');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		DB_Txn_Commit();
 		prnMsg(_('The work order has been cancelled'), 'success');
@@ -556,8 +555,7 @@ if (isset($_POST['Search']) or isset($_POST['Prev']) or isset($_POST['Next'])) {
 	$SQL = $SQL . ' LIMIT ' . $_SESSION['DisplayRecordsMax'] . ' OFFSET ' . strval($_SESSION['DisplayRecordsMax'] * $Offset);
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL used to get the part selection was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('There are no products available meeting the criteria specified'), 'info');

--- a/WorkOrderIssue.php
+++ b/WorkOrderIssue.php
@@ -190,8 +190,7 @@ if (isset($_POST['Process'])) { //user hit the process the work order issues ent
 					AND loccode = '" . $_POST['FromLocation'] . "'";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-			$DbgMsg = _('The following SQL to update the location stock record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 		} else {
 			$NewQtyOnHand = 0; //since we can't have stock of labour type items!!
 
@@ -224,8 +223,7 @@ if (isset($_POST['Process'])) { //user hit the process the work order issues ent
 							'" . $NewQtyOnHand . "')";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('stock movement records could not be inserted when processing the work order issue because');
-		$DbgMsg = _('The following SQL to insert the stock movement records was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*Get the ID of the StockMove... */
 		$StkMoveNo = DB_Last_Insert_ID('stockmoves', 'stkmoveno');
@@ -246,8 +244,7 @@ if (isset($_POST['Process'])) { //user hit the process the work order issues ent
 										AND (loccode = '" . $_POST['FromLocation'] . "')
 										AND (serialno = '" . $SerialNo . "')";
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the serial stock item records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						/** end of handle stockserialitems records */
 
@@ -261,8 +258,7 @@ if (isset($_POST['Process'])) { //user hit the process the work order issues ent
 											'" . $SerialNo . "',
 											-1)";
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 					} //non blank SerialNo
 
 				} //end for all of the potential serialised entries in the multi select box
@@ -280,8 +276,7 @@ if (isset($_POST['Process'])) { //user hit the process the work order issues ent
 								AND loccode = '" . $_POST['FromLocation'] . "'
 								AND serialno = '" . $_POST['BatchRef' . $i] . "'";
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not check if a batch/lot reference for the item already exists because');
-						$DbgMsg = _('The following SQL to test for an already existing controlled item was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 						$AlreadyExistsRow = DB_fetch_row($Result);
 
 						if ($AlreadyExistsRow[0] > 0 and $_POST['Qty' . $i] != 0) {
@@ -307,8 +302,7 @@ if (isset($_POST['Process'])) { //user hit the process the work order issues ent
 						}
 
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The batch/lot item record could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the batch/lot item records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						/** end of handle stockserialitems records */
 
@@ -323,8 +317,7 @@ if (isset($_POST['Process'])) { //user hit the process the work order issues ent
 											'" . $_POST['BatchRef' . $i] . "',
 											'" . filter_number_format($_POST['Qty' . $i]) * -1 . "')";
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-							$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 						}
 					} //non blank BundleRef
 
@@ -358,8 +351,7 @@ if (isset($_POST['Process'])) { //user hit the process the work order issues ent
 						'" . ($IssueItemRow['cost'] * $QuantityIssued) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The issue of the item to the work order GL posting could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the work order issue GLTrans record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			/*now the credit Stock entry*/
 			$SQL = "INSERT INTO gltrans (type,
@@ -378,17 +370,15 @@ if (isset($_POST['Process'])) { //user hit the process the work order issues ent
 						'" . -($IssueItemRow['cost'] * $QuantityIssued) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock account credit on the issue of items to a work order GL posting could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the stock GLTrans record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		} /* end of if GL and stock integrated and standard cost !=0 */
 
 		//update the wo with the new qtyrecd
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not update the work order cost issued to the work order because');
-		$DbgMsg = _('The following SQL was used to update the work order');
 		$UpdateWOResult = DB_query("UPDATE workorders
 									SET costissued=costissued+" . ($QuantityIssued * $IssueItemRow['cost']) . "
-									WHERE wo='" . $_POST['WO'] . "'", $ErrMsg, $DbgMsg, true);
+									WHERE wo='" . $_POST['WO'] . "'", $ErrMsg, '', true);
 
 		DB_Txn_Commit();
 
@@ -509,8 +499,7 @@ elseif (isset($_POST['ProcessMultiple'])) {
 							AND loccode = '" . $_POST['FromLocation'] . "'";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-				$DbgMsg = _('The following SQL to update the location stock record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			} else {
 				$NewQtyOnHand = 0; //since we can't have stock of labour type items!!
 
@@ -541,8 +530,7 @@ elseif (isset($_POST['ProcessMultiple'])) {
 									'" . $IssueItemRow['cost'] . "',
 									'" . $NewQtyOnHand . "')";
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('stock movement records could not be inserted when processing the work order issue because');
-			$DbgMsg = _('The following SQL to insert the stock movement records was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 			if ($_SESSION['CompanyRecord']['gllink_stock'] == 1) {
 				/*GL integration with stock is activated so need the GL journals to make it so */
 				/*first the debit the WIP of the item being manufactured from the WO
@@ -564,8 +552,7 @@ elseif (isset($_POST['ProcessMultiple'])) {
 								'" . ($IssueItemRow['cost'] * $QuantityIssued) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The issue of the item to the work order GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the work order issue GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 				/*now the credit Stock entry*/
 				$SQL = "INSERT INTO gltrans (type,
 										typeno,
@@ -583,17 +570,15 @@ elseif (isset($_POST['ProcessMultiple'])) {
 								'" . -($IssueItemRow['cost'] * $QuantityIssued) . "')";
 
 				$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock account credit on the issue of items to a work order GL posting could not be inserted because');
-				$DbgMsg = _('The following SQL to insert the stock GLTrans record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			} /* end of if GL and stock integrated and standard cost !=0 */
 
 			//update the wo with the new qtyrecd
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not update the work order cost issued to the work order because');
-			$DbgMsg = _('The following SQL was used to update the work order');
 			$UpdateWOResult = DB_query("UPDATE workorders
 									SET costissued=costissued+" . ($QuantityIssued * $IssueItemRow['cost']) . "
-									WHERE wo='" . $_POST['WO'] . "'", $ErrMsg, $DbgMsg, true);
+									WHERE wo='" . $_POST['WO'] . "'", $ErrMsg, '', true);
 
 			prnMsg(_('The issue of') . ' ' . $QuantityIssued . ' ' . _('of') . ' ' . $_POST['IssueItem'] . ' ' . _('against work order') . ' ' . $_POST['WO'] . ' ' . _('has been processed'), 'info');
 		} //end of foreach loop;
@@ -706,8 +691,7 @@ if (isset($_POST['Search'])) {
 	}
 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
-	$DbgMsg = _('The SQL used to get the part selection was');
-	$SearchResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$SearchResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('There are no products available meeting the criteria specified'), 'info');

--- a/WorkOrderReceive.php
+++ b/WorkOrderReceive.php
@@ -152,8 +152,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 							AND loccode = '" . $_POST['IntoLocation'] . "'
 							AND serialno = '" . $_POST['SerialNo' .$i] . "'";
 					$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not check if a serial number for the stock item already exists because');
-					$DbgMsg =  _('The following SQL to test for an already existing serialised stock item was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					$AlreadyExistsRow = DB_fetch_row($Result);
 
 					if ($AlreadyExistsRow[0]>0){
@@ -182,7 +181,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 				  AND worequirements.autoissue=1";
 
 		$ErrMsg = _('Could not retrieve the component quantity left at the location once the component items are issued to the work order (for the purposes of checking that stock will not go negative) because');
-		$Result = DB_query($SQL,$ErrMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 		while ($NegRow = DB_fetch_array($Result)){
 			if ($NegRow['qtyleft']<0){
 				prnMsg(_('Receiving the selected quantity against this work order would result in negative stock for a component. The system parameters are set to prohibit negative stocks from occurring. This manufacturing receipt cannot be created until the stock on hand is corrected.'),'error',_('Component') . ' - ' .$NegRow['component'] . ' ' . $NegRow['description'] . ' - ' . _('Negative Stock Prohibited'));
@@ -265,8 +264,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 								'" . (-$ValueOfChange) . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL credit for the stock cost adjustment posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 					$SQL = "INSERT INTO gltrans (type,
 								typeno,
@@ -284,8 +282,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 								'" . $ValueOfChange . "')";
 
 					$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The GL debit for stock cost adjustment posting could not be inserted because');
-					$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-					$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 				}
 
 				$SQL = "UPDATE stockmaster SET
@@ -297,8 +294,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 						WHERE stockid='" . $_POST['StockID'] . "'";
 
 				$ErrMsg = _('The cost details for the stock item could not be updated because');
-				$DbgMsg = _('The SQL that failed was');
-				$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			} //cost as rolled up now <> current standard cost  so do adjustments
 		}   //qty recd previously was 0 so need to check costs and do adjustments as required
 
@@ -343,8 +339,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 							AND loccode = '" . $WORow['loccode'] . "'";
 
 				$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated by the issue of stock to the work order from an auto issue component because');
-				$DbgMsg =  _('The following SQL to update the location stock record was used');
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+				$Result = DB_query($SQL, $ErrMsg, '', true);
 			} else {
 				$NewQtyOnHand =0;
 			}
@@ -374,16 +369,14 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 								'" . $NewQtyOnHand . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('stock movement record could not be inserted for an auto-issue component because');
-			$DbgMsg =  _('The following SQL to insert the stock movement records was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			//Update the workorder record with the cost issued to the work order
 			$SQL = "UPDATE workorders SET
 						costissued = costissued+" . ($AutoIssueCompRow['qtypu'] * $QuantityReceived * $AutoIssueCompRow['cost']) ."
 					WHERE wo='" . $_POST['WO'] . "'";
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not update the work order cost for an auto-issue component because');
-			$DbgMsg =  _('The following SQL to update the work order cost was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			if ($_SESSION['CompanyRecord']['gllink_stock']==1
 				AND ($AutoIssueCompRow['qtypu'] * $QuantityReceived * $AutoIssueCompRow['cost'])!=0){
@@ -405,8 +398,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 								'" . ($AutoIssueCompRow['qtypu'] * $QuantityReceived * $AutoIssueCompRow['cost']) . "')";
 
 					$ErrMsg =   _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The WIP side of the work order issue GL posting could not be inserted because');
-					$DbgMsg =  _('The following SQL to insert the WO issue GLTrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 
 				$SQL = "INSERT INTO gltrans (type,
 									typeno,
@@ -424,8 +416,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 								'" . -($AutoIssueCompRow['qtypu'] * $QuantityReceived * $AutoIssueCompRow['cost']) . "')";
 
 					$ErrMsg =   _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The stock side of the work order issue GL posting could not be inserted because');
-					$DbgMsg =  _('The following SQL to insert the WO issue GLTrans record was used');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 			}//end GL-stock linked
 
 		} //end of auto-issue loop for all components set to auto-issue
@@ -452,8 +443,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 				AND loccode = '" . $_POST['IntoLocation'] . "'";
 
 		$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The location stock record could not be updated because');
-		$DbgMsg =  _('The following SQL to update the location stock record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		$WOReceiptNo = GetNextTransNo(26);
 		/*Insert stock movements - with unit cost */
 
@@ -483,8 +473,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 							'" . ($QtyOnHandPrior + $QuantityReceived) . "')";
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('stock movement records could not be inserted when processing the work order receipt because');
-		$DbgMsg =  _('The following SQL to insert the stock movement records was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*Get the ID of the StockMove... */
 		$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -537,8 +526,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 							}
 
 							$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be inserted because');
-							$DbgMsg =  _('The following SQL to insert the serial stock item records was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 
 							/** end of handle stockserialitems records */
 
@@ -552,8 +540,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 												'" . $_POST['SerialNo' .$i] . "',
 												1)";
 							$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-							$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-							$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+							$Result = DB_query($SQL, $ErrMsg, '', true);
 
 							if ($_SESSION['DefineControlledOnWOEntry']==1){
 								//need to delete the item from woserialnos
@@ -562,8 +549,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 											AND stockid='" . $_POST['StockID'] ."'
 											AND serialno='" . $_POST['SerialNo'.$i] . "'";
 								$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The predefined serial number record could not be deleted because');
-								$DbgMsg = _('The following SQL to delete the predefined work order serial number record was used');
-								$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+								$Result = DB_query($SQL, $ErrMsg, '', true);
 							}
 						}//end prefined controlled items or not
 						if ($_SESSION['QualityLogSamples']==1) {
@@ -584,8 +570,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 								AND loccode = '" . $_POST['IntoLocation'] . "'
 								AND serialno = '" . $_POST['BatchRef' .$i] . "'";
 						$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('Could not check if a serial number for the stock item already exists because');
-						$DbgMsg =  _('The following SQL to test for an already existing serialised stock item was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 						$AlreadyExistsRow = DB_fetch_row($Result);
 						if (isset($_POST['QualityText'.$i])){
 							$QualityText = $_POST['QualityText'.$i];
@@ -633,8 +618,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 							exit();
 						}
 						$ErrMsg =  _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock item record could not be inserted because');
-						$DbgMsg =  _('The following SQL to insert the serial stock item records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						/** end of handle stockserialitems records */
 
@@ -648,8 +632,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 											'" . $_POST['BatchRef'.$i]  . "',
 											'" . filter_number_format($_POST['Qty'.$i])  . "')";
 						$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The serial stock movement record could not be inserted because');
-						$DbgMsg = _('The following SQL to insert the serial stock movement records was used');
-						$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+						$Result = DB_query($SQL, $ErrMsg, '', true);
 
 						if ($_SESSION['DefineControlledOnWOEntry']==1){
 							//check how many of the batch/bundle/lot has been received
@@ -668,8 +651,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 										AND stockid='" . $_POST['StockID'] ."'
 										AND serialno='" . $_POST['BatchRef'.$i] . "'";
 								$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The predefined batch/lot/bundle record could not be deleted because');
-								$DbgMsg = _('The following SQL to delete the predefined work order batch/bundle/lot record was used');
-								$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+								$Result = DB_query($SQL, $ErrMsg, '', true);
 						} */
 						}
 						if ($_SESSION['QualityLogSamples']==1) {
@@ -705,8 +687,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 								'" . ($WORow['stdcost'] * $QuantityReceived) . "')";
 
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The receipt of work order finished stock GL posting could not be inserted because');
-			$DbgMsg = _('The following SQL to insert the work order receipt of finished items GLTrans record was used');
-			$Result = DB_query($SQL,$ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		/*now the credit WIP entry*/
 			$SQL = "INSERT INTO gltrans (type,
@@ -725,8 +706,7 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 								'" . -($WORow['stdcost'] * $QuantityReceived) . "')";
 
 			$ErrMsg =   _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' . _('The WIP credit on receipt of finished items from a work order GL posting could not be inserted because');
-			$DbgMsg =  _('The following SQL to insert the WIP GLTrans record was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '',true);
 
 		} /* end of if GL and stock integrated and standard cost !=0 */
 
@@ -735,14 +715,13 @@ if (isset($_POST['Process'])){ //user hit the process the work order receipts en
 		}
 		//update the wo with the new qtyrecd
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': ' ._('Could not update the work order item record with the total quantity received because');
-		$DbgMsg = _('The following SQL was used to update the work order');
-		$UpdateWOResult =DB_query("UPDATE woitems
+		$UpdateWOResult = DB_query("UPDATE woitems
 									SET qtyrecd=qtyrecd+" . $QuantityReceived . ",
 										nextlotsnref='" . $LastRef . "'
 									WHERE wo='" . $_POST['WO'] . "'
 									AND stockid='" . $_POST['StockID'] . "'",
 									$ErrMsg,
-									$DbgMsg,
+									'',
 									true);
 
 

--- a/Z_BottomUpCosts.php
+++ b/Z_BottomUpCosts.php
@@ -24,9 +24,8 @@ if (isset($Run)) { //start bom processing
 			WHERE b2.parent is null;" ;
 
 	$ErrMsg =  _('An error occurred selecting all bottom level components');
-	$DbgMsg =  _('The SQL that was used to select bottom level components and failed in the process was');
 
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	while ($Item = DB_fetch_array($Result)) {
 		$InputError=UpdateCost($Item['component']);

--- a/Z_ChangeBranchCode.php
+++ b/Z_ChangeBranchCode.php
@@ -14,7 +14,7 @@ echo '<p class="page_title_text"><img alt="" src="'.$RootPath.'/css/'.$Theme.
 if (isset($_POST['ProcessCustomerChange'])){
 
 /*First check the customer code exists */
-	$Result=DB_query("SELECT debtorno,
+	$Result = DB_query("SELECT debtorno,
 							branchcode
 						FROM custbranch
 						WHERE debtorno='" . $_POST['DebtorNo'] . "'
@@ -38,7 +38,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 
 
 /*Now check that the new code doesn't already exist */
-	$Result=DB_query("SELECT debtorno FROM custbranch WHERE debtorno='" . $_POST['DebtorNo'] . "' AND branchcode ='" . $_POST['NewBranchCode'] . "'");
+	$Result = DB_query("SELECT debtorno FROM custbranch WHERE debtorno='" . $_POST['DebtorNo'] . "' AND branchcode ='" . $_POST['NewBranchCode'] . "'");
 	if (DB_num_rows($Result)!=0){
 		prnMsg(_('The replacement customer branch code') . ': ' . $_POST['NewBranchCode'] . ' ' . _('already exists as a branch code for the same customer') . ' - ' . _('a unique branch code must be entered for the new code'),'error');
 		include('includes/footer.php');
@@ -110,9 +110,8 @@ if (isset($_POST['ProcessCustomerChange'])){
 			FROM custbranch
 			WHERE debtorno='" . $_POST['DebtorNo'] . "'
 			AND branchcode='" . $_POST['OldBranchCode'] . "'";
-	$DbgMsg = _('The SQL that failed was');
 	$ErrMsg = _('The SQL to insert the new customer branch master record failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg (_('Changing customer transaction records'),'info');
 	$SQL = "UPDATE debtortrans SET
@@ -121,7 +120,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 					AND branchcode='" . $_POST['OldBranchCode'] . "'";
 
 	$ErrMsg = _('The SQL to update debtor transaction records failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing sales analysis records'),'info');
 	$SQL = "UPDATE salesanalysis
@@ -130,7 +129,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 					AND custbranch='" . $_POST['OldBranchCode'] . "'";
 
 	$ErrMsg = _('The SQL to update Sales Analysis records failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 	prnMsg(_('Changing order delivery differences records'),'info');
@@ -140,7 +139,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 					AND branch='" . $_POST['OldBranchCode'] . "'";
 
 	$ErrMsg = _('The SQL to update order delivery differences records failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 	prnMsg (_('Changing pricing records'),'info');
@@ -149,7 +148,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 				WHERE debtorno='" . $_POST['DebtorNo'] . "'
 				AND branchcode='" . $_POST['OldBranchCode'] . "'";
 	$ErrMsg = _('The SQL to update the pricing records failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 	prnMsg(_('Changing sales orders records'),'info');
@@ -158,7 +157,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 					WHERE debtorno='" . $_POST['DebtorNo'] . "'
 					AND branchcode='" . $_POST['OldBranchCode'] . "'";
 	$ErrMsg = _('The SQL to update the sales order header records failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 	prnMsg(_('Changing stock movement records'),'info');
@@ -167,7 +166,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 					WHERE debtorno='" . $_POST['DebtorNo'] . "'
 					AND branchcode='" . $_POST['OldBranchCode'] . "'";
 	$ErrMsg = _('The SQL to update the stock movement records failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing user default customer records'),'info');
 	$SQL = "UPDATE www_users
@@ -176,7 +175,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 					AND branchcode='" . $_POST['OldBranchCode'] . "'";
 
 	$ErrMsg = _('The SQL to update the user records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing the customer branch code in contract header records'),'info');
 	$SQL = "UPDATE contracts
@@ -184,7 +183,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 					WHERE debtorno='" . $_POST['DebtorNo'] . "'
 					AND branchcode='" . $_POST['OldBranchCode'] . "'";
 	$ErrMsg = _('The SQL to update contract header records failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	DB_Txn_Commit();
 
@@ -195,7 +194,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 					AND branchcode='" . $_POST['OldBranchCode'] . "'";
 
 	$ErrMsg = _('The SQL to delete the old customer branch record failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	DB_ReinstateForeignKeys();
 
 }

--- a/Z_ChangeCustomerCode.php
+++ b/Z_ChangeCustomerCode.php
@@ -14,7 +14,7 @@ echo '<p class="page_title_text"><img alt="" src="'.$RootPath.'/css/'.$Theme.
 if (isset($_POST['ProcessCustomerChange'])){
 
 /*First check the customer code exists */
-	$Result=DB_query("SELECT debtorno FROM debtorsmaster WHERE debtorno='" . $_POST['OldDebtorNo'] . "'");
+	$Result = DB_query("SELECT debtorno FROM debtorsmaster WHERE debtorno='" . $_POST['OldDebtorNo'] . "'");
 	if (DB_num_rows($Result)==0){
 		prnMsg ('<br /><br />' . _('The customer code') . ': ' . $_POST['OldDebtorNo'] . ' ' . _('does not currently exist as a customer code in the system'),'error');
 		include('includes/footer.php');
@@ -28,7 +28,7 @@ if (isset($_POST['ProcessCustomerChange'])){
 		exit();
 	}
 /*Now check that the new code doesn't already exist */
-	$Result=DB_query("SELECT debtorno FROM debtorsmaster WHERE debtorno='" . $_POST['NewDebtorNo'] . "'");
+	$Result = DB_query("SELECT debtorno FROM debtorsmaster WHERE debtorno='" . $_POST['NewDebtorNo'] . "'");
 	if (DB_num_rows($Result)!=0){
 		prnMsg(_('The replacement customer code') .': ' . $_POST['NewDebtorNo'] . ' ' . _('already exists as a customer code in the system') . ' - ' . _('a unique customer code must be entered for the new code'),'error');
 		include('includes/footer.php');
@@ -92,9 +92,8 @@ if (isset($_POST['ProcessCustomerChange'])){
 									`typeid`
 					FROM debtorsmaster
 					WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
-	$DbgMsg =_('The SQL that failed was');
 	$ErrMsg = _('The SQL to insert the new debtors master record failed') . ', ' . _('the SQL statement was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Inserting new customer branch records'),'info');
 	$SQL = "INSERT INTO custbranch ( `branchcode`,
@@ -159,69 +158,69 @@ if (isset($_POST['ProcessCustomerChange'])){
 								WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
 
 	$ErrMsg = _('The SQL to insert new customer branch records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	prnMsg(_('Changing debtor transaction records'),'info');
 
 	$SQL = "UPDATE debtortrans SET debtorNo='" . $_POST['NewDebtorNo'] . "' WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
 
 	$ErrMsg = _('The SQL to update debtor transaction records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing sales analysis records'),'info');
 
 	$SQL = "UPDATE salesanalysis SET cust='" . $_POST['NewDebtorNo'] . "' WHERE cust='" . $_POST['OldDebtorNo'] . "'";
 
 	$ErrMsg = _('The SQL to update Sales Analysis records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg (_('Changing order delivery differences records'),'info');
 	$SQL = "UPDATE orderdeliverydifferenceslog SET debtorno='" . $_POST['NewDebtorNo'] . "' WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
 	$ErrMsg = _('The SQL to update order delivery differences records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 	prnMsg(_('Changing pricing records'),'info');
 	$SQL = "UPDATE prices SET debtorno='" . $_POST['NewDebtorNo'] . "' WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
 
 	$ErrMsg = _('The SQL to update the pricing records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing sales orders records'),'info');
 	$SQL = "UPDATE salesorders SET debtorno='" . $_POST['NewDebtorNo'] . "' WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
 
 	$ErrMsg = _('The SQL to update the sales order header records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg( _('Changing stock movement records'),'info');
 	$SQL = "UPDATE stockmoves SET debtorno='" . $_POST['NewDebtorNo'] . "' WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
 	$ErrMsg = _('The SQL to update the sales order header records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing user default customer records'),'info');
 	$SQL = "UPDATE www_users SET customerid='" . $_POST['NewDebtorNo'] . "' WHERE customerid='" . $_POST['OldDebtorNo'] . "'";
 
 	$ErrMsg = _('The SQL to update the user records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing the customer code in contract header records'),'info');
 	$SQL = "UPDATE contracts SET debtorno='" . $_POST['NewDebtorNo'] . "' WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
 
 	$ErrMsg = _('The SQL to update contract header records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	DB_IgnoreForeignKeys();
 
 	prnMsg(_('Deleting the old customer branch records from the CustBranch table'),'info');
 	$SQL = "DELETE FROM custbranch WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
 	$ErrMsg = _('The SQL to delete the old CustBranch records for the old debtor record failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 	prnMsg(_('Deleting the customer code from the DebtorsMaster table'),'info');
 	$SQL = "DELETE FROM debtorsmaster WHERE debtorno='" . $_POST['OldDebtorNo'] . "'";
 
 	$ErrMsg = _('The SQL to delete the old debtor record failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 
 	DB_Txn_Commit();

--- a/Z_ChangeGLAccountCode.php
+++ b/Z_ChangeGLAccountCode.php
@@ -20,7 +20,7 @@ if(isset($_POST['ProcessGLAccountCode'])) {
 	$_POST['NewAccountCode'] = mb_strtoupper($_POST['NewAccountCode']);
 
 /*First check the code exists */
-	$Result=DB_query("SELECT accountcode FROM chartmaster WHERE accountcode='" . $_POST['OldAccountCode'] . "'");
+	$Result = DB_query("SELECT accountcode FROM chartmaster WHERE accountcode='" . $_POST['OldAccountCode'] . "'");
 	if(DB_num_rows($Result)==0) {
 		prnMsg(_('The GL account code') . ': ' . $_POST['OldAccountCode'] . ' ' . _('does not currently exist as a GL account code in the system'),'error');
 		$InputError =1;
@@ -38,7 +38,7 @@ if(isset($_POST['ProcessGLAccountCode'])) {
 
 
 /*Now check that the new code doesn't already exist */
-	$Result=DB_query("SELECT accountcode FROM chartmaster WHERE accountcode='" . $_POST['NewAccountCode'] . "'");
+	$Result = DB_query("SELECT accountcode FROM chartmaster WHERE accountcode='" . $_POST['NewAccountCode'] . "'");
 	if(DB_num_rows($Result)!=0) {
 		echo '<br /><br />';
 		prnMsg(_('The replacement GL account code') . ': ' . $_POST['NewAccountCode'] . ' ' . _('already exists as a GL account code in the system') . ' - ' . _('a unique GL account code must be entered for the new code'),'error');
@@ -58,9 +58,8 @@ if(isset($_POST['ProcessGLAccountCode'])) {
 				FROM chartmaster
 				WHERE accountcode='" . $_POST['OldAccountCode'] . "'";
 
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg =_('The SQL to insert the new chartmaster record failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		DB_IgnoreForeignKeys();
@@ -129,7 +128,7 @@ if(isset($_POST['ProcessGLAccountCode'])) {
 		echo '<br />' . _('Deleting the old chartmaster record');
 		$SQL = "DELETE FROM chartmaster WHERE accountcode='" . $_POST['OldAccountCode'] . "'";
 		$ErrMsg = _('The SQL to delete the old chartmaster record failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<p>' . _('GL account Code') . ': ' . $_POST['OldAccountCode'] . ' ' . _('was successfully changed to') . ' : ' . $_POST['NewAccountCode'];

--- a/Z_ChangeLocationCode.php
+++ b/Z_ChangeLocationCode.php
@@ -20,7 +20,7 @@ if(isset($_POST['ProcessLocationChange'])) {
 	$_POST['NewLocationID'] = mb_strtoupper($_POST['NewLocationID']);
 
 /*First check the location code exists */
-	$Result=DB_query("SELECT loccode FROM locations WHERE loccode='" . $_POST['OldLocationID'] . "'");
+	$Result = DB_query("SELECT loccode FROM locations WHERE loccode='" . $_POST['OldLocationID'] . "'");
 	if(DB_num_rows($Result)==0) {
 		prnMsg(_('The location code') . ': ' . $_POST['OldLocationID'] . ' ' . _('does not currently exist as a location code in the system'),'error');
 		$InputError =1;
@@ -46,7 +46,7 @@ if(isset($_POST['ProcessLocationChange'])) {
 		$InputError =1;
 	}
 /*Now check that the new code doesn't already exist */
-	$Result=DB_query("SELECT loccode FROM locations WHERE loccode='" . $_POST['NewLocationID'] . "'");
+	$Result = DB_query("SELECT loccode FROM locations WHERE loccode='" . $_POST['NewLocationID'] . "'");
 	if(DB_num_rows($Result)!=0) {
 		echo '<br /><br />';
 		prnMsg(_('The replacement location code') . ': ' . $_POST['NewLocationID'] . ' ' . _('already exists as a location code in the system') . ' - ' . _('a unique location code must be entered for the new code'),'error');
@@ -102,63 +102,62 @@ if(isset($_POST['ProcessLocationChange'])) {
 				FROM locations
 				WHERE loccode='" . $_POST['OldLocationID'] . "'";
 
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg =_('The SQL to insert the new location record failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing the BOM table records');
 		$SQL = "UPDATE bom SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the BOM records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing the config table records');
 		$SQL = "UPDATE config SET confvalue='" . $_POST['NewLocationID'] . "' WHERE confvalue='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the BOM records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing the contracts table records');
 		$SQL = "UPDATE contracts SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the contracts records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing the custbranch table records');
 		$SQL = "UPDATE custbranch SET defaultlocation='" . $_POST['NewLocationID'] . "' WHERE defaultlocation='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the custbranch records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing the freightcosts table records');
 		$SQL = "UPDATE freightcosts SET locationfrom='" . $_POST['NewLocationID'] . "' WHERE locationfrom='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the freightcosts records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing the locationusers table records');
 		$SQL = "UPDATE locationusers SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update users records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing stock location records');
 		$SQL = "UPDATE locstock SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update stock location records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing location transfer information (Shipping location)');
 		$SQL = "UPDATE loctransfers SET shiploc='" . $_POST['NewLocationID'] . "' WHERE shiploc='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the loctransfers records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing location transfer information (Receiving location)');
 		$SQL = "UPDATE loctransfers SET recloc='" . $_POST['NewLocationID'] . "' WHERE recloc='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the loctransfers records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		//check if MRP tables exist before assuming
@@ -168,80 +167,80 @@ if(isset($_POST['ProcessLocationChange'])) {
 			echo '<br />' . _('Changing MRP parameters information');
 			$SQL = "UPDATE mrpparameters SET location='" . $_POST['NewLocationID'] . "' WHERE location='" . $_POST['OldLocationID'] . "'";
 			$ErrMsg = _('The SQL to update the mrpparameters records failed');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 			echo ' ... ' . _('completed');
 		}
 
 		echo '<br />' . _('Changing purchase orders information');
 		$SQL = "UPDATE purchorders SET intostocklocation='" . $_POST['NewLocationID'] . "' WHERE intostocklocation='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the purchase orders records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing recurring sales orders information');
 		$SQL = "UPDATE recurringsalesorders SET fromstkloc='" . $_POST['NewLocationID'] . "' WHERE fromstkloc='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the recurring sales orders records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing  sales orders information');
 		$SQL = "UPDATE salesorders SET fromstkloc='" . $_POST['NewLocationID'] . "' WHERE fromstkloc='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update the  sales orders records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing stock check freeze records');
 		$SQL = "UPDATE stockcheckfreeze SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update stock check freeze records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing stockcounts records');
 		$SQL = "UPDATE stockcounts SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update stockcounts records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing stockmoves records');
 		$SQL = "UPDATE stockmoves SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update stockmoves records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing stockrequest records');
 		$SQL = "UPDATE stockrequest SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update stockrequest records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing stockserialitems records');
 		$SQL = "UPDATE stockserialitems SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update stockserialitems records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing tenders records');
 		$SQL = "UPDATE tenders SET location='" . $_POST['NewLocationID'] . "' WHERE location='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update tenders records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing workcentres records');
 		$SQL = "UPDATE workcentres SET location='" . $_POST['NewLocationID'] . "' WHERE location='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update workcentres records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing workorders records');
 		$SQL = "UPDATE workorders SET loccode='" . $_POST['NewLocationID'] . "' WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update workorders records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Changing users records');
 		$SQL = "UPDATE www_users SET defaultlocation='" . $_POST['NewLocationID'] . "' WHERE defaultlocation='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to update users records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		DB_ReinstateForeignKeys();
@@ -251,7 +250,7 @@ if(isset($_POST['ProcessLocationChange'])) {
 		echo '<br />' . _('Deleting the old location record');
 		$SQL = "DELETE FROM locations WHERE loccode='" . $_POST['OldLocationID'] . "'";
 		$ErrMsg = _('The SQL to delete the old location record failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 

--- a/Z_ChangeSalesmanCode.php
+++ b/Z_ChangeSalesmanCode.php
@@ -22,7 +22,7 @@ if (isset($_POST['ProcessSalesmanChange'])){
 	}
 
 /*First check the salesman code exists */
-	$Result=DB_query("SELECT salesmancode FROM salesman WHERE salesmancode='" . $_POST['OldSalesmanCode'] . "'");
+	$Result = DB_query("SELECT salesmancode FROM salesman WHERE salesmancode='" . $_POST['OldSalesmanCode'] . "'");
 	if (DB_num_rows($Result) == 0){
 		prnMsg('<br /><br />' . _('The salesman code') . ': ' . $_POST['OldSalesmanCode'] . ' ' . _('does not currently exist as a sales person code in the system'), 'error');
 		include('includes/footer.php');
@@ -43,7 +43,7 @@ if (isset($_POST['ProcessSalesmanChange'])){
 	$_POST['NewSalesmanCode'] = mb_strtoupper($_POST['NewSalesmanCode']);
 
 /*Now check that the new code doesn't already exist */
-	$Result=DB_query("SELECT salesmancode FROM salesman WHERE salesmancode='" . $_POST['NewSalesmanCode'] . "'");
+	$Result = DB_query("SELECT salesmancode FROM salesman WHERE salesmancode='" . $_POST['NewSalesmanCode'] . "'");
 	if (DB_num_rows($Result)!=0){
 		prnMsg(_('The replacement salesman code') .': ' . $_POST['NewSalesmanCode'] . ' ' . _('already exists as a salesman code in the system') . ' - ' . _('a unique salesman code must be entered for the new code'), 'error');
 		include('includes/footer.php');
@@ -72,39 +72,38 @@ if (isset($_POST['ProcessSalesmanChange'])){
 					FROM salesman
 					WHERE salesmancode='" . $_POST['OldSalesmanCode'] . "'";
 
-	$DbgMsg =_('The SQL that failed was');
 	$ErrMsg = _('The SQL to insert the new salesman master record failed') . ', ' . _('the SQL statement was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing debtor branch records'), 'info');
 	$SQL = "UPDATE custbranch SET salesman='" . $_POST['NewSalesmanCode'] . "' WHERE salesman='" . $_POST['OldSalesmanCode'] . "'";
 
 	$ErrMsg = _('The SQL to update debtor branch records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing debtor transaction records'), 'info');
 	$SQL = "UPDATE debtortrans SET salesperson='" . $_POST['NewSalesmanCode'] . "' WHERE salesperson='" . $_POST['OldSalesmanCode'] . "'";
 
 	$ErrMsg = _('The SQL to update debtor transaction records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing sales analysis records'), 'info');
 	$SQL = "UPDATE salesanalysis SET salesperson='" . $_POST['NewSalesmanCode'] . "' WHERE salesperson='" . $_POST['OldSalesmanCode'] . "'";
 
 	$ErrMsg = _('The SQL to update Sales Analysis records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing sales orders records'), 'info');
 	$SQL = "UPDATE salesorders SET salesperson='" . $_POST['NewSalesmanCode'] . "' WHERE salesperson='" . $_POST['OldSalesmanCode'] . "'";
 
 	$ErrMsg = _('The SQL to update the sales order header records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	prnMsg(_('Changing user salesman records'), 'info');
 	$SQL = "UPDATE www_users SET salesman='" . $_POST['NewSalesmanCode'] . "' WHERE salesman='" . $_POST['OldSalesmanCode'] . "'";
 
 	$ErrMsg = _('The SQL to update the user records failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	DB_IgnoreForeignKeys();
 
@@ -112,7 +111,7 @@ if (isset($_POST['ProcessSalesmanChange'])){
 	$SQL = "DELETE FROM salesman WHERE salesmancode='" . $_POST['OldSalesmanCode'] . "'";
 
 	$ErrMsg = _('The SQL to delete the old salesman record failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	DB_Txn_Commit();
 	DB_ReinstateForeignKeys();

--- a/Z_ChangeStockCategory.php
+++ b/Z_ChangeStockCategory.php
@@ -70,39 +70,38 @@ if (isset($_POST['ProcessStockChange'])) {
 					wipact
 			FROM stockcategory
 			WHERE categoryid='" . $_POST['OldStockCategory'] . "'";
-	$DbgMsg = _('The SQL statement that failed was');
 	$ErrMsg = _('The SQL to insert the new stock category record failed');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	echo ' ... ' . _('completed');
 	echo '<br />' . _('Changing stock properties');
 	$SQL = "UPDATE stockcatproperties SET categoryid='" . $_POST['NewStockCategory'] . "' WHERE categoryid='" . $_POST['OldStockCategory'] . "'";
 	$ErrMsg = _('The SQL to update stock properties records failed');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	echo ' ... ' . _('completed');
 	echo '<br />' . _('Changing stock master records');
 	$SQL = "UPDATE stockmaster SET categoryid='" . $_POST['NewStockCategory'] . "' WHERE categoryid='" . $_POST['OldStockCategory'] . "'";
 	$ErrMsg = _('The SQL to update stock master transaction records failed');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	echo ' ... ' . _('completed');
 	echo '<br />' . _('Changing sales analysis records');
 	$SQL = "UPDATE salesanalysis SET stkcategory='" . $_POST['NewStockCategory'] . "' WHERE stkcategory='" . $_POST['OldStockCategory'] . "'";
 	$ErrMsg = _('The SQL to update Sales Analysis records failed');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	echo ' ... ' . _('completed');
 
 	echo '<br />' . _('Changing internal stock category roles records');
 	$SQL = "UPDATE internalstockcatrole SET categoryid='" . $_POST['NewStockCategory'] . "' WHERE categoryid='" . $_POST['OldStockCategory'] . "'";
 	$ErrMsg = _('The SQL to update internal stock category role records failed');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	echo ' ... ' . _('completed');
 
 	$SQL = 'SET FOREIGN_KEY_CHECKS=1';
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	DB_Txn_Commit();
 	echo '<br />' . _('Deleting the old stock category record');
 	$SQL = "DELETE FROM stockcategory WHERE categoryid='" . $_POST['OldStockCategory'] . "'";
 	$ErrMsg = _('The SQL to delete the old stock category record failed');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	echo ' ... ' . _('completed');
 	echo '<p>' . _('Stock Category') . ': ' . $_POST['OldStockCategory'] . ' ' . _('was successfully changed to') . ' : ' . $_POST['NewStockCategory'];
 }

--- a/Z_ChangeStockCode.php
+++ b/Z_ChangeStockCode.php
@@ -22,7 +22,7 @@ if (isset($_POST['ProcessStockChange'])){
 	$_POST['NewStockID'] = mb_strtoupper($_POST['NewStockID']);
 
 /*First check the stock code exists */
-	$Result=DB_query("SELECT stockid FROM stockmaster WHERE stockid='" . $_POST['OldStockID'] . "'");
+	$Result = DB_query("SELECT stockid FROM stockmaster WHERE stockid='" . $_POST['OldStockID'] . "'");
 	if (DB_num_rows($Result)==0){
 		prnMsg(_('The stock code') . ': ' . $_POST['OldStockID'] . ' ' . _('does not currently exist as a stock code in the system'),'error');
 		$InputError =1;
@@ -40,7 +40,7 @@ if (isset($_POST['ProcessStockChange'])){
 
 
 /*Now check that the new code doesn't already exist */
-	$Result=DB_query("SELECT stockid FROM stockmaster WHERE stockid='" . $_POST['NewStockID'] . "'");
+	$Result = DB_query("SELECT stockid FROM stockmaster WHERE stockid='" . $_POST['NewStockID'] . "'");
 	if (DB_num_rows($Result)!=0){
 		echo '<br /><br />';
 		prnMsg(_('The replacement stock code') . ': ' . $_POST['NewStockID'] . ' ' . _('already exists as a stock code in the system') . ' - ' . _('a unique stock code must be entered for the new code'),'error');
@@ -112,9 +112,8 @@ if (isset($_POST['ProcessStockChange'])){
 				FROM stockmaster
 				WHERE stockid='" . $_POST['OldStockID'] . "'";
 
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg =_('The SQL to insert the new stock master record failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		ChangeFieldInTable("locstock", "stockid", $_POST['OldStockID'], $_POST['NewStockID']);
@@ -195,7 +194,7 @@ if (isset($_POST['ProcessStockChange'])){
 		echo '<br />' . _('Deleting the old stock master record');
 		$SQL = "DELETE FROM stockmaster WHERE stockid='" . $_POST['OldStockID'] . "'";
 		$ErrMsg = _('The SQL to delete the old stock master record failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 		echo '<p>' . _('Stock Code') . ': ' . $_POST['OldStockID'] . ' ' . _('was successfully changed to') . ' : ' . $_POST['NewStockID'];
 

--- a/Z_ChangeSupplierCode.php
+++ b/Z_ChangeSupplierCode.php
@@ -85,28 +85,27 @@ function ProcessSupplier($OldCode, $NewCode) {
 		`phn`, `port`, `email`, `fax`, `telephone`
 		FROM suppliers WHERE supplierid='" . $OldCode . "'";
 
-	$DbgMsg =_('The SQL that failed was');
 	$ErrMsg = _('The SQL to insert the new suppliers master record failed') . ', ' . _('the SQL statement was');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	foreach ($Table_key as $Table=>$key) {
 		prnMsg(_('Changing').' '. $Table.' ' . _('records'),'info');
 		$SQL = "UPDATE " . $Table . " SET $key='" . $NewCode . "' WHERE $key='" . $OldCode . "'";
 		$ErrMsg = _('The SQL to update') . ' ' . $Table . ' ' . _('records failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	}
 
 	prnMsg(_('Deleting the supplier code from the suppliers master table'),'info');
 	$SQL = "DELETE FROM suppliers WHERE supplierid='" . $OldCode . "'";
 
 	$ErrMsg = _('The SQL to delete the old supplier record failed');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 	DB_Txn_Commit();
 }
 
 function checkSupplierExist($CodeSupplier) {
-	$Result=DB_query("SELECT supplierid FROM suppliers WHERE supplierid='" . $CodeSupplier . "'");
+	$Result = DB_query("SELECT supplierid FROM suppliers WHERE supplierid='" . $CodeSupplier . "'");
 	if (DB_num_rows($Result)==0) return false;
 	return true;
 }

--- a/Z_CheckAllocationsFrom.php
+++ b/Z_CheckAllocationsFrom.php
@@ -25,7 +25,7 @@ $SQL = "SELECT debtortrans.type,
 		currencies.decimalplaces
 	HAVING SUM(custallocns.amt) < -alloc";
 
-$Result =DB_query($SQL);
+$Result = DB_query($SQL);
 
 if (DB_num_rows($Result)>0){
 	echo '<table>

--- a/Z_CheckAllocs.php
+++ b/Z_CheckAllocs.php
@@ -55,7 +55,7 @@ while ($MyRow = DB_fetch_array($Result)){
 			WHERE custallocns.transid_allocto='" . $AllocToID . "'";
 
 	$ErrMsg = _('The customer transactions for the selected criteria could not be retrieved because');
-	$TransResult = DB_query($SQL,$ErrMsg);
+	$TransResult = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">';
 

--- a/Z_CreateChartDetails.php
+++ b/Z_CreateChartDetails.php
@@ -43,7 +43,7 @@ if(DB_num_rows($ChartDetailsNotSetUpResult)>0){
 		AND chartdetails.accountcode IS NULL";
 
 	$ErrMsg = _('Inserting new chart details records required failed because');
-	$InsChartDetailsRecords = DB_query($SQL,$ErrMsg);
+	$InsChartDetailsRecords = DB_query($SQL, $ErrMsg);
 
 
 	while ($AccountRow = DB_fetch_array($ChartDetailsNotSetUpResult)){

--- a/Z_DataExport.php
+++ b/Z_DataExport.php
@@ -537,7 +537,7 @@ if ( isset($_POST['pricelist']) ) {
 	echo '<table>';
 	echo '<tr><th colspan="2">' . _('Price List Export') . '</th></tr>';
 	$SQL = 'SELECT sales_type, typeabbrev FROM salestypes';
-	$SalesTypesResult=DB_query($SQL);
+	$SalesTypesResult = DB_query($SQL);
 	echo '<tr><td>' . _('For Sales Type/Price List') . ':</td>';
 	echo '<td><select name="SalesType">';
 	while ($MyRow=DB_fetch_array($SalesTypesResult)){
@@ -546,7 +546,7 @@ if ( isset($_POST['pricelist']) ) {
 	echo '</select></td></tr>';
 
 	$SQL = 'SELECT loccode, locationname FROM locations';
-	$SalesTypesResult=DB_query($SQL);
+	$SalesTypesResult = DB_query($SQL);
 	echo '<tr><td>' . _('For Location') . ':</td>';
 	echo '<td><select name="Location">';
 	while ($MyRow=DB_fetch_array($SalesTypesResult)){
@@ -570,7 +570,7 @@ if ( isset($_POST['pricelist']) ) {
 	echo '<tr><th colspan="2">' . _('Customer List Export') . '</th></tr>';
 
 	$SQL = 'SELECT loccode, locationname FROM locations';
-	$SalesTypesResult=DB_query($SQL);
+	$SalesTypesResult = DB_query($SQL);
 	echo '<tr><td>' . _('For Location') . ':</td>';
 	echo '<td><select name="Location">';
 	while ($MyRow=DB_fetch_array($SalesTypesResult)){

--- a/Z_DeleteCreditNote.php
+++ b/Z_DeleteCreditNote.php
@@ -60,9 +60,8 @@ DB_Txn_Begin(); /* commence a database transaction */
 $SQL = "DELETE FROM custallocns
         WHERE transid_allocfrom ='" . $IDDebtorTrans . "'";
 
-$DbgMsg = _('The SQL that failed was');
 $ErrMsg = _('The custallocns record could not be deleted') . ' - ' . _('the sql server returned the following error');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 
 prnMsg(_('The custallocns record has been deleted'), 'info');
 
@@ -70,18 +69,16 @@ prnMsg(_('The custallocns record has been deleted'), 'info');
 
 $SQL = "DELETE debtortranstaxes FROM debtortranstaxes
                WHERE debtortransid ='" . $IDDebtorTrans . "'";
-$DbgMsg = _('The SQL that failed was');
 $ErrMsg = _('The debtortranstaxes record could not be deleted') . ' - ' . _('the sql server returned the following error');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 
 prnMsg(_('The debtortranstaxes record has been deleted'), 'info');
 
 /*Now delete the DebtorTrans */
 $SQL = "DELETE FROM debtortrans
                WHERE transno ='" . $_GET['CreditNoteNo'] . "' AND Type=11";
-$DbgMsg = _('The SQL that failed was');
 $ErrMsg = _('A problem was encountered trying to delete the Debtor transaction record');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 
 /*Now reverse updated SalesOrderDetails for the quantities credited */
 
@@ -92,7 +89,7 @@ foreach ($StockMovement as $CreditLine) {
                        AND stkcode = '" . $CreditLine['stockid'] . "'";
 
 	$ErrMsg =_('A problem was encountered attempting to reverse the update the sales order detail record') . ' - ' . _('the SQL server returned the following error message');
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 /*reverse the update to LocStock */
 
@@ -102,7 +99,7 @@ foreach ($StockMovement as $CreditLine) {
 
 	$ErrMsg = _('SQL to reverse update to the location stock records failed with the error');
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 
 /*Delete Sales Analysis records
  * This is unreliable as the salesanalysis record contains totals for the item cust custbranch periodno */
@@ -115,7 +112,7 @@ foreach ($StockMovement as $CreditLine) {
 
 	$ErrMsg = _('The SQL to delete the sales analysis records with the message');
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 }
 
 /* Delete the stock movements  */
@@ -124,7 +121,7 @@ $SQL = "DELETE stockmovestaxes.* FROM stockmovestaxes INNER JOIN stockmoves
                WHERE stockmoves.type=11 AND stockmoves.transno = '" . $_GET['CreditNoteNo'] . "'";
 
 $ErrMsg = _('SQL to delete the stock movement tax records failed with the message');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 prnMsg(_('Deleted the credit note stock move taxes'), 'info');
 echo '<br /><br />';
 
@@ -135,7 +132,7 @@ $SQL = "DELETE stockserialmoves.* FROM stockserialmoves INNER JOIN stockmoves
                WHERE stockmoves.type=11 AND stockmoves.transno = '" . $_GET['CreditNoteNo'] . "'";
 
 $ErrMsg = _('SQL to delete the stock serial moves records failed with the message');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 prnMsg(_('Deleted the credit note stock serial moves'), 'info');
 echo '<br /><br />';
 
@@ -144,14 +141,14 @@ $SQL = "DELETE FROM stockmoves
                WHERE type=11 AND transno = '" . $_GET['CreditNoteNo'] . "'";
 
 $ErrMsg = _('SQL to delete the stock movement record failed with the message');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 prnMsg(_('Deleted the credit note stock movements'), 'info');
 echo '<br /><br />';
 
 
 $SQL = "DELETE FROM gltrans WHERE type=11 AND typeno= '" . $_GET['CreditNoteNo'] . "'";
 $ErrMsg = _('SQL to delete the gl transaction records failed with the message');
-$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 prnMsg(_('Deleted the credit note general ledger transactions'), 'info');
 
 DB_Txn_Commit();

--- a/Z_DeleteInvoice.php
+++ b/Z_DeleteInvoice.php
@@ -77,7 +77,7 @@ $SQL = "DELETE FROM orderdeliverydifferenceslog
                AND invoiceno = '" . $_GET['InvoiceNo'] . "'";
 
 $ErrMsg = _('The SQL to delete the delivery differences records failed because');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 prnMsg(_('Any order delivery differences records have been deleted'),'info');
 
 /*Now delete the custallocns */
@@ -85,9 +85,8 @@ prnMsg(_('Any order delivery differences records have been deleted'),'info');
 $SQL = "DELETE custallocns FROM custallocns
         WHERE transid_allocto ='" . $IDDebtorTrans . "'";
 
-$DbgMsg = _('The SQL that failed was');
 $ErrMsg = _('The custallocns record could not be deleted') . ' - ' . _('the sql server returned the following error');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 
 prnMsg(_('The custallocns record has been deleted'),'info');
 
@@ -95,9 +94,8 @@ prnMsg(_('The custallocns record has been deleted'),'info');
 
 $SQL = "DELETE debtortranstaxes FROM debtortranstaxes
                WHERE debtortransid ='" . $IDDebtorTrans . "'";
-$DbgMsg = _('The SQL that failed was');
 $ErrMsg = _('The debtortranstaxes record could not be deleted') . ' - ' . _('the sql server returned the following error');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 
 prnMsg(_('The debtortranstaxes record has been deleted'),'info');
 
@@ -107,9 +105,8 @@ prnMsg(_('The debtortranstaxes record has been deleted'),'info');
 $SQL = "DELETE FROM debtortrans
                WHERE transno ='" . $_GET['InvoiceNo'] . "'
                AND debtortrans.type=10";
-$DbgMsg = _('The SQL that failed was');
 $ErrMsg = _('The debtorTrans record could not be deleted') . ' - ' . _('the sql server returned the following error');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 
 prnMsg(_('The debtor transaction record has been deleted'),'info');
 
@@ -124,13 +121,13 @@ foreach ($StockMovement as $OrderLine) {
                                 AND stkcode = '" . $OrderLine['stockid'] . "'";
 
 	$ErrMsg = _('The SQL to reverse the update of the sales order detail records failed because');
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
     prnMsg(_('The sales order records have been updated as not invoiced'),'info');
 /*reverse the update to LocStock */
     if ($OrderLine['mbflag']!='A' AND $OrderLine['mbflag']!='D'){
 
         	$ErrMsg = _('The SQL to reverse update to the location stock records failed because');
-	        $Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	        $Result = DB_query($SQL, $ErrMsg, '', true);
              prnMsg(_('Reversed the location stock quantities for items that decreased'),'info');
     }
 
@@ -146,7 +143,7 @@ Delete Sales Analysis records */
 
 	$ErrMsg = _('The SQL to delete the sales analysis records failed because');
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg,true);
+	$Result = DB_query($SQL, $ErrMsg, '',true);
 	prnMsg(_('Sales analysis records deleted') . ' - ' . _('this deleted all sales analysis for the customer/branch and items on this invoice'),'info');
 }
 
@@ -155,7 +152,7 @@ $SQL = "DELETE stockmovestaxes.* FROM stockmovestaxes INNER JOIN stockmoves
 		WHERE stockmoves.type=10 AND stockmoves.transno = '" . $_GET['InvoiceNo'] . "'";
 
 $ErrMsg = _('SQL to delete the stock movement tax records failed with the message');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 prnMsg(_('Deleted the credit note stock move taxes').'info');
 echo '<br /><br />';
 
@@ -163,14 +160,14 @@ echo '<br /><br />';
 $SQL = "DELETE FROM stockmoves WHERE type=10 AND transno = '" . $_GET['InvoiceNo'] . "'";
 
 $ErrMsg = _('The SQL to delete the stock movement records failed because');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 prnMsg(_('The stock movement records associated with the invoice have been deleted'),'info');
 echo '<br /><br />';
 
 /* Delete any GL Transaction records*/
 $SQL = "DELETE FROM gltrans WHERE gltrans.type=10 AND gltrans.typeno='" . $_GET['InvoiceNo'] . "'";
 $ErrMsg = _('The SQL to delete the general ledger journal records failed because');
-$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+$Result = DB_query($SQL, $ErrMsg, '', true);
 prnMsg(_('The GL journal records associated with the invoice have been deleted'),'info');
 
 DB_Txn_Commit();

--- a/Z_DeleteOldPrices.php
+++ b/Z_DeleteOldPrices.php
@@ -11,7 +11,7 @@ $Result = DB_query("UPDATE prices SET enddate='9999-12-31' WHERE enddate='1000-0
 if (isset($_POST['DeleteOldPrices'])){
 	DB_Txn_Begin();
 
-	$Result = DB_query("DELETE FROM prices WHERE enddate<'" . Date('Y-m-d') . "'",'','',true);
+	$Result = DB_query("DELETE FROM prices WHERE enddate<'" . Date('Y-m-d') . "'", '', '', true);
 	$Result = DB_query("SELECT stockid,
 							typeabbrev,
 							currabrev,

--- a/Z_DescribeTable.php
+++ b/Z_DescribeTable.php
@@ -5,7 +5,7 @@ $Title = _('Database table details');
 include('includes/header.php');
 
 $SQL='DESCRIBE '.$_GET['table'];
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 
 echo '<table><tr>';
 echo '<th>' . _('Field name') . '</th>';

--- a/Z_GLAccountUsersCopyAuthority.php
+++ b/Z_GLAccountUsersCopyAuthority.php
@@ -29,9 +29,8 @@ if(isset($_POST['ProcessCopyAuthority'])) {
 
 		echo '<br />' . _('Deleting the current authority to view / update the GL Accounts of user') . ' ' .  $_POST['ToUserID'];
 		$SQL = "DELETE FROM glaccountusers WHERE userid = '" . $_POST['ToUserID'] . "'";
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg =_('The SQL to delete the auhority in glaccountusers record failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 
 		echo '<br />' . _('Copying the authority to view / update the GL Accounts from user') . ' ' . $_POST['FromUserID'] . ' ' . _('to') . ' ' . $_POST['ToUserID'];
@@ -40,9 +39,8 @@ if(isset($_POST['ProcessCopyAuthority'])) {
 						FROM glaccountusers
 						WHERE userid = '" . $_POST['FromUserID'] . "'";
 
-		$DbgMsg = _('The SQL statement that failed was');
 		$ErrMsg =_('The SQL to insert the auhority in glaccountusers record failed');
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 		echo ' ... ' . _('completed');
 		echo '<br />';
 		DB_Txn_Commit();

--- a/Z_ImportChartOfAccounts.php
+++ b/Z_ImportChartOfAccounts.php
@@ -94,8 +94,7 @@ if (isset($_FILES['ChartFile']) and $_FILES['ChartFile']['name']) { //start file
 										'" . $MyRow[2] . "')";
 
 			$ErrMsg =  _('The general ledger account could not be added because');
-			$DbgMsg = _('The SQL that was used to add the general ledger account that failed was');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 		}
 
 		if ($InputError == 1) { //this row failed so exit loop

--- a/Z_ImportCustbranch.php
+++ b/Z_ImportCustbranch.php
@@ -74,35 +74,35 @@ if (isset($_FILES['userfile']) and $_FILES['userfile']['name']) { //start file p
 	$Salesmen=array();
 	$SQL = "SELECT salesmancode
 				     FROM salesman";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	while ($MyRow = DB_fetch_array($Result)) {
 		$Salesmen[]=$MyRow['salesmancode'];
 	}
 	$Areas=array();
 	$SQL = "SELECT areacode
 				     FROM areas";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	while ($MyRow = DB_fetch_array($Result)) {
 		$Areas[]=$MyRow['areacode'];
 	}
 	$Locations=array();
 	$SQL = "SELECT loccode
 				     FROM locations";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	while ($MyRow = DB_fetch_array($Result)) {
 		$Locations[]=$MyRow['loccode'];
 	}
 	$Shippers=array();
 	$SQL = "SELECT shipper_id
 				     FROM shippers";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	while ($MyRow = DB_fetch_array($Result)) {
 		$Shippers[]=$MyRow['shipper_id'];
 	}
 	$Taxgroups=array();
 	$SQL = "SELECT taxgroupid
 				     FROM taxgroups";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	while ($MyRow = DB_fetch_array($Result)) {
 		$Taxgroups[]=$MyRow['taxgroupid'];
 	}
@@ -351,7 +351,7 @@ if (isset($_FILES['userfile']) and $_FILES['userfile']['name']) { //start file p
 					$SQL = "SELECT 1
 						 FROM debtorsmaster
 						 WHERE debtorno='".$_POST['DebtorNo']."' LIMIT 1";
-					$Result=DB_query($SQL);
+					$Result = DB_query($SQL);
 					$DebtorExists=(DB_num_rows($Result)>0);
 					if ($DebtorExists) {
 						$ExistDebtorNos[]=$_POST['DebtorNo'];
@@ -366,7 +366,7 @@ if (isset($_FILES['userfile']) and $_FILES['userfile']['name']) { //start file p
 				     FROM custbranch
            			 WHERE debtorno='".$_POST['DebtorNo']."' AND
 				           branchcode='".$_POST['BranchCode']."' LIMIT 1";
-				$Result=DB_query($SQL);
+				$Result = DB_query($SQL);
 				$BranchExists=(DB_num_rows($Result)>0);
 				if ($BranchExists AND $_POST['UpdateIfExists']!=1) {
 					$ExistedBranches[] = array('debtor'=>$_POST['DebtorNo'],

--- a/Z_ImportFixedAssets.php
+++ b/Z_ImportFixedAssets.php
@@ -214,8 +214,7 @@ if (isset($_FILES['SelectedAssetFile']['name'])) { //start file processing
 									'" . FormatDateForSQL($DatePurchased) . "')";
 
 			$ErrMsg =  _('The asset could not be added because');
-			$DbgMsg = _('The SQL that was used to add the asset and failed was');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			if (DB_error_no() ==0) { //the insert of the new code worked so bang in the fixedassettrans records too
 
@@ -239,8 +238,7 @@ if (isset($_FILES['SelectedAssetFile']['name'])) { //start file processing
 											'" . $Cost . "')";
 
 				$ErrMsg =  _('The transaction for the cost of the asset could not be added because');
-				$DbgMsg = _('The SQL that was used to add the fixedasset trans record that failed was');
-				$InsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$InsResult = DB_query($SQL, $ErrMsg);
 
 				$SQL = "INSERT INTO fixedassettrans ( assetid,
 													transtype,
@@ -260,8 +258,7 @@ if (isset($_FILES['SelectedAssetFile']['name'])) { //start file processing
 											'" . $AccumDepn . "')";
 
 				$ErrMsg =  _('The transaction for the cost of the asset could not be added because');
-				$DbgMsg = _('The SQL that was used to add the fixedasset trans record that failed was');
-				$InsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$InsResult = DB_query($SQL, $ErrMsg);
 
 				if (DB_error_no() ==0) {
 					prnMsg( _('Inserted the new asset:') . ' ' . $Description,'info');

--- a/Z_ImportGLAccountGroups.php
+++ b/Z_ImportGLAccountGroups.php
@@ -12,7 +12,7 @@ include('includes/header.php');
 
 //$weberpuser = $_SESSION['UserID'];
 //$SQL="SELECT password FROM www_users WHERE userid='" . $weberpuser . "'";
-//$Result=DB_query($SQL);
+//$Result = DB_query($SQL);
 //$MyRow=DB_fetch_array($Result);
 //$weberppassword = $MyRow[0];
 

--- a/Z_ImportGLAccountSections.php
+++ b/Z_ImportGLAccountSections.php
@@ -12,7 +12,7 @@ include('includes/header.php');
 
 //$webERPUser = $_SESSION['UserID'];
 //$SQL="SELECT password FROM www_users WHERE userid='" . $webERPUser ."'";
-//$Result=DB_query($SQL);
+//$Result = DB_query($SQL);
 //$MyRow=DB_fetch_array($Result);
 //$weberppassword = $MyRow[0];
 

--- a/Z_ImportPartCodes.php
+++ b/Z_ImportPartCodes.php
@@ -12,7 +12,7 @@ include('includes/header.php');
 
 //$webERPUser = $_SESSION['UserID'];
 //$SQL="SELECT password FROM www_users WHERE userid='" . $webERPUser."'";
-//$Result=DB_query($SQL);
+//$Result = DB_query($SQL);
 //$MyRow=DB_fetch_array($Result);
 //$weberppassword = $MyRow[0];
 

--- a/Z_ImportPriceList.php
+++ b/Z_ImportPriceList.php
@@ -127,8 +127,7 @@ if (isset($_FILES['PriceListFile']) and $_FILES['PriceListFile']['name']) { //st
 										'" . FormatDateForSQL($_POST['StartDate']) . "')";
 
 			$ErrMsg =  _('The price could not be added because');
-			$DbgMsg = _('The SQL that was used to add the price failed was');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 		}
 
 		if ($InputError == 1) { //this row failed so exit loop

--- a/Z_ImportStocks.php
+++ b/Z_ImportStocks.php
@@ -230,8 +230,7 @@ if (isset($_FILES['userfile']) and $_FILES['userfile']['name']) { //start file p
 			";
 
 			$ErrMsg =  _('The item could not be added because');
-			$DbgMsg = _('The SQL that was used to add the item failed was');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+			$Result = DB_query($SQL, $ErrMsg);
 
 			if (DB_error_no() ==0) { //the insert of the new code worked so bang in the stock location records too
 
@@ -242,8 +241,7 @@ if (isset($_FILES['userfile']) and $_FILES['userfile']['name']) { //start file p
 									FROM locations";
 
 				$ErrMsg =  _('The locations for the item') . ' ' . $StockID .  ' ' . _('could not be added because');
-				$DbgMsg = _('NB Locations records can be added by opening the utility page') . ' <i>Z_MakeStockLocns.php</i> ' . _('The SQL that was used to add the location records that failed was');
-				$InsResult = DB_query($SQL,$ErrMsg,$DbgMsg);
+				$InsResult = DB_query($SQL, $ErrMsg);
 
 				if (DB_error_no() ==0) {
 					prnMsg( _('New Item') .' ' . $StockID  . ' '. _('has been added to the transaction'),'info');

--- a/Z_ImportSuppliers.php
+++ b/Z_ImportSuppliers.php
@@ -199,7 +199,7 @@ if(isset($_FILES['userfile']) and $_FILES['userfile']['name']) { //start file pr
 
 			//first off validate inputs sensible
 			$SQL="SELECT COUNT(supplierid) FROM suppliers WHERE supplierid='".$SupplierID."'";
-			$Result=DB_query($SQL);
+			$Result = DB_query($SQL);
 			$MyRow=DB_fetch_row($Result);
 
 			$SuppExists = ($MyRow[0]>0);
@@ -250,9 +250,7 @@ if(isset($_FILES['userfile']) and $_FILES['userfile']['name']) { //start file pr
 				}
 
 				$ErrMsg = _('The supplier could not be updated because');
-				$DbgMsg = _('The SQL that was used to update the supplier but failed was');
-				// echo $SQL;
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 
 			} else { //its a new supplier
 				$InsertNum++;
@@ -306,9 +304,8 @@ if(isset($_FILES['userfile']) and $_FILES['userfile']['name']) { //start file pr
 										'" . $_POST['TaxRef'] . "')";
 
 				$ErrMsg = _('The supplier') . ' ' . $_POST['SuppName'] . ' ' . _('could not be added because');
-				$DbgMsg = _('The SQL that was used to insert the supplier but failed was');
 
-				$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+				$Result = DB_query($SQL, $ErrMsg);
 
 			}
 			if(DB_error_no() ==0) {

--- a/Z_MakeLocUsers.php
+++ b/Z_MakeLocUsers.php
@@ -21,7 +21,7 @@ $SQL = "INSERT INTO locationusers (userid, loccode, canview, canupd)
         WHERE locationusers.userid IS NULL;";
 
 $ErrMsg = _('The users/locations that need user location records created cannot be retrieved because');
-$Result = DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 echo '<p />';
 prnMsg(_('Any users that may not have had user location records have now been given new location user records'),'info');

--- a/Z_MakeStockLocns.php
+++ b/Z_MakeStockLocns.php
@@ -19,7 +19,7 @@ $SQL = "INSERT INTO locstock (stockid, loccode)
                 WHERE locstock.stockid IS NULL";
 
 $ErrMsg = _('The items/locations that need stock location records created cannot be retrieved because');
-$Result = DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 echo '<p />';
 prnMsg(_('Any stock items that may not have had stock location records have now been given new location stock records'),'info');

--- a/Z_ReApplyCostToSA.php
+++ b/Z_ReApplyCostToSA.php
@@ -46,7 +46,7 @@ if (isset($_POST['UpdateSalesAnalysis']) AND $_POST['PeriodNo']!=0){
 
 
 	$ErrMsg = _('Could not retrieve the sales analysis records to be updated because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	while ($ItemsToUpdate = DB_fetch_array($Result)){
 
@@ -59,7 +59,7 @@ if (isset($_POST['UpdateSalesAnalysis']) AND $_POST['PeriodNo']!=0){
 					AND bom.effectiveafter < '" . Date('Y-m-d') . "'";
 
 			$ErrMsg = _('Could not recalculate the current cost of the assembly item') . $ItemsToUpdate['stockid'] . ' ' . _('because');
-			$AssemblyCostResult = DB_query($SQL,$ErrMsg);
+			$AssemblyCostResult = DB_query($SQL, $ErrMsg);
 			$AssemblyCost = DB_fetch_row($AssemblyCostResult);
 			$Cost = $AssemblyCost[0];
 		} else {
@@ -71,7 +71,7 @@ if (isset($_POST['UpdateSalesAnalysis']) AND $_POST['PeriodNo']!=0){
 				AND periodno ='" . $_POST['PeriodNo'] . "'";
 
 		$ErrMsg = _('Could not update the sales analysis records for') . ' ' . $ItemsToUpdate['stockid'] . ' ' . _('because');
-		$UpdResult = DB_query($SQL,$ErrMsg);
+		$UpdResult = DB_query($SQL, $ErrMsg);
 
 
 		prnMsg(_('Updated sales analysis for period') . ' ' . $_POST['PeriodNo'] . ' ' . _('and stock item') . ' ' . $ItemsToUpdate['stockid'] . ' ' . _('using a cost of') . ' ' . $Cost,'success');

--- a/Z_RebuildSalesAnalysis.php
+++ b/Z_RebuildSalesAnalysis.php
@@ -58,7 +58,7 @@ $SQL = "INSERT INTO salesanalysis (typeabbrev,
 		ORDER BY prd";
 
 $ErrMsg = _('The sales analysis data could not be recreated because');
-$Result = DB_query($SQL,$ErrMsg);
+$Result = DB_query($SQL, $ErrMsg);
 
 echo '<p />';
 prnMsg(_('The sales analsysis data has been recreated based on current stock master and customer master information'),'info');

--- a/Z_ReverseSuppPaymentRun.php
+++ b/Z_ReverseSuppPaymentRun.php
@@ -48,7 +48,7 @@ if (isset($_POST['RevPayts']) AND Is_Date($_POST['PaytDate'])==1){
 					AND transno='" . $Alloc['transno'] . "'";
 
 			$ErrMsg =_('The update to the suppliers charges that were settled by the payment failed because');
-			$UpdResult = DB_query($SQL,$ErrMsg);
+			$UpdResult = DB_query($SQL, $ErrMsg);
 
 		}
 

--- a/Z_UpdateItemCosts.php
+++ b/Z_UpdateItemCosts.php
@@ -71,7 +71,7 @@ if (isset($_FILES['CostUpdateFile']) and $_FILES['CostUpdateFile']['name']) { //
 						overheadcost";
 
 		$ErrMsg = _('The selected item code does not exist');
-	    $OldResult = DB_query($SQL,$ErrMsg);
+	    $OldResult = DB_query($SQL, $ErrMsg);
 	    $OldRow = DB_fetch_array($OldResult);
 	    $QOH = $OldRow['totalqoh'];
 
@@ -92,11 +92,9 @@ if (isset($_FILES['CostUpdateFile']) and $_FILES['CostUpdateFile']['name']) { //
 									WHERE stockid='" . $StockID . "'";
 
 			$ErrMsg = _('The cost details for the stock item could not be updated because');
-			$DbgMsg = _('The SQL that failed was');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			UpdateCost($StockID); //Update any affected BOMs
-
 		}
 
 		$LineNumber++;

--- a/Z_UpdateSalesAnalysisWithLatestCustomerData.php
+++ b/Z_UpdateSalesAnalysisWithLatestCustomerData.php
@@ -27,7 +27,7 @@ if (isset($_POST['UpdateSalesAnalysis'])){
 			ON debtorsmaster.debtorno=custbranch.debtorno";
 
 	$ErrMsg = _('Could not retrieve the customer records to be updated because');
-	$Result = DB_query($SQL,$ErrMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	while ($CustomerRow = DB_fetch_array($Result)){
 
@@ -38,7 +38,7 @@ if (isset($_POST['UpdateSalesAnalysis'])){
 				AND custbranch ='" . $CustomerRow['branchcode'] . "'";
 
 		$ErrMsg = _('Could not update the sales analysis records for') . ' ' . $CustomerRow['debtorno'] . ' ' . _('because');
-		$UpdResult = DB_query($SQL,$ErrMsg);
+		$UpdResult = DB_query($SQL, $ErrMsg);
 
 		prnMsg(_('Updated sales analysis for customer code') . ': ' . $CustomerRow['debtorno'] . ' ' . _('and branch code') . ': ' . $CustomerRow['branchcode'],'success');
 	}

--- a/Z_Upgrade3.10.php
+++ b/Z_Upgrade3.10.php
@@ -19,11 +19,11 @@ if ($_POST['DoUpgrade'] == _('Perform Upgrade')){
     $SQL='SELECT count(typeid)
             FROM debtortype
             WHERE typeid=1';
-    $Result=DB_query($SQL);
+    $Result = DB_query($SQL);
     $MyRow=DB_fetch_array($Result);
     if ($MyRow[0]==0) {
         $SQL='INSERT INTO `debtortype` ( `typeid` , `typename` ) VALUES (1, "Default")';
-        $Result=DB_query($SQL);
+        $Result = DB_query($SQL);
         if (DB_error_no()==0) {
             echo '<td>' . _('Success') . '</td></tr>';
         } else {
@@ -36,11 +36,11 @@ if ($_POST['DoUpgrade'] == _('Perform Upgrade')){
     $SQL="SELECT count(id)
             FROM factorcompanies
             WHERE coyname='None'";
-    $Result=DB_query($SQL);
+    $Result = DB_query($SQL);
     $MyRow=DB_fetch_array($Result);
     if ($MyRow[0]==0) {
         $SQL='INSERT INTO `factorcompanies` ( `id` , `coyname` ) VALUES (null, "None")';
-        $Result=DB_query($SQL);
+        $Result = DB_query($SQL);
         if (DB_error_no()==0) {
             echo '<td>' . _('Success') . '</td></tr>';
         } else {
@@ -51,10 +51,10 @@ if ($_POST['DoUpgrade'] == _('Perform Upgrade')){
     }
     echo '<tr><td>' . _('Adding quotedate to salesorders table') . '</td>';
     $SQL='DESCRIBE `salesorders` `quotedate`';
-    $Result=DB_query($SQL);
+    $Result = DB_query($SQL);
     if (DB_num_rows($Result)==0) {
         $SQL='ALTER TABLE `salesorders` ADD `quotedate` date NOT NULL default "0000-00-00"';
-        $Result=DB_query($SQL);
+        $Result = DB_query($SQL);
         if (DB_error_no()==0) {
             echo '<td>' . _('Success') . '</td></tr>';
         } else {
@@ -65,10 +65,10 @@ if ($_POST['DoUpgrade'] == _('Perform Upgrade')){
     }
     echo '<tr><td>' . _('Adding confirmeddate to salesorders table') . '</td>';
     $SQL='DESCRIBE `salesorders` `confirmeddate`';
-    $Result=DB_query($SQL);
+    $Result = DB_query($SQL);
     if (DB_num_rows($Result)==0) {
         $SQL="ALTER TABLE `salesorders` ADD `confirmeddate` date NOT NULL default '0000-00-00'";
-        $Result=DB_query($SQL);
+        $Result = DB_query($SQL);
         if (DB_error_no()==0) {
             echo '<td>' . _('Success') . '</td></tr>';
         } else {

--- a/api/api_customers.php
+++ b/api/api_customers.php
@@ -9,7 +9,7 @@
 		$Searchsql = "SELECT count(debtorno)
   				     FROM debtorsmaster
 				     WHERE debtorno='".$DebtorNumber."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] != 0) {
 			$Errors[$i] = DebtorNoAlreadyExists;
@@ -22,7 +22,7 @@
 		$Searchsql = "SELECT count(debtorno)
 				     FROM debtorsmaster
 				     WHERE debtorno='".$DebtorNumber."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0) {
 			$Errors[$i] = DebtorDoesntExist;
@@ -51,7 +51,7 @@
 		$Searchsql = "SELECT COUNT(currabrev)
 					  FROM currencies
 					  WHERE currabrev='".$CurrCode."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] == 0) {
 			$Errors[$i] = CurrencyCodeNotSetup;
@@ -64,7 +64,7 @@
 		$Searchsql = "SELECT COUNT(typeabbrev)
 					 FROM salestypes
 					  WHERE typeabbrev='".$SalesType."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] == 0) {
 			$Errors[$i] = SalesTypeNotSetup;
@@ -85,7 +85,7 @@
 		$Searchsql = "SELECT COUNT(reasoncode)
 					 FROM holdreasons
 					  WHERE reasoncode='".$HoldReason."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] == 0) {
 			$Errors[$i] = HoldReasonNotSetup;
@@ -98,7 +98,7 @@
 		$Searchsql = "SELECT COUNT(termsindicator)
 					 FROM paymentterms
 					  WHERE termsindicator='".$PaymentTerms."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] == 0) {
 			$Errors[$i] = PaymentTermsNotSetup;
@@ -232,7 +232,7 @@
 		$Searchsql = "SELECT COUNT(typeid)
 					 FROM debtortype
 					  WHERE typeid='".$DebtorType."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] == 0) {
 			$Errors[$i] = CustomerTypeNotSetup;

--- a/api/api_debtortransactions.php
+++ b/api/api_debtortransactions.php
@@ -6,7 +6,7 @@
 		$Searchsql = "SELECT count(transno)
 				FROM debtortrans
 				WHERE type='".$Type."' and transno='".$TransNo . "'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]>0) {
 			$Errors[$i] = TransactionNumberAlreadyExists;
@@ -49,7 +49,7 @@ function ConvertToSQLDate($DateEntry) {
  * target webERP company */
 	function VerifyTransactionDate($TranDate, $i, $Errors) {
 		$SQL="SELECT confvalue FROM config WHERE confname='DefaultDateFormat'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 		$DateFormat=$MyRow[0];
 		if (mb_strpos($TranDate,'/')>0) {
@@ -85,7 +85,7 @@ function ConvertToSQLDate($DateEntry) {
  * This function doesn't create periods if required so there is the danger of not being able to insert transactions*/
 	function GetPeriodFromTransactionDate($TranDate, $i, $Errors) {
 		$SQL="SELECT confvalue FROM config WHERE confname='DefaultDateFormat'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 		$DateFormat=$MyRow[0];
 		if (mb_strstr('/',$PeriodEnd)) {
@@ -116,7 +116,7 @@ function ConvertToSQLDate($DateEntry) {
 		$Year=$DateArray[0];
 		$Date=$Year.'-'.$Month.'-'.$Day;
 		$SQL="SELECT MAX(periodno) FROM periods WHERE lastdate_in_period<='" . $Date . "'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 		return $MyRow[0];
 	}
@@ -250,7 +250,7 @@ function ConvertToSQLDate($DateEntry) {
 	function GetSalesGLCode($salesarea, $partnumber) {
 		$SQL="SELECT salesglcode FROM salesglpostings
 			WHERE stkcat='any'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 		return $MyRow[0];
 	}
@@ -259,7 +259,7 @@ function ConvertToSQLDate($DateEntry) {
 /* Retrieves the default debtors code for webERP */
 	function GetDebtorsGLCode() {
 		$SQL="SELECT debtorsact FROM companies";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 		return $MyRow[0];
 	}
@@ -368,7 +368,7 @@ function ConvertToSQLDate($DateEntry) {
 						'" . round($Receipt['amountfx'] / $ReceiptExRate,4) . "',
 						'" . $CustCurrRow['currcode'] . "')";
 
-		$Result = api_DB_query($SQL,'','',true);
+		$Result = api_DB_query($SQL,'', '', true);
 
 
 		if ($CompanyRecord['gllink_debtors']==1) {
@@ -388,7 +388,7 @@ function ConvertToSQLDate($DateEntry) {
 						'" . mb_substr($Receipt['reference'], 0, 200) . "',
 						'" . round((-$Receipt['amountfx']-$Receipt['discountfx']) / $CustCurrRow['rate'],4) . "')";
 
-			$Result = api_DB_query($SQL,'','',true);
+			$Result = api_DB_query($SQL,'', '', true);
 
 			if($Receipt['discountfx']!=0){
 				$SQL="INSERT INTO gltrans ( type,
@@ -406,7 +406,7 @@ function ConvertToSQLDate($DateEntry) {
 						'" . mb_substr($Receipt['reference'], 0, 200) . "',
 						'" . round($Receipt['discountfx'] / $CustCurrRow['rate'],4) . "')";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 			}
 		/*and debit bank account with the receipt */
 			$SQL="INSERT INTO gltrans ( type,
@@ -425,7 +425,7 @@ function ConvertToSQLDate($DateEntry) {
 						'" . mb_substr($Receipt['reference'], 0, 200) . "',
 						'" . round($Receipt['amountfx'] / $CustCurrRow['rate'],4) . "')";
 
-			$Result = api_DB_query($SQL,'','',true);
+			$Result = api_DB_query($SQL,'', '', true);
 
 		} /* end if GL linked to debtors */
 
@@ -452,13 +452,13 @@ function ConvertToSQLDate($DateEntry) {
 							'" . -$Receipt['discountfx'] . "',
 							'" . $Receipt['paymentmethod'] . "')";
 
-		$Result = api_DB_query($SQL,'','',true);
+		$Result = api_DB_query($SQL,'', '', true);
 
 		$SQL = "UPDATE debtorsmaster SET lastpaiddate = '" . $Receipt['trandate'] . "',
 						lastpaid='" . $Receipt['amountfx'] ."'
 					WHERE debtorsmaster.debtorno='" . $Receipt['debtorno'] . "'";
 
-		$Result = api_DB_query($SQL,'','',true);
+		$Result = api_DB_query($SQL,'', '', true);
 
 
 		if (sizeof($Errors)==0) {
@@ -660,7 +660,7 @@ function ConvertToSQLDate($DateEntry) {
 						WHERE locstock.stockid = '" . $CN_Line['stockid'] . "'
 						AND loccode = '" . $Header['fromstkloc'] . "'";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 				$SQL = "INSERT INTO stockmoves (stockid,
 												type,
@@ -691,7 +691,7 @@ function ConvertToSQLDate($DateEntry) {
 								'" . $StandardCost . "',
 								'" . ($QtyOnHandPrior - $CN_Line['qty']) . "' )";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 			} else if ($LineRow['mbflag']=='A'){ /* its an assembly */
 				/*Need to get the BOM for this part and make
@@ -757,14 +757,14 @@ function ConvertToSQLDate($DateEntry) {
 												 0,
 												 '" . ($QtyOnHandPrior - ($AssParts['quantity'] * $CN_Line['qty'])) . "'	)";
 
-					$Result = DB_query($SQL,'','',true);
+					$Result = DB_query($SQL,'', '', true);
 
 					$SQL = "UPDATE locstock
 							SET quantity = locstock.quantity - " . ($AssParts['quantity'] * $CN_Line['qty']) . "
 							WHERE locstock.stockid = '" . $AssParts['component'] . "'
 							AND loccode = '" . $Header['fromlocstk'] . "'";
 
-					$Result = DB_query($SQL,'','',true);
+					$Result = DB_query($SQL,'', '', true);
 				} /* end of assembly explosion and updates */
 			} /* end of its an assembly */
 
@@ -801,7 +801,7 @@ function ConvertToSQLDate($DateEntry) {
 								'" . $StandardCost . "',
 								'0' )";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 			}
 			/*Get the ID of the StockMove... */
 			$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -819,7 +819,7 @@ function ConvertToSQLDate($DateEntry) {
 							'" . $Tax['TaxCalculationOrder'] . "',
 							'" . $Tax['TaxOnTax'] . "')";
 
-				$Result = DB_query($SQL,'','',true);
+				$Result = DB_query($SQL,'', '', true);
 			}
 
 			/*Insert Sales Analysis records */
@@ -857,7 +857,7 @@ function ConvertToSQLDate($DateEntry) {
 						salesanalysis.typeabbrev,
 						salesanalysis.salesperson";
 
-			$Result = api_DB_query($SQL,'','',true);
+			$Result = api_DB_query($SQL,'', '', true);
 
 			$MyRow = DB_fetch_row($Result);
 
@@ -912,7 +912,7 @@ function ConvertToSQLDate($DateEntry) {
 
 			}
 
-			$Result = api_DB_query($SQL,'','',true);
+			$Result = api_DB_query($SQL,'', '', true);
 
 			if ($CompanyRecord['gllink_stock']==1 AND $StandardCost !=0){
 
@@ -933,7 +933,7 @@ function ConvertToSQLDate($DateEntry) {
 										'" . mb_substr($Header['debtorno'] . " - " . $CN_Line['stockid'] . " x " . $CN_Line['qty'] . " @ " . $StandardCost, 0, 200) . "',
 										'" . ($StandardCost * $CN_Line['qty']) . "')";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 /*now the stock entry - this is set to the cost act in the case of a fixed asset disposal */
 				$StockGLCode = GetStockGLCode($CN_Line['stockid']);
@@ -953,7 +953,7 @@ function ConvertToSQLDate($DateEntry) {
 										'" . mb_substr($Header['debtorno'] . " - " . $CN_Line['stockid'] . " x " . $CN_Line['qty'] . " @ " . $StandardCost, 0, 200) . "',
 										'" . (-$StandardCost * $CN_Line['qty']) . "')";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 			} /* end of if GL and stock integrated and standard cost !=0  and not an asset */
 
@@ -977,7 +977,7 @@ function ConvertToSQLDate($DateEntry) {
 						'" . $Header['debtorno'] . " - " . $CN_Line['stockid'] . " x " . $CN_Line['qty'] . " @ " . $CN_Line['price'] . "',
 						'" . (-$CN_Line['price'] * $CN_Line['qty']/$CN_Header['rate']) . "'
 					)";
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 				if ($CN_Line['discountpercent'] !=0){
 
@@ -996,7 +996,7 @@ function ConvertToSQLDate($DateEntry) {
 								'" . $Header['debtorno'] . " - " . $CN_Line['stockid'] . " @ " . ($CN_Line['discountpercent'] * 100) . "%',
 								'" . ($CN_Line['price'] * $CN_Line['qty'] * $CN_Line['discountpercent']/$CN_Header['rate']) . "')";
 
-					$Result = DB_query($SQL,'','',true);
+					$Result = DB_query($SQL,'', '', true);
 				} /*end of if discount !=0 */
 
 			} /*end of if sales integrated with gl */
@@ -1028,7 +1028,7 @@ function ConvertToSQLDate($DateEntry) {
 											'" . $Header['debtorno'] . "-" . $Tax['TaxAuthDescription'] . "',
 											'" . -$Tax['FXAmount']/$CN_Header['rate'] . "' )";
 
-					$Result = api_DB_query($SQL,'','',true);
+					$Result = api_DB_query($SQL,'', '', true);
 				}
 			}
 
@@ -1049,7 +1049,7 @@ function ConvertToSQLDate($DateEntry) {
 										'" . $Header['debtorno'] . "',
 										'" . $TotalCreditLocalCurr . "')";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 			}
 			EnsureGLEntriesBalance(11,$CreditNoteNo);
 
@@ -1087,7 +1087,7 @@ function ConvertToSQLDate($DateEntry) {
 										'" . $Header['shipvia'] . "',
 										'" . $CN_Header['salesman'] . "')";
 
-		$Result = api_DB_query($SQL,'','',true);
+		$Result = api_DB_query($SQL,'', '', true);
 
 		$DebtorTransID = DB_Last_Insert_ID('debtortrans','id');
 
@@ -1100,7 +1100,7 @@ function ConvertToSQLDate($DateEntry) {
 								VALUES ('" . $DebtorTransID . "',
 										'" . $TaxAuthID . "',
 										'" . $Tax['FXAmount']/$CN_Header['rate'] . "')";
-			$Result = api_DB_query($SQL,'','',true);
+			$Result = api_DB_query($SQL,'', '', true);
 		}
 
 		#Now figure out if there was an invoice in the same POS transaction to allocate against?
@@ -1112,7 +1112,7 @@ function ConvertToSQLDate($DateEntry) {
 				WHERE customerref='" . $Header['customerref'] . "'
 				AND type=10
 				AND settled=0";
-		$Result = api_DB_query($SQL,'','',true);
+		$Result = api_DB_query($SQL,'', '', true);
 
 		$TotalCreditFX = $TotalFXNetCredit + $TotalFXTax; #Should be negative number
 		$Allocated = 0;
@@ -1135,7 +1135,7 @@ function ConvertToSQLDate($DateEntry) {
 									'" . $AllocateAmount . "',
 									'" . $DebtorTransID . "',
 									'" . $InvoiceRow['id'] . "')";
-					$InsertAllocResult = api_DB_query($SQL,'','',true);
+					$InsertAllocResult = api_DB_query($SQL,'', '', true);
 				}
 				if (abs($InvoiceRow['total'] - $InvoiceRow['alloc'] - $AllocateAmount)<0.005){
 					$Settled = 1;
@@ -1145,7 +1145,7 @@ function ConvertToSQLDate($DateEntry) {
 				$SQL = "UPDATE debtortrans SET alloc = alloc + " . $AllocateAmount . ",
 												settled = '" . $Settled . "'
 						WHERE id = '" . $InvoiceRow['id'] ."'";
-				$UpdateAllocResult = api_DB_query($SQL,'','',true);
+				$UpdateAllocResult = api_DB_query($SQL,'', '', true);
 
 				$Allocated -= $AllocateAmount;
 			}
@@ -1157,7 +1157,7 @@ function ConvertToSQLDate($DateEntry) {
 			$SQL = "UPDATE debtortrans SET alloc = alloc + " . $Allocated . ",
 												settled = '" . $Settled . "'
 					WHERE id = '" . $DebtorTransID  ."'";
-			$UpdateAllocResult = api_DB_query($SQL,'','',true);
+			$UpdateAllocResult = api_DB_query($SQL,'', '', true);
 		}
 
 		if (sizeof($Errors)==0) {
@@ -1380,14 +1380,14 @@ function ConvertToSQLDate($DateEntry) {
 										'" . Date('Y-m-d') . "',
 										'" . $LeftToAllocRow['id'] . "',
 										'" . $OSInvRow['id'] . "')";
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 				/*Now update the allocated amounts in the debtortrans for both transactions */
 				$SQL = "UPDATE debtortrans SET alloc=alloc-" . $AllocateAmount . "
 						WHERE id = '" . $LeftToAllocRow['id'] . "'";
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 				$SQL = "UPDATE debtortrans SET alloc=alloc+" . $AllocateAmount . "
 						WHERE id = '" . $OSInvRow['id'] . "'";
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 			} /*end if the exchange rates are the same so no diff on exchange */
          /*end if it is a normal allocation of receipt to invoice*/
 		} elseif ($LeftToAllocRow['lefttoalloc']>0) {
@@ -1445,14 +1445,14 @@ function ConvertToSQLDate($DateEntry) {
 											'" . Date('Y-m-d') . "',
 											'" . $OSCreditRow['id'] . "',
 											'" . $LeftToAllocRow['id'] . "')";
-					$Result = api_DB_query($SQL,'','',true);
+					$Result = api_DB_query($SQL,'', '', true);
 					/*Now update the allocated amounts in the debtortrans for both transactions */
 					$SQL = "UPDATE debtortrans SET alloc=alloc+" . $AllocateAmount . "
 							WHERE id = '" . $LeftToAllocRow['id'] . "'";
-					$Result = api_DB_query($SQL,'','',true);
+					$Result = api_DB_query($SQL,'', '', true);
 					$SQL = "UPDATE debtortrans SET alloc=alloc-" . $AllocateAmount . "
 							WHERE id = '" . $OSCreditRow['id'] . "'";
-					$Result = api_DB_query($SQL,'','',true);
+					$Result = api_DB_query($SQL,'', '', true);
 
 				}
 			} //end loop around potential positive receipts not fully allocated already

--- a/api/api_glaccounts.php
+++ b/api/api_glaccounts.php
@@ -5,7 +5,7 @@
 		$Searchsql = "SELECT count(accountcode)
 				FROM chartmaster
 				WHERE accountcode='".$AccountCode."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]>0) {
 			$Errors[$i] = GLAccountCodeAlreadyExists;
@@ -18,7 +18,7 @@
 		$Searchsql = "SELECT count(accountcode)
 				FROM chartmaster
 				WHERE accountcode='".$AccountCode."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0) {
 			$Errors[$i] = GLAccountCodeDoesntExists;
@@ -39,7 +39,7 @@
 		$Searchsql = "SELECT count(groupname)
 				FROM accountgroups
 				WHERE groupname='".$AccountGroup."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0) {
 			$Errors[$i] = AccountGroupDoesntExist;

--- a/api/api_glgroups.php
+++ b/api/api_glgroups.php
@@ -5,7 +5,7 @@
 		$Searchsql = "SELECT count(groupname)
 				FROM accountgroups
 				WHERE groupname='".$AccountGroup."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]>0) {
 			$Errors[$i] = GLAccountGroupAlreadyExists;
@@ -18,7 +18,7 @@
 		$Searchsql = "SELECT count(sectionid)
 				FROM accountsection
 				WHERE sectionid='".$AccountSection."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0) {
 			$Errors[$i] = GLAccountSectionDoesntExist;
@@ -47,7 +47,7 @@
 		$Searchsql = "SELECT count(groupname)
 				FROM accountgroups
 				WHERE groupname='".$AccountGroup."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0 and $AccountGroup!='') {
 			$Errors[$i] = AccountGroupDoesntExist;

--- a/api/api_glsections.php
+++ b/api/api_glsections.php
@@ -5,7 +5,7 @@
 		$Searchsql = "SELECT count(sectionid)
 				FROM accountsection
 				WHERE sectionid='".$AccountSection."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]>0) {
 			$Errors[$i] = GLAccountSectionAlreadyExists;

--- a/api/api_locations.php
+++ b/api/api_locations.php
@@ -14,7 +14,7 @@
 		$Searchsql = "SELECT count(loccode)
 						FROM locations
 						WHERE loccode='".$LocationCode."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] != 0) {
 			$Errors[$i] = LocationCodeAlreadyExists;
@@ -27,7 +27,7 @@
 		$Searchsql = "SELECT count(loccode)
 						FROM locations
 						WHERE loccode='".$LocationCode."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0) {
 			$Errors[$i] = LocationCodeDoesntExist;
@@ -48,7 +48,7 @@
 		$Searchsql = "SELECT COUNT(taxprovinceid)
 						FROM taxprovinces
 						WHERE taxprovinceid='".$TaxProvinceId."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] == 0) {
 			$Errors[$i] = TaxProvinceIdNotSetup;

--- a/api/api_salesareas.php
+++ b/api/api_salesareas.php
@@ -5,7 +5,7 @@
 		$Searchsql = "SELECT COUNT(areacode)
 					 FROM areas
 					  WHERE areacode='".$AreaCode."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] > 0) {
 			$Errors[$i] = AreaCodeNotSetup;

--- a/api/api_salesorders.php
+++ b/api/api_salesorders.php
@@ -800,7 +800,7 @@ $SOH_DateFields = array ('orddate',
 					WHERE orderno = '" . $OrderNo . "'
 					AND stkcode = '" . $OrderLineRow['stkcode'] . "'";
 
-			$Result = api_DB_query($SQL,'','',true);
+			$Result = api_DB_query($SQL,'', '', true);
 
 
 			if ($OrderLineRow['mbflag']=='B' OR $OrderLineRow['mbflag']=='M') {
@@ -826,7 +826,7 @@ $SOH_DateFields = array ('orddate',
 						SET quantity = locstock.quantity - " . $OrderLineRow['quantity'] . "
 						WHERE locstock.stockid = '" . $OrderLineRow['stkcode'] . "'
 						AND loccode = '" . $OrderHeader['fromstkloc'] . "'";
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 				$SQL = "INSERT INTO stockmoves (stockid,
 												type,
@@ -857,7 +857,7 @@ $SOH_DateFields = array ('orddate',
 								'" . $StandardCost . "',
 								'" . ($QtyOnHandPrior - $OrderLineRow['quantity']) . "' )";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 			} else if ($OrderLineRow['mbflag']=='A'){ /* its an assembly */
 				/*Need to get the BOM for this part and make
@@ -923,14 +923,14 @@ $SOH_DateFields = array ('orddate',
 												 0,
 												 '" . ($QtyOnHandPrior - $AssParts['quantity'] * $OrderLineRow['quantity']) . "'	)";
 
-					$Result = DB_query($SQL,'','',true);
+					$Result = DB_query($SQL,'', '', true);
 
 					$SQL = "UPDATE locstock
 							SET quantity = locstock.quantity - " . ($AssParts['quantity'] * $OrderLineRow['quantity']) . "
 							WHERE locstock.stockid = '" . $AssParts['component'] . "'
 							AND loccode = '" . $OrderHeader['fromlocstk'] . "'";
 
-					$Result = DB_query($SQL,'','',true);
+					$Result = DB_query($SQL,'', '', true);
 				} /* end of assembly explosion and updates */
 			} /* end of its an assembly */
 
@@ -967,7 +967,7 @@ $SOH_DateFields = array ('orddate',
 								'" . $StandardCost . "',
 								'0' )";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 			}
 			/*Get the ID of the StockMove... */
 			$StkMoveNo = DB_Last_Insert_ID('stockmoves','stkmoveno');
@@ -985,7 +985,7 @@ $SOH_DateFields = array ('orddate',
 							'" . $Tax['TaxCalculationOrder'] . "',
 							'" . $Tax['TaxOnTax'] . "')";
 
-				$Result = DB_query($SQL,'','',true);
+				$Result = DB_query($SQL,'', '', true);
 			}
 
 			/*Insert Sales Analysis records */
@@ -1024,8 +1024,7 @@ $SOH_DateFields = array ('orddate',
 						salesanalysis.salesperson";
 
 			$ErrMsg = _('The count of existing Sales analysis records could not run because');
-			$DbgMsg = _('SQL to count the no of sales analysis records');
-			$Result = DB_query($SQL,$ErrMsg,$DbgMsg,true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 			$MyRow = DB_fetch_row($Result);
 
@@ -1080,7 +1079,7 @@ $SOH_DateFields = array ('orddate',
 
 			}
 
-			$Result = api_DB_query($SQL,'','',true);
+			$Result = api_DB_query($SQL,'', '', true);
 
 			if ($CompanyRecord['gllink_stock']==1 AND $StandardCost !=0){
 
@@ -1101,7 +1100,7 @@ $SOH_DateFields = array ('orddate',
 										'" . mb_substr($OrderHeader['debtorno'] . " - " . $OrderLineRow['stkcode'] . " x " . $OrderLineRow['quantity'] . " @ " . $StandardCost, 0, 200) . "',
 										'" . ($StandardCost * $OrderLineRow['quantity']) . "')";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 /*now the stock entry - this is set to the cost act in the case of a fixed asset disposal */
 				$StockGLCode = GetStockGLCode($OrderLineRow['stkcode']);
@@ -1121,7 +1120,7 @@ $SOH_DateFields = array ('orddate',
 										'" . mb_substr($OrderHeader['debtorno'] . " - " . $OrderLineRow['stkcode'] . " x " . $OrderLineRow['quantity'] . " @ " . $StandardCost, 0, 200) . "',
 										'" . (-$StandardCost * $OrderLineRow['quantity']) . "')";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 			} /* end of if GL and stock integrated and standard cost !=0  and not an asset */
 
@@ -1145,7 +1144,7 @@ $SOH_DateFields = array ('orddate',
 						'" . $OrderHeader['debtorno'] . " - " . $OrderLineRow['stkcode'] . " x " . $OrderLineRow['quantity'] . " @ " . $OrderLineRow['unitprice'] . "',
 						'" . -$OrderLineRow['unitprice'] * $OrderLineRow['quantity']/$OrderHeader['rate'] . "'
 					)";
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 
 				if ($OrderLineRow['discountpercent'] !=0){
 
@@ -1164,7 +1163,7 @@ $SOH_DateFields = array ('orddate',
 								'" . $OrderHeader['debtorno'] . " - " . $OrderLineRow['stkcode'] . " @ " . ($OrderLineRow['discountpercent'] * 100) . "%',
 								'" . ($OrderLineRow['unitprice'] * $OrderLineRow['quantity'] * $OrderLineRow['discountpercent']/$OrderHeader['rate']) . "')";
 
-					$Result = DB_query($SQL,'','',true);
+					$Result = DB_query($SQL,'', '', true);
 				} /*end of if discount !=0 */
 
 			} /*end of if sales integrated with gl */
@@ -1196,7 +1195,7 @@ $SOH_DateFields = array ('orddate',
 											'" . $OrderHeader['debtorno'] . "-" . $Tax['TaxAuthDescription'] . "',
 											'" . -$Tax['FXAmount']/$OrderHeader['rate'] . "' )";
 
-					$Result = api_DB_query($SQL,'','',true);
+					$Result = api_DB_query($SQL,'', '', true);
 				}
 			}
 
@@ -1217,7 +1216,7 @@ $SOH_DateFields = array ('orddate',
 										'" . $OrderHeader['debtorno'] . "',
 										'" . $TotalInvLocalCurr . "')";
 
-				$Result = api_DB_query($SQL,'','',true);
+				$Result = api_DB_query($SQL,'', '', true);
 			}
 			EnsureGLEntriesBalance(10,$InvoiceNo);
 
@@ -1225,7 +1224,7 @@ $SOH_DateFields = array ('orddate',
 
 	/*Update order header for invoice charged on */
 		$SQL = "UPDATE salesorders SET comments = CONCAT(comments,' Inv ','" . $InvoiceNo . "') WHERE orderno= '" . $OrderNo . "'";
-		$Result = api_DB_query($SQL,'','',true);
+		$Result = api_DB_query($SQL,'', '', true);
 
 	/*Now insert the DebtorTrans */
 
@@ -1261,7 +1260,7 @@ $SOH_DateFields = array ('orddate',
 										'" . $OrderHeader['shipvia'] . "',
 										'" . $OrderHeader['salesman'] . "')";
 
-		$Result = api_DB_query($SQL,'','',true);
+		$Result = api_DB_query($SQL,'', '', true);
 
 		$DebtorTransID = DB_Last_Insert_ID('debtortrans','id');
 
@@ -1274,7 +1273,7 @@ $SOH_DateFields = array ('orddate',
 								VALUES ('" . $DebtorTransID . "',
 										'" . $TaxAuthID . "',
 										'" . $Tax['FXAmount']/$OrderHeader['rate'] . "')";
-			$Result = api_DB_query($SQL,'','',true);
+			$Result = api_DB_query($SQL,'', '', true);
 		}
 
 		if (sizeof($Errors)==0) {
@@ -1365,7 +1364,7 @@ $SOH_DateFields = array ('orddate',
 						AND lastdate_in_period >= '" . Date('Y-m-d', $TransDate) . "'";
 
 		$ErrMsg = _('An error occurred in retrieving the period number');
-		$GetPrdResult = DB_query($GetPrdSQL,$ErrMsg);
+		$GetPrdResult = DB_query($GetPrdSQL, $ErrMsg);
 		$MyRow = DB_fetch_row($GetPrdResult);
 
 		return $MyRow[0];

--- a/api/api_stock.php
+++ b/api/api_stock.php
@@ -5,7 +5,7 @@
 		$Searchsql = "SELECT count(stockid)
     				  FROM stockmaster
 	    			  WHERE stockid='".$StockCode."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]>0) {
 			$Errors[$i] = StockCodeAlreadyExists;
@@ -18,7 +18,7 @@
 		$Searchsql = "SELECT count(stockid)
 				      FROM stockmaster
 				      WHERE stockid='".$StockCode."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0) {
 			$Errors[$i] = StockCodeDoesntExist;
@@ -31,7 +31,7 @@
 		$Searchsql = "SELECT count(categoryid)
 				      FROM stockcategory
 				      WHERE categoryid='".$StockCategory."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0) {
 			$Errors[$i] = StockCategoryDoesntExist;
@@ -76,7 +76,7 @@
  * target webERP company */
 	function VerifyLastCurCostDate($CurCostDate, $i, $Errors) {
 		$SQL="SELECT confvalue FROM config WHERE confname='DefaultDateFormat'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 		$DateFormat=$MyRow[0];
 		if (mb_strstr('/',$PeriodEnd)) {
@@ -216,7 +216,7 @@
 		$Searchsql = "SELECT count(taxcatid)
 				      FROM taxcategories
 				      WHERE taxcatid='".$TaxCat."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0) {
 			$Errors[$i] = TaxCategoriesDoesntExist;

--- a/api/api_stockcategories.php
+++ b/api/api_stockcategories.php
@@ -12,7 +12,7 @@
 		$Searchsql = "SELECT count(categoryid)
 				      FROM stockcategory
 				      WHERE categoryid='".$StockCategory."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]>0) {
 			$Errors[$i] = StockCategoryAlreadyExists;

--- a/api/api_suppliers.php
+++ b/api/api_suppliers.php
@@ -9,7 +9,7 @@
 		$Searchsql = "SELECT count(supplierid)
   				      FROM suppliers
 				      WHERE supplierid='".$SupplierNumber."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] != 0) {
 			$Errors[$i] = SupplierNoAlreadyExists;
@@ -26,7 +26,7 @@
 		$Searchsql = "SELECT count(supplierid)
 				      FROM suppliers
 				      WHERE supplierid='".$SupplierNumber."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] == 0) {
 			$Errors[$i] = SupplierNoDoesntExists;
@@ -47,7 +47,7 @@
  * target webERP company */
 	function VerifySupplierSinceDate($suppliersincedate, $i, $Errors) {
 		$SQL="SELECT confvalue FROM config where confname='DefaultDateFormat'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 		$DateFormat=$MyRow[0];
 		if (mb_strstr('/',$PeriodEnd)) {
@@ -111,7 +111,7 @@
 		$Searchsql = "SELECT COUNT(id)
 					 FROM factorcompanies
 					  WHERE id='".$factorco."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] == 0) {
 			$Errors[$i] = FactorCompanyNotSetup;

--- a/api/api_workorders.php
+++ b/api/api_workorders.php
@@ -5,7 +5,7 @@
 		$Searchsql = "SELECT count(wo)
 				FROM workorders
 				WHERE wo='".$WorkOrder."'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_array($SearchResult);
 		if ($Answer[0]==0) {
 			$Errors[$i] = WorkOrderDoesntExist;
@@ -18,7 +18,7 @@
 		$Searchsql = "SELECT COUNT(loccode)
 					 FROM locations
 					  WHERE loccode='" . $Location . "'";
-		$SearchResult=DB_query($Searchsql);
+		$SearchResult = DB_query($Searchsql);
 		$Answer = DB_fetch_row($SearchResult);
 		if ($Answer[0] == 0) {
 			$Errors[$i] = LocationCodeNotSetup;
@@ -44,7 +44,7 @@
 
 	function VerifyRequiredByDate($RequiredByDate, $i, $Errors) {
 		$SQL="SELECT confvalue FROM config WHERE confname='DefaultDateFormat'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 		$DateFormat=$MyRow[0];
 		if (mb_strstr('/',$PeriodEnd)) {
@@ -77,7 +77,7 @@
 
 	function VerifyStartDate($StartDate, $i, $Errors) {
 		$SQL="SELECT confvalue FROM config WHERE confname='DefaultDateFormat'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_array($Result);
 		$DateFormat=$MyRow[0];
 		if (mb_strstr('/',$PeriodEnd)) {
@@ -145,7 +145,7 @@
 
 	function VerifyBatch($batch, $stockid, $Location, $i, $Errors) {
 		$SQL="SELECT controlled, serialised FROM stockmaster WHERE stockid='".$stockid."'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		$MyRow=DB_fetch_row($Result);
 		if ($MyRow[0]!=1) {
 			$Errors[$i] = ItemNotControlled;
@@ -158,7 +158,7 @@
               WHERE stockid='".$stockid. "'
               AND loccode='".$Location."'
               AND serialno='".$batch."'";
-		$Result=DB_query($SQL);
+		$Result = DB_query($SQL);
 		if (DB_num_rows($Result)==0) {
 			$Errors[$i] = BatchNumberDoesntExist;
 			return $Errors;

--- a/includes/ConnectDB_mariadb.php
+++ b/includes/ConnectDB_mariadb.php
@@ -74,7 +74,9 @@ function DB_query($SQL, $ErrorMessage='', $DebugMessage= '', $Transaction=false,
 			if ($DebugMessage == '') {
 				$DebugMessage = _('The SQL that failed was');
 			}
-			prnMsg($DebugMessage. '<br />' . $SQL . '<br />', 'error', _('Database SQL Failure'));
+			$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+			prnMsg($DebugMessage. '<br />' . $SQL . '<br />' . _('in file') . ' ' . $trace[0]['file'] . _('on line') . ' ' . $trace[0]['line'],
+				'error', _('Database SQL Failure'));
 		}
 		if ($Transaction) {
 			$SQL = 'rollback';

--- a/includes/ConnectDB_mariadb.php
+++ b/includes/ConnectDB_mariadb.php
@@ -80,7 +80,7 @@ function DB_query($SQL, $ErrorMessage='', $DebugMessage= '', $Transaction=false,
 			$SQL = 'rollback';
 			$Result = DB_query($SQL);
 			if (DB_error_no() != 0) {
-				prnMsg(_('Error Rolling Back Transaction'), 'error', _('Database Rollback Error'). ' ' .DB_error_no() );
+				prnMsg(_('Error Rolling Back Transaction'), 'error', _('Database Rollback Error') . ' ' . DB_error_no());
 			} else {
 				prnMsg(_('Rolling Back Transaction OK'), 'error', _('Database Rollback Due to Error Above'));
 			}

--- a/includes/ConnectDB_mysql.php
+++ b/includes/ConnectDB_mysql.php
@@ -66,7 +66,9 @@ function DB_query($SQL, $ErrorMessage='', $DebugMessage= '', $Transaction=false,
 			if ($DebugMessage == '') {
 				$DebugMessage = _('The SQL that failed was');
 			}
-			prnMsg($DebugMessage . '<br />' . $SQL . '<br />', 'error', _('Database SQL Failure'));
+			$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+			prnMsg($DebugMessage. '<br />' . $SQL . '<br />' . _('in file') . ' ' . $trace[0]['file'] . _('on line') . ' ' . $trace[0]['line'],
+				'error', _('Database SQL Failure'));
 		}
 		if ($Transaction) {
 			$SQL = 'rollback';

--- a/includes/ConnectDB_mysql.php
+++ b/includes/ConnectDB_mysql.php
@@ -72,7 +72,9 @@ function DB_query($SQL, $ErrorMessage='', $DebugMessage= '', $Transaction=false,
 			$SQL = 'rollback';
 			$Result = DB_query($SQL);
 			if (DB_error_no() != 0) {
-				prnMsg(_('Error Rolling Back Transaction'), 'error', _('Database Rollback Error') );
+				prnMsg(_('Error Rolling Back Transaction'), 'error', _('Database Rollback Error') . ' ' . DB_error_no());
+			} else {
+				prnMsg(_('Rolling Back Transaction OK'), 'error', _('Database Rollback Due to Error Above'));
 			}
 		}
 		include($PathPrefix . 'includes/footer.php');

--- a/includes/ConnectDB_mysqli.php
+++ b/includes/ConnectDB_mysqli.php
@@ -74,7 +74,9 @@ function DB_query($SQL, $ErrorMessage='', $DebugMessage= '', $Transaction=false,
 			if ($DebugMessage == '') {
 				$DebugMessage = _('The SQL that failed was');
 			}
-			prnMsg($DebugMessage. '<br />' . $SQL . '<br />', 'error', _('Database SQL Failure'));
+			$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+			prnMsg($DebugMessage. '<br />' . $SQL . '<br />' . _('in file') . ' ' . $trace[0]['file'] . _('on line') . ' ' . $trace[0]['line'],
+				'error', _('Database SQL Failure'));
 		}
 		if ($Transaction) {
 			$SQL = 'rollback';

--- a/includes/ConnectDB_mysqli.php
+++ b/includes/ConnectDB_mysqli.php
@@ -80,7 +80,7 @@ function DB_query($SQL, $ErrorMessage='', $DebugMessage= '', $Transaction=false,
 			$SQL = 'rollback';
 			$Result = DB_query($SQL);
 			if (DB_error_no() != 0) {
-				prnMsg(_('Error Rolling Back Transaction'), 'error', _('Database Rollback Error'). ' ' .DB_error_no() );
+				prnMsg(_('Error Rolling Back Transaction'), 'error', _('Database Rollback Error') . ' ' . DB_error_no());
 			} else {
 				prnMsg(_('Rolling Back Transaction OK'), 'error', _('Database Rollback Due to Error Above'));
 			}

--- a/includes/ConnectDB_postgres.php
+++ b/includes/ConnectDB_postgres.php
@@ -58,7 +58,9 @@ function DB_query($SQL, $ErrorMessage='', $DebugMessage= '', $Transaction=false,
 			if ($DebugMessage == '') {
 				$DebugMessage = _('The SQL that failed was:');
 			}
-			prnMsg('<br />' . $DebugMessage. "<br />$SQL<br />", 'error', _('Database SQL Failure'));
+			$trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 1);
+			prnMsg($DebugMessage. '<br />' . $SQL . '<br />' . _('in file') . ' ' . $trace[0]['file'] . _('on line') . ' ' . $trace[0]['line'],
+				'error', _('Database SQL Failure'));
 		}
 		if ($Transaction) {
 			$SQL = 'rollback';

--- a/includes/ConnectDB_postgres.php
+++ b/includes/ConnectDB_postgres.php
@@ -58,13 +58,15 @@ function DB_query($SQL, $ErrorMessage='', $DebugMessage= '', $Transaction=false,
 			if ($DebugMessage == '') {
 				$DebugMessage = _('The SQL that failed was:');
 			}
-			echo '<BR>' . $DebugMessage. "<BR>$SQL<BR>";
+			prnMsg('<br />' . $DebugMessage. "<br />$SQL<br />", 'error', _('Database SQL Failure'));
 		}
 		if ($Transaction) {
 			$SQL = 'rollback';
 			$Result = DB_query($SQL);
 			if (DB_error_no() !=0) {
-				prnMsg('<br />' . _('Error Rolling Back Transaction!!'), '', _('DB DEBUG:') );
+				prnMsg('<br />' . _('Error Rolling Back Transaction!!'), 'error', _('DB Database Rollback Error') . ' ' . DB_error_no());
+			} else {
+				prnMsg(_('Rolling Back Transaction OK'), 'error', _('Database Rollback Due to Error Above'));
 			}
 		}
 		include($PathPrefix . 'includes/footer.php');

--- a/includes/ConnectDB_postgres.php
+++ b/includes/ConnectDB_postgres.php
@@ -129,7 +129,7 @@ function DB_escape_string($String) {
 }
 
 function DB_show_tables() {
-	$Result =DB_query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'");
+	$Result = DB_query("SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'");
 	return $Result;
 }
 

--- a/includes/ConstructSQLForUserDefinedSalesReport.php
+++ b/includes/ConstructSQLForUserDefinedSalesReport.php
@@ -150,7 +150,7 @@ $GetReportSpecSQL="SELECT reportheading,
 			FROM reportheaders
 			WHERE reportid='" . $_GET['ReportID'] . "'";
 
-$SpecResult= DB_query($GetReportSpecSQL);
+$SpecResult = DB_query($GetReportSpecSQL);
 $ReportSpec = DB_fetch_array($SpecResult);
 
 $GetColsSQL = "SELECT colno,
@@ -331,8 +331,7 @@ exit();
 
 /*Now let her go .... */
 $ErrMsg = _('There was a problem running the SQL to retrieve the sales analysis information');
-$DbgMsg = _('The SQL that was used to retrieve the user defined sales analysis info was');
-$Result=DB_query($SQLTheLot,$ErrMsg,$DbgMsg);
+$Result = DB_query($SQLTheLot, $ErrMsg);
 
 if (DB_num_rows($Result)==0){
     $Title = _('User Defined Sales Analysis Problem') . ' ....';

--- a/includes/Contract_Readin.php
+++ b/includes/Contract_Readin.php
@@ -28,8 +28,7 @@ $ContractHeaderSQL = "SELECT contractdescription,
 						WHERE contractref= '" . $ContractRef . "'";
 
 $ErrMsg =  _('The contract cannot be retrieved because');
-$DbgMsg =  _('The SQL statement that was used and failed was');
-$ContractHdrResult = DB_query($ContractHeaderSQL,$ErrMsg,$DbgMsg);
+$ContractHdrResult = DB_query($ContractHeaderSQL, $ErrMsg);
 
 if (DB_num_rows($ContractHdrResult)==1 and !isset($_SESSION['Contract'.$identifier]->ContractRef )) {
 
@@ -68,8 +67,7 @@ if (DB_num_rows($ContractHdrResult)==1 and !isset($_SESSION['Contract'.$identifi
 						WHERE contractref ='" . $ContractRef . "'";
 
 	$ErrMsg =  _('The bill of material cannot be retrieved because');
-	$DbgMsg =  _('The SQL statement that was used to retrieve the contract bill of material was');
-	$ContractBOMResult = DB_query($ContractBOMsql,$ErrMsg,$DbgMsg);
+	$ContractBOMResult = DB_query($ContractBOMsql, $ErrMsg);
 
 	if (DB_num_rows($ContractBOMResult) > 0) {
 		while ($MyRow=DB_fetch_array($ContractBOMResult)) {
@@ -92,8 +90,7 @@ if (DB_num_rows($ContractHdrResult)==1 and !isset($_SESSION['Contract'.$identifi
 						ORDER BY contractreqid";
 
 	$ErrMsg =  _('The other contract requirementscannot be retrieved because');
-	$DbgMsg =  _('The SQL statement that was used to retrieve the other contract requirments was');
-	$ContractReqtsResult = DB_query($ContractReqtsSQL,$ErrMsg,$DbgMsg);
+	$ContractReqtsResult = DB_query($ContractReqtsSQL, $ErrMsg);
 
 	if (DB_num_rows($ContractReqtsResult) > 0) {
 		while ($MyRow=DB_fetch_array($ContractReqtsResult)) {

--- a/includes/DateFunctions.php
+++ b/includes/DateFunctions.php
@@ -1263,7 +1263,7 @@ function PeriodExists($TransDate) {
 	$GetPrdSQL = "SELECT periodno FROM periods WHERE lastdate_in_period < '" . Date('Y/m/d', $MonthAfterTransDate) . "' AND lastdate_in_period >= '" . Date('Y/m/d', $TransDate) . "'";
 
 	$ErrMsg = _('An error occurred in retrieving the period number');
-	$GetPrdResult = DB_query($GetPrdSQL,$ErrMsg);
+	$GetPrdResult = DB_query($GetPrdSQL, $ErrMsg);
 
 	if (DB_num_rows($GetPrdResult) == 0) {
 		return false;
@@ -1384,7 +1384,7 @@ function GetPeriod($TransDate, $UseProhibit = true) {
 					AND lastdate_in_period >= '" . Date('Y-m-d', $TransDate) . "'";
 
 	$ErrMsg = _('An error occurred in retrieving the period number');
-	$GetPrdResult = DB_query($GetPrdSQL,$ErrMsg);
+	$GetPrdResult = DB_query($GetPrdSQL, $ErrMsg);
 	$MyRow = DB_fetch_row($GetPrdResult);
 
 	return $MyRow[0];

--- a/includes/DefineCartClass.php
+++ b/includes/DefineCartClass.php
@@ -319,7 +319,7 @@ Class Cart {
 				ORDER BY taxcalculationorder";
 
 		$ErrMsg = _('The taxes and rates for this item could not be retrieved because');
-		$GetTaxRatesResult = DB_query($SQL,$ErrMsg);
+		$GetTaxRatesResult = DB_query($SQL, $ErrMsg);
 		$i=1;
 		while ($MyRow = DB_fetch_array($GetTaxRatesResult)){
 
@@ -353,7 +353,7 @@ Class Cart {
 			ORDER BY taxgrouptaxes.calculationorder";
 
 		$ErrMsg = _('The taxes and rates for this item could not be retrieved because');
-		$GetTaxRatesResult = DB_query($SQL,$ErrMsg);
+		$GetTaxRatesResult = DB_query($SQL, $ErrMsg);
 		unset($this->LineItems[$LineNumber]->Taxes);
 		if (DB_num_rows($GetTaxRatesResult)==0){
 			prnMsg(_('It appears that taxes are not defined correctly for this customer tax group') ,'error');
@@ -401,7 +401,7 @@ Class Cart {
 				ORDER BY taxgrouptaxes.calculationorder";
 
 		$ErrMsg = _('The taxes and rates for this item could not be retrieved because');
-		$GetTaxRatesResult = DB_query($SQL,$ErrMsg);
+		$GetTaxRatesResult = DB_query($SQL, $ErrMsg);
 		$i=1;
 		while ($MyRow = DB_fetch_array($GetTaxRatesResult)){
 

--- a/includes/DefineOfferClass.php
+++ b/includes/DefineOfferClass.php
@@ -91,8 +91,7 @@ Class Offer {
 								'" . FormatDateForSQL($LineItems->ExpiryDate) . "',
 								'" . $this->CurrCode . "')";
 					$ErrMsg = _('The suppliers offer could not be inserted into the database because');
-					$DbgMsg = _('The SQL statement used to insert the suppliers offer record and failed was');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					if (DB_error_no() == 0) {
 						prnMsg(_('The offer for') . ' ' . $LineItems->StockID . ' ' . _('has been inserted into the database'), 'success');
 						$this->OfferMailText .= $LineItems->Quantity . ' ' . $LineItems->Units . ' ' . _('of') . ' ' .
@@ -114,8 +113,7 @@ Class Offer {
 							expirydate='" . FormatDateForSQL($LineItem->ExpiryDate) . "'
 						WHERE offerid='" . $LineItem->LineNo . "'";
 					$ErrMsg = _('The suppliers offer could not be updated on the database because');
-					$DbgMsg = _('The SQL statement used to update the suppliers offer record and failed was');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					if (DB_error_no() == 0) {
 						prnMsg(_('The offer for') . ' ' . $LineItem->StockID . ' ' . _('has been updated in the database'), 'success');
 						$this->OfferMailText .= $LineItem->Quantity . ' ' . $LineItem->Units . ' ' . _('of') . ' ' .
@@ -128,8 +126,7 @@ Class Offer {
 				} else { // the LineItem is Deleted flag is true so delete it
 					$SQL = "DELETE from offers WHERE offerid='" . $LineItem->LineNo . "'";
 					$ErrMsg = _('The supplier offer could not be deleted on the database because');
-					$DbgMsg = _('The SQL statement used to delete the suppliers offer record are failed was');
-					$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+					$Result = DB_query($SQL, $ErrMsg, '', true);
 					if (DB_error_no() == 0) {
 						prnMsg(_('The offer for') . ' ' . $LineItem->StockID . ' ' . _('has been deleted in the database'), 'info');
 						$this->OfferMailText .= $LineItem->Quantity . ' ' . $LineItem->Units . ' ' . _('of') . ' ' .

--- a/includes/DefineSuppTransClass.php
+++ b/includes/DefineSuppTransClass.php
@@ -71,7 +71,7 @@ Class SuppTrans {
 			ORDER BY taxgrouptaxes.calculationorder";
 
 		$ErrMsg = _('The taxes and rates for this item could not be retrieved because');
-		$GetTaxRatesResult = DB_query($SQL,$ErrMsg);
+		$GetTaxRatesResult = DB_query($SQL, $ErrMsg);
 
 		while ($MyRow = DB_fetch_array($GetTaxRatesResult)){
 

--- a/includes/DefineTenderClass.php
+++ b/includes/DefineTenderClass.php
@@ -122,7 +122,7 @@ Class Tender {
 			foreach ($this->Suppliers as $Supplier) {
 				$SQL="DELETE FROM tendersuppliers
 					WHERE  tenderid='" . $this->TenderId . "'";
-				$Result=DB_query($SQL);
+				$Result = DB_query($SQL);
 				$SuppliersSQL[]="INSERT INTO tendersuppliers (
 									tenderid,
 									supplierid,
@@ -134,7 +134,7 @@ Class Tender {
 			foreach ($this->LineItems as $LineItem) {
 				$SQL="DELETE FROM tenderitems
 						WHERE  tenderid='" . $this->TenderId . "'";
-				$Result=DB_query($SQL);
+				$Result = DB_query($SQL);
 				$ItemsSQL[]="INSERT INTO tenderitems (tenderid,
 														stockid,
 														quantity,
@@ -146,12 +146,12 @@ Class Tender {
 			}
 		}
 		DB_Txn_Begin();
-		$Result=DB_query($HeaderSQL, '', '', True);
+		$Result = DB_query($HeaderSQL, '', '', True);
 		foreach ($SuppliersSQL as $SQL) {
-			$Result=DB_query($SQL, '', '', True);
+			$Result = DB_query($SQL, '', '', True);
 		}
 		foreach ($ItemsSQL as $SQL) {
-			$Result=DB_query($SQL, '', '', True);
+			$Result = DB_query($SQL, '', '', True);
 		}
 		DB_Txn_Commit();
 	}

--- a/includes/GLFunctions.php
+++ b/includes/GLFunctions.php
@@ -21,12 +21,11 @@ Returns:
 function InsertGLTags($TagArray) {
 	if (!empty($TagArray)) {
 		$ErrMsg = _('Cannot insert a GL tag for the journal line because');
-		$DbgMsg = _('The SQL that failed to insert the GL tag record was');
 		foreach ($TagArray as $Tag) {
 			$SQL = "INSERT INTO gltags
 					VALUES ( LAST_INSERT_ID(),
 							'" . $Tag . "')";
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
         }
 	}
     return true;

--- a/includes/GetConfig.php
+++ b/includes/GetConfig.php
@@ -29,7 +29,7 @@ if ((isset($ForceConfigReload) AND $ForceConfigReload==true) OR !isset($_SESSION
 
 	/* Load the pagesecurity settings from the database */
 	$SQL="SELECT script, pagesecurity FROM scripts";
-	$Result=DB_query($SQL,'','',false,false);
+	$Result = DB_query($SQL,'','',false,false);
 	if (DB_error_no()!=0) {
 		/* the table may not exist with the pagesecurity field in it if it is an older webERP database
 		 * divert to the db upgrade if the VersionNumber is not in the config table
@@ -73,7 +73,7 @@ if ((isset($ForceConfigReload) AND $ForceConfigReload==true) OR !isset($_SESSION
 				WHERE coycode=1";
 
 	$ErrMsg = _('An error occurred accessing the database to retrieve the company information');
-	$ReadCoyResult = DB_query($SQL,$ErrMsg);
+	$ReadCoyResult = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($ReadCoyResult)==0) {
       		echo '<br /><b>';
@@ -94,7 +94,7 @@ if ((isset($ForceConfigReload) AND $ForceConfigReload==true) OR !isset($_SESSION
 				timeout,
 				auth
 			FROM emailsettings";
-	$Result=DB_query($SQL,'','',false,false);
+	$Result = DB_query($SQL,'','',false,false);
 	if (DB_error_no()==0 and DB_num_rows($Result) > 0) {
 		/*test to ensure that the emailsettings table exists!!
 		 * if it doesn't exist then we are into an UpgradeDatabase scenario anyway

--- a/includes/GetSalesTransGLCodes.php
+++ b/includes/GetSalesTransGLCodes.php
@@ -8,12 +8,11 @@ Function returns the relavent GL Code to post COGS entries to*/
 function GetCOGSGLAccount ($Area, $StockID, $SalesType) {
 
 	$ErrMsg = _('Can not retrieve the cost of sales GL code because');
-	$DbgMsg =_('SQL to get the cost of sales GL Code');
 
 	/*Get the StockCategory for this item */
 
 	$SQL = "SELECT categoryid FROM stockmaster WHERE stockid='" . $StockID . "'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow = DB_fetch_row($Result);
 	$StockCategory = $MyRow[0];
 
@@ -39,7 +38,7 @@ function GetCOGSGLAccount ($Area, $StockID, $SalesType) {
 	*/
 
 
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result)==0){
 
@@ -49,7 +48,7 @@ function GetCOGSGLAccount ($Area, $StockID, $SalesType) {
 			AND stkcat = '" . $StockCategory . "'
 			AND salestype = 'AN'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 
 	}
 
@@ -60,7 +59,7 @@ function GetCOGSGLAccount ($Area, $StockID, $SalesType) {
 			WHERE area = '" . $Area . "'
 			AND stkcat = 'ANY' AND salestype = '" . $SalesType . "'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 	if (DB_num_rows($Result)==0){
 
@@ -70,7 +69,7 @@ function GetCOGSGLAccount ($Area, $StockID, $SalesType) {
 			AND stkcat = '" . $StockCategory . "'
 			AND salestype = '" . $SalesType . "'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 
 	if (DB_num_rows($Result)==0){
@@ -82,7 +81,7 @@ function GetCOGSGLAccount ($Area, $StockID, $SalesType) {
 			AND salestype='AN'
 			AND stkcat = '" . $StockCategory . "'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 
 	if (DB_num_rows($Result)==0){
@@ -93,7 +92,7 @@ function GetCOGSGLAccount ($Area, $StockID, $SalesType) {
 			WHERE area = '" . $Area . "'
 			AND stkcat = 'ANY'
 			AND salestype='AN'";
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 
 	if (DB_num_rows($Result)==0) {
@@ -103,7 +102,7 @@ function GetCOGSGLAccount ($Area, $StockID, $SalesType) {
                 		WHERE area = 'AN'
                 		AND stkcat = 'ANY'
                 		AND salestype = '" . $SalesType . "'";
-            $Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+            $Result = DB_query($SQL, $ErrMsg);
       }
 
 	if (DB_num_rows($Result)==0){
@@ -114,7 +113,7 @@ function GetCOGSGLAccount ($Area, $StockID, $SalesType) {
                   WHERE area = 'AN'
                   AND stkcat = 'ANY'
                   AND salestype='AN'";
-                  $Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+                  $Result = DB_query($SQL, $ErrMsg);
       }
 
 	if (DB_num_rows($Result)==0){ /*STILL!*/
@@ -150,12 +149,10 @@ function GetSalesGLAccount ($Area, $StockID, $SalesType) {
 /*Gets the  Sales GL Code for a specific area, sales type and stock category */
 
 	$ErrMsg = _('There was a problem retrieving the sales general ledger code because');
-	$DbgMsg =  _('SQL to get the sales GL Codes for sales and discounts');
-
 
 		/*Get the StockCategory for this item */
 	$SQL = "SELECT categoryid FROM stockmaster WHERE stockid='" . $StockID . "'";
-	$Result=DB_query($SQL);
+	$Result = DB_query($SQL);
 	$MyRow = DB_fetch_row($Result);
 	$StockCategory = $MyRow[0];
 
@@ -181,7 +178,7 @@ function GetSalesGLAccount ($Area, $StockID, $SalesType) {
 			AND stkcat = '" . $StockCategory . "'
 			AND salestype = '". $SalesType . "'";
 
-	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 
 	if (DB_num_rows($Result)==0){
 		DB_free_result($Result);
@@ -192,7 +189,7 @@ function GetSalesGLAccount ($Area, $StockID, $SalesType) {
 				AND stkcat = '" . $StockCategory . "'
 				AND salestype = 'AN'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 
 	if (DB_num_rows($Result)==0){
@@ -204,7 +201,7 @@ function GetSalesGLAccount ($Area, $StockID, $SalesType) {
 				AND stkcat = 'ANY'
 				AND salestype = '" . $SalesType . "'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 
 	if (DB_num_rows($Result)==0){
@@ -216,7 +213,7 @@ function GetSalesGLAccount ($Area, $StockID, $SalesType) {
 				AND salestype='" . $SalesType . "'
 				AND stkcat = '" . $StockCategory . "'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 
 	if (DB_num_rows($Result)==0){
@@ -228,7 +225,7 @@ function GetSalesGLAccount ($Area, $StockID, $SalesType) {
 				AND salestype='AN'
 				AND stkcat = '" . $StockCategory . "'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 
 	if (DB_num_rows($Result)==0){
@@ -240,7 +237,7 @@ function GetSalesGLAccount ($Area, $StockID, $SalesType) {
 				AND stkcat = 'ANY'
 				AND salestype='AN'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 
         if (DB_num_rows($Result)==0) {
@@ -251,7 +248,7 @@ function GetSalesGLAccount ($Area, $StockID, $SalesType) {
                 	WHERE area = 'AN'
                 	AND stkcat = 'ANY'
                 	AND salestype = '" . $SalesType . "'";
-        	$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+        	$Result = DB_query($SQL, $ErrMsg);
         }
 
 	if (DB_num_rows($Result)==0){
@@ -264,7 +261,7 @@ function GetSalesGLAccount ($Area, $StockID, $SalesType) {
 				AND stkcat = 'ANY'
 				AND salestype='AN'";
 
-		$Result = DB_query($SQL,$ErrMsg,$DbgMsg);
+		$Result = DB_query($SQL, $ErrMsg);
 	}
 	if (DB_num_rows($Result)==0){ /*STILL!*/
 		/*The default if all else fails */

--- a/includes/MiscFunctions.php
+++ b/includes/MiscFunctions.php
@@ -547,9 +547,8 @@ function ChangeFieldInTable($TableName, $FieldName, $OldValue, $NewValue) {
 	*/
 	echo '<br />' . _('Changing') . ' ' . $TableName . ' ' . _('records');
 	$SQL = "UPDATE " . $TableName . " SET " . $FieldName . " ='" . $NewValue . "' WHERE " . $FieldName . "='" . $OldValue . "'";
-	$DbgMsg = _('The SQL statement that failed was');
 	$ErrMsg = _('The SQL to update' . ' ' . $TableName . ' ' . _('records failed'));
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+	$Result = DB_query($SQL, $ErrMsg, '', true);
 	echo ' ... ' . _('completed');
 }
 

--- a/includes/OutputSerialItems.php
+++ b/includes/OutputSerialItems.php
@@ -22,7 +22,7 @@ $RemoveLink = '<a href="' . htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UT
 $SQL="SELECT perishable
 		FROM stockmaster
 		WHERE stockid='".$StockID."'";
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 $MyRow=DB_fetch_array($Result);
 $Perishable=$MyRow['perishable'];
 if ($LineItem->Serialised==1){
@@ -165,7 +165,7 @@ $SQL="SELECT serialno,
 		FROM stockserialitems
 		WHERE stockid='".$StockID."'
 		AND loccode='" . $Location . "'";
-$Result=DB_query($SQL);
+$Result = DB_query($SQL);
 
 $RowNumber=0;
 while ($MyRow=DB_fetch_array($Result)){

--- a/includes/PO_ReadInOrder.php
+++ b/includes/PO_ReadInOrder.php
@@ -58,8 +58,7 @@
 							WHERE purchorders.orderno = '" . $_GET['ModifyOrderNumber'] . "'";
 
 	   $ErrMsg =  _('The order cannot be retrieved because');
-	   $DbgMsg =  _('The SQL statement that was used and failed was');
-	   $GetOrdHdrResult = DB_query($OrderHeaderSQL,$ErrMsg,$DbgMsg);
+	   $GetOrdHdrResult = DB_query($OrderHeaderSQL, $ErrMsg);
 
 	if (DB_num_rows($GetOrdHdrResult)==1 and !isset($_SESSION['PO'.$identifier]->OrderNo )) {
 
@@ -117,7 +116,7 @@
 							ORDER BY suppliers.supplierid";
 
 			$ErrMsg = _('The searched supplier records requested cannot be retrieved because');
-			$Result_SuppSelect = DB_query($SupplierSQL,$ErrMsg);
+			$Result_SuppSelect = DB_query($SupplierSQL, $ErrMsg);
 
 			if (DB_num_rows($Result_SuppSelect)==1){
 				$MyRow=DB_fetch_array($Result_SuppSelect);
@@ -163,8 +162,7 @@
 									ORDER BY podetailitem";
 
 			$ErrMsg =  _('The lines on the purchase order cannot be retrieved because');
-			$DbgMsg =  _('The SQL statement that was used to retrieve the purchase order lines was');
-			$LineItemsResult = DB_query($LineItemsSQL,$ErrMsg,$DbgMsg);
+			$LineItemsResult = DB_query($LineItemsSQL, $ErrMsg);
 
 		  if (DB_num_rows($LineItemsResult) > 0) {
 

--- a/includes/SQL_CommonFunctions.php
+++ b/includes/SQL_CommonFunctions.php
@@ -17,13 +17,11 @@ function GetNextTransNo($TransType) {
 	$SQL = "UPDATE systypes SET typeno = typeno + 1 WHERE typeid = '" . $TransType . "'";
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': '
 		. _('The transaction number could not be incremented');
-	$DbgMsg = _('The following SQL to increment the transaction number was used');
-	DB_query($SQL, $ErrMsg, $DbgMsg);
+	DB_query($SQL, $ErrMsg);
 	$SQL = "SELECT typeno FROM systypes WHERE typeid= '" . $TransType . "'";
 	$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': <BR>'
 		. _('The next transaction number could not be retrieved from the database because');
-	$DbgMsg = _('The following SQL to retrieve the transaction number was used');
-	$GetTransNoResult = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$GetTransNoResult = DB_query($SQL, $ErrMsg);
 	$MyRow = DB_fetch_row($GetTransNoResult);
 	return $MyRow[0];
 }
@@ -103,7 +101,7 @@ function GetTaxes($TaxGroup, $DispatchTaxProvince, $TaxCategory) {
 function GetSalesGLCode($salesarea, $partnumber) {
     $SQL="SELECT salesglcode FROM salesglpostings
 			WHERE stkcat='any'";
-    $Result=DB_query($SQL);
+    $Result = DB_query($SQL);
     $MyRow=DB_fetch_array($Result);
     return $MyRow[0];
 }
@@ -185,8 +183,7 @@ function ItemCostUpdateGL($StockID, $NewCost, $OldCost, $QOH) {
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': '
 			. _('The GL credit for the stock cost adjustment posting could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		$SQL = "INSERT INTO gltrans (type,
 						typeno,
@@ -206,8 +203,7 @@ function ItemCostUpdateGL($StockID, $NewCost, $OldCost, $QOH) {
 
 		$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': '
 			. _('The GL debit for stock cost adjustment posting could not be inserted because');
-		$DbgMsg = _('The following SQL to insert the GLTrans record was used');
-		$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+		$Result = DB_query($SQL, $ErrMsg, '', true);
 	}
 }
 
@@ -409,8 +405,7 @@ function CreateQASample($ProdSpecKey, $LotKey, $Identifier, $Comments, $Cert, $D
 										'" . date('Y-m-d') . "')";
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': '
 				. _('The create of the qasamples record failed');
-			$DbgMsg = _('The following SQL to create the qasamples was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 			$SampleID = DB_Last_Insert_ID('qasamples', 'sampleid');
 			$SQL = "INSERT INTO sampleresults (sampleid,
 											testid,
@@ -432,8 +427,7 @@ function CreateQASample($ProdSpecKey, $LotKey, $Identifier, $Comments, $Cert, $D
 											AND prodspecs.active='1'";
 			$ErrMsg = _('CRITICAL ERROR') . '! ' . _('NOTE DOWN THIS ERROR AND SEEK ASSISTANCE') . ': '
 				. _('The create of the sampleresults record failed');
-			$DbgMsg = _('The following SQL to create the sampleresults was used');
-			$Result = DB_query($SQL, $ErrMsg, $DbgMsg, true);
+			$Result = DB_query($SQL, $ErrMsg, '', true);
 
 		} //$MyRow2[0]==0
 	} //$MyRow[0]>0

--- a/includes/SelectOrderItems_IntoCart.php
+++ b/includes/SelectOrderItems_IntoCart.php
@@ -51,8 +51,7 @@ if ($AlreadyOnThisOrder!=1){
 			AND stockmaster.stockid = '". $NewItem . "'";
 
     $ErrMsg = _('The details for') . ' ' . $NewItem . ' ' . _('could not be retrieved because');
-    $DbgMsg = _('The SQL used to retrieve the pricing details but failed was');
-    $Result1 = DB_query($SQL,$ErrMsg,$DbgMsg);
+    $Result1 = DB_query($SQL, $ErrMsg);
 
     if (DB_num_rows($Result1)==0){
 		prnMsg(_('The item code') . ' ' . $NewItem  . ' '  . _('could not be found in the database') . ' - ' . _('it has not been added to the order'),'warn',_('Item Does Not Exist'));

--- a/includes/StockFunctions.php
+++ b/includes/StockFunctions.php
@@ -59,13 +59,12 @@ function GetQuantityOnHand($StockID, $Location) {
 		$UserAllowedLocations = '';
 		$ErrMsg = _('The quantity on hand for this product in the specified location cannot be retrieved because');
 	}
-	$DbgMsg = _('The following SQL to retrieve the total stock quantity was used');
 	$SQL = "SELECT SUM(quantity) AS qoh
 			FROM locstock " .
 			$UserAllowedLocations . "
 			WHERE stockid = '" . $StockID . "'" .
 			$WhereLocation . "";
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result) == 0) {
 		return 0;
 	}else{
@@ -282,7 +281,6 @@ function GetDemandQuantityDueToOutstandingSalesOrders($StockID, $Location) {
 		$UserAllowedLocations = '';
 		$ErrMsg = _('The quantity demanded for this product in the specified location cannot be retrieved because');
 	}
-	$DbgMsg = _('The following SQL to retrieve the demanded stock quantity was used');
 
 	$SQL = "SELECT SUM(salesorderdetails.quantity - salesorderdetails.qtyinvoiced) AS demand
 			FROM salesorderdetails
@@ -294,7 +292,7 @@ function GetDemandQuantityDueToOutstandingSalesOrders($StockID, $Location) {
 				AND salesorders.quotation = 0 " .
 				$WhereLocation;
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result) == 0) {
 		return 0;
 	}
@@ -358,7 +356,6 @@ function GetDemandQuantityAsComponentInAssemblyItems($StockID, $Location){
 		$UserAllowedLocations = '';
 		$ErrMsg = _('The quantity demanded for this product as a component in BOM in the specified location cannot be retrieved because');
 	}
-	$DbgMsg = _('The following SQL to retrieve the demanded stock quantity  as a component in BOM was used');
 
 	$SQL = "SELECT SUM((salesorderdetails.quantity - salesorderdetails.qtyinvoiced) * bom.quantity) AS demand
 			FROM salesorderdetails
@@ -375,7 +372,7 @@ function GetDemandQuantityAsComponentInAssemblyItems($StockID, $Location){
 				AND salesorders.quotation = 0 " .
 				$WhereLocation;
 
-	$Result = DB_query($SQL, $ErrMsg, $DbgMsg);
+	$Result = DB_query($SQL, $ErrMsg);
 	if (DB_num_rows($Result) == 0) {
 		return 0;
 	}
@@ -447,7 +444,6 @@ function GetDemandQuantityAsComponentInWorkOrders($StockID, $Location) {
 		$UserAllowedLocations = '';
 		$ErrMsg = _('The quantity demanded for this product as a component in work orders in the specified location cannot be retrieved because');
 	}
-	$DbgMsg = _('The following SQL to retrieve the demanded stock quantity  as a component in work orders was used');
 
 	$SQL = "SELECT SUM(qtypu * (woitems.qtyreqd - woitems.qtyrecd)) AS demand
 			FROM woitems

--- a/includes/UserLogin.php
+++ b/includes/UserLogin.php
@@ -45,7 +45,7 @@ function userLogin($Name, $Password, $SysAdminEmail = '') {
 		$ErrMsg = _('Could not retrieve user details on login because');
 		$Debug =1;
         $PasswordVerified = false;
-		$Auth_Result = DB_query($SQL,$ErrMsg);
+		$Auth_Result = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($Auth_Result) > 0) {
 			$MyRow = DB_fetch_array($Auth_Result);

--- a/reportwriter/FormMaker.php
+++ b/reportwriter/FormMaker.php
@@ -144,7 +144,7 @@ function BuildFormList($GroupID) {
 					AND reporttype='frm'
 					ORDER BY groupname,
 												reportname";
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 			$FormList = array();
 			while ($Temp = DB_fetch_array($Result)) $FormList[] = $Temp;
 			foreach ($FormGroups as $index=>$value) {
@@ -167,7 +167,7 @@ function BuildFormList($GroupID) {
 				FROM ".DBReports."
 				WHERE defaultreport='1' AND groupname='".$GroupID."'
 				ORDER BY reportname";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		$OutputString .= '<tr><td colspan="3" width="250" valign="top">';
 		while ($Forms = DB_fetch_array($Result)) {
 			$OutputString .= '<input type="radio" name="ReportID" value="'.$Forms['id'].'">'.$Forms['reportname'].'<br />';
@@ -200,7 +200,7 @@ function FetchReportDetails($ReportID) {
 					table6criteria
 			FROM " . DBReports . "
 			WHERE id = '".$ReportID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$myrow=DB_fetch_assoc($Result);
 	foreach ($myrow as $key=>$value) {
 		$Prefs[$key]=$value;
@@ -219,7 +219,7 @@ function RetrieveFields($ReportID, $EntryType) {
 			WHERE reportid = '".$ReportID."'
 			AND entrytype = '".$EntryType."'
 			ORDER BY seqnum";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	while ($FieldValues = DB_fetch_assoc($Result)) { $FieldListings[] = $FieldValues; }
 	return $FieldListings;
 }

--- a/reportwriter/ReportMaker.php
+++ b/reportwriter/ReportMaker.php
@@ -49,7 +49,7 @@ if (!isset($_GET['action']) OR (!isset($_POST['ReportID']))) {
 	} elseif (isset($_POST['dn'.$SeqNum.'_x'])) { // the shift down button was pushed
 		$sql = "SELECT seqnum FROM ".DBRptFields."
 						WHERE reportid = '".$ReportID."' AND entrytype = 'fieldlist';";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		if ($SeqNum<DB_num_rows($Result)) {
 			$success = ChangeSequence($ReportID, $SeqNum, 'fieldlist', 'down');
 		}
@@ -69,9 +69,9 @@ if (!isset($_GET['action']) OR (!isset($_POST['ReportID']))) {
 	switch ($_POST['todo']) {
 		case RPT_BTN_DELRPT: // enter here only from My Report selection, never from default report
 			$sql= "DELETE FROM ".DBReports." WHERE id = '".$ReportID."'";
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 			$sql= "DELETE FROM ".DBRptFields." WHERE reportid = '".$ReportID."'";
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 			// Recreate drop down list and return to report home (handled in Cancel below)
 
 		case RPT_BTN_CANCEL:
@@ -189,7 +189,7 @@ function GetReports($Default) {
 		WHERE defaultreport='".$Def."'
 		ORDER BY groupname, reportname";
 
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$DefaultReports = array();
 	while ($Temp = DB_fetch_array($Result)) {
 		$DefaultReports[] = $Temp;
@@ -217,7 +217,7 @@ function build_dropdown_list($arraylist) {
 
 function FetchReportDetails($ReportID) {
 	$sql= "SELECT *	FROM ".DBReports." WHERE id = '".$ReportID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$myrow=DB_fetch_assoc($Result);
 	foreach ($myrow as $key=>$value) {
 		$Prefs[$key]=$value;
@@ -239,7 +239,7 @@ function RetrieveFields($ReportID, $EntryType) {
 	$sql= "SELECT *	FROM ".DBRptFields."
 		WHERE reportid = '".$ReportID."' AND entrytype = '".$EntryType."'
 		ORDER BY seqnum";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	while ($FieldValues = DB_fetch_assoc($Result)) {
 		$FieldListings[] = $FieldValues;
 	}
@@ -256,7 +256,7 @@ function ChangeSequence($ReportID,
 		AND entrytype = '".$EntryType."'
 		AND seqnum = '".$SeqNum."'";
 
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$myrow = DB_fetch_row($Result);
 	$OrigID = $myrow[0];
 	if ($UpDown=='up') {
@@ -269,9 +269,9 @@ function ChangeSequence($ReportID,
 		WHERE reportid = '".$ReportID."'
 		AND entrytype = '".$EntryType."'
 		AND seqnum = '".$NewSeqNum."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$sql = "UPDATE ".DBRptFields." SET seqnum='".$NewSeqNum."' WHERE id = '".$OrigID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	return true;
 }
 
@@ -335,7 +335,7 @@ function ReadPostData($ReportID, $Prefs) {
 		$success = SavePrefs($ReportID);
 		// values saved, read them back in to update $Prefs array
 		$sql= "SELECT *	FROM ".DBReports." WHERE id = '".$ReportID."'";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		$myrow=DB_fetch_assoc($Result);
 		foreach ($myrow as $key=>$value) $Prefs[$key]=$value;
 		return $Prefs;
@@ -376,7 +376,7 @@ function ReadPostData($ReportID, $Prefs) {
 		if (!$Prefs['defaultreport']) { // save it since it's a custom report
 			$sql = "UPDATE ".DBRptFields." SET params='".$Prefs['CritListings'][$i-1]['params']."'
 				WHERE reportid ='".$ReportID."' AND entrytype='critlist' AND seqnum='".$i."'";
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 		}
 		$i++;
 	}
@@ -393,7 +393,7 @@ function ReadPostData($ReportID, $Prefs) {
 				visible='".$Prefs['FieldListings'][$i-1]['visible']."',
 				columnbreak='".$Prefs['FieldListings'][$i-1]['columnbreak']."'
 			WHERE reportid ='".$ReportID."' AND entrytype='fieldlist' AND seqnum='".$i."'";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		$i++;
 	}
 	return $Prefs;
@@ -401,17 +401,17 @@ function ReadPostData($ReportID, $Prefs) {
 
 function SaveFilters($ReportID, $EntryType, $Params) {
 	$sql = "UPDATE ".DBRptFields." SET params='".$Params."' WHERE reportid ='".$ReportID."' AND entrytype='".$EntryType."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	return true;
 }
 
 function SaveDefSettings($ReportID, $EntryType, $SeqNum) {
 	// This function sets all the params for a given entrytype to 0 and sets just the new default seqnum to 1
 	$sql = "UPDATE ".DBRptFields." SET params='0' WHERE reportid='".$ReportID."' AND entrytype='".$EntryType."';";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$sql = "UPDATE ".DBRptFields." SET params='1'
 		WHERE reportid ='".$ReportID."' AND entrytype='".$EntryType."' AND seqnum='".$SeqNum."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	return true;
 }
 
@@ -477,7 +477,7 @@ function SavePrefs($ReportID) {
 			col19width = ".$_POST['Col19Width'].",
 			col20width = ".$_POST['Col20Width'].",
 		WHERE id ='".$ReportID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	return true;
 }
 
@@ -493,7 +493,7 @@ function SaveNewReport($ReportID, $AllowOverwrite) {
 	}
 	// check for duplicate report name and error or overwrite if allowed
 	$sql = "SELECT id, defaultreport FROM ".DBReports." WHERE reportname='".addslashes($_POST['ReportName'])."';";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	if (DB_num_rows($Result)>0) $myrow = DB_fetch_array($Result);
 	if (isset($myrow)) { // then we have a duplicate report name do some checking
 		if ($myrow['defaultreport']) { // it's a default don't allow overwrite no matter what, return
@@ -510,9 +510,9 @@ function SaveNewReport($ReportID, $AllowOverwrite) {
 		// check for the same report to update or replace a different report than ReportID
 		if ($myrow['id']<>$ReportID) { // erase the report to overwrite and duplicate ReportID
 			$sql= "DELETE FROM ".DBReports." WHERE id = '".$myrow['id']."'";
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 			$sql= "DELETE FROM ".DBRptFields." WHERE reportid = '".$myrow['id']."'";
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 		} else { // just return because the save as name is the same as the current report name
 			$Rtn['message'] = RPT_REPORT.$Prefs['reportname'].RPT_WASSAVED.$_POST['ReportName'];
 			$Rtn['ReportID'] = $ReportID;
@@ -524,20 +524,20 @@ function SaveNewReport($ReportID, $AllowOverwrite) {
 	$OrigID = $ReportID;
 	// Set the report id to 0 to prepare to duplicate
 	$sql = "UPDATE ".DBReports." SET id=0 WHERE id='".$ReportID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$sql = "INSERT INTO ".DBReports." SELECT * FROM ".DBReports." WHERE id=0;";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	// Fetch the id entered
 	$ReportID = DB_Last_Insert_ID('reports','id');
 	// Restore original report ID from 0
 	$sql = "UPDATE ".DBReports." SET id='".$OrigID."' WHERE id=0;";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	// Set the report name per the form and make a non-default report
 	$sql = "UPDATE ".DBReports." SET reportname='".addslashes($_POST['ReportName'])."', defaultreport='0' WHERE id ='".$ReportID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	// fetch the fields and duplicate
 	$sql = "SELECT * FROM ".DBRptFields." WHERE reportid='".$OrigID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	while ($temp = DB_fetch_array($Result)) $field[] = $temp;
 	foreach ($field as $row) {
 		$sql = "INSERT INTO ".DBRptFields." (reportid, entrytype, seqnum, fieldname,
@@ -545,7 +545,7 @@ function SaveNewReport($ReportID, $AllowOverwrite) {
 			VALUES ('".$ReportID."', '".$row['entrytype']."', '".$row['seqnum']."',
 				'".$row['fieldname']."', '".$row['displaydesc']."', '".$row['visible']."',
 				'".$row['columnbreak']."', '".$row['params']."');";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 	}
 	$Rtn['message'] = RPT_REPORT.$Prefs['reportname'].RPT_WASSAVED.$_POST['ReportName'];
 	$Rtn['ReportID'] = $ReportID;

--- a/reportwriter/admin/RCFunctions.php
+++ b/reportwriter/admin/RCFunctions.php
@@ -61,19 +61,19 @@ function RetrieveReports() {
 		$sql= "SELECT id, reportname FROM ".DBReports."
 			WHERE defaultreport='1' AND reporttype='rpt' AND groupname='".$key."'
 			ORDER BY reportname";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		while ($Temp = DB_fetch_array($Result)) $OutputString .= '<input type="radio" name="ReportID" value="'.$Temp['id'].'">'.$Temp['reportname'].'<br />';
 		$sql= "SELECT id, reportname FROM ".DBReports."
 			WHERE defaultreport='0' AND reporttype='rpt' AND groupname='".$key."'
 			ORDER BY reportname";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		if (DB_num_rows($Result)>0) $OutputString .= '<u>'.RPT_CUSTRPT.'</u><br />';
 		while ($Temp = DB_fetch_array($Result)) $OutputString .= '<input type="radio" name="ReportID" value="'.$Temp['id'].'">'.$Temp['reportname'].'<br />';
 		$OutputString .= '</td>'.chr(10).'<td width="250" valign="top">';
 		$sql= "SELECT id, groupname, reportname FROM ".DBReports."
 			WHERE defaultreport='1' AND reporttype='frm'
 			ORDER BY groupname, reportname";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		$FormList = array();
 		while ($Temp = DB_fetch_array($Result)) $FormList[] = $Temp;
 		foreach ($FormGroups as $index=>$value) {
@@ -99,7 +99,7 @@ function RetrieveFields($EntryType) {
 	$sql= "SELECT *	FROM ".DBRptFields."
 		WHERE reportid = ".$ReportID." AND entrytype = '".$EntryType."'
 		ORDER BY seqnum";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	if (DB_num_rows($Result)>0) {
 		while ($FieldValues = DB_fetch_array($Result)) {
 			$FieldListings['lists'][] = $FieldValues;
@@ -182,7 +182,7 @@ function UpdatePageFields($ReportID) {
 				col20width = ".$_POST['Col20Width'];
 	}
 	$sql .=" WHERE id =".$ReportID.";";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	return true;
 }
 
@@ -195,7 +195,7 @@ function UpdateCritFields($ReportID, $DateString) {
 		displaydesc = '".$DateString."',
 		params = '".$_POST['DefDate']."'
 		WHERE reportid = ".$ReportID." AND entrytype = 'dateselect';";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	if ($Type<>'frm') { // then write specifics for a report
 		// write the truncate long descriptions choice
 		$sql = "UPDATE ".DBRptFields." SET
@@ -204,7 +204,7 @@ function UpdateCritFields($ReportID, $DateString) {
 			params = '".$_POST['TruncLongDesc']."',
 			displaydesc = ''
 			WHERE reportid = ".$ReportID." AND entrytype = 'trunclong';";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 	} else { // it's a form update the page break info
 		// write the form page break fieldname
 		$sql = "UPDATE ".DBRptFields." SET
@@ -215,7 +215,7 @@ function UpdateCritFields($ReportID, $DateString) {
 			params = '',
 			displaydesc = ''
 			WHERE reportid = ".$ReportID." AND entrytype = 'grouplist';";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 	}
 	return true;
 }
@@ -233,7 +233,7 @@ function UpdateDBFields($ReportID) {
     for ($i=0;$i<6;$i++) {
 	  	if (isset($_POST['Table'.$i]) and $_POST['Table'.$i]) {
 			$sql = "SHOW TABLES WHERE Tables_in_".$_SESSION['DatabaseName']."='".$_POST['Table'.$i]."'";
-			$Result=DB_query($sql,'','',false,false);
+			$Result = DB_query($sql,'','',false,false);
 			if (DB_num_rows($Result)==0) return false;
 		}
 		// if we have a row, sql was valid
@@ -251,7 +251,7 @@ function UpdateDBFields($ReportID) {
 			table6 = '".DB_escape_string($_POST['Table6'])."',
 			table6criteria = '".DB_escape_string($_POST['Table6Criteria'])."'
 		WHERE id =".$ReportID.";";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	return true;
 }
 
@@ -268,7 +268,7 @@ function UpdateSequence($EntryType) {
 	// Only update params if not a form (cannot update params once initially set)
 	if ($Type<>'frm') $sql .= ", params = '".$Params."' ";
 	$sql .= "WHERE reportid = ".$ReportID." AND entrytype = '".$EntryType."' AND seqnum = ".$_POST['SeqNum'].";";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	return true;
 }
 
@@ -277,16 +277,16 @@ function ChangeSequence($SeqNum, $EntryType, $UpDown) {
 	// find the id of the row to move
 	$sql = "SELECT id FROM ".DBRptFields."
 		WHERE reportid = ".$ReportID." AND entrytype = '".$EntryType."' AND seqnum = ".$SeqNum.";";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$myrow = DB_fetch_row($Result);
 	$OrigID = $myrow[0];
 	if ($UpDown=='up') $NewSeqNum = $SeqNum-1; else $NewSeqNum = $SeqNum+1;
 	// first move affected sequence to seqnum, then seqnum to new position
 	$sql = "UPDATE ".DBRptFields." SET seqnum='".$SeqNum."'
 		WHERE reportid = ".$ReportID." AND entrytype = '".$EntryType."' AND seqnum = ".$NewSeqNum.";";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$sql = "UPDATE ".DBRptFields." SET seqnum='".$NewSeqNum."' WHERE id = ".$OrigID.";";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	return true;
 }
 
@@ -298,14 +298,14 @@ function InsertSequence($SeqNum, $EntryType) {
 	$sql = "SELECT id FROM ".DBRptFields."
 		WHERE reportid = ".$ReportID." AND entrytype = '".$EntryType."'
 		ORDER BY seqnum;";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	while ($FieldID = DB_fetch_array($Result)) { $IDList[] = $FieldID['id']; }
 	$NumRows = DB_num_rows($Result);
 	if (!$IDList OR ($NumRows < $SeqNum)) { $SeqNum = DB_num_rows($Result) + 1;	}
 	if ($SeqNum <= $NumRows) { // shift the fields down to make a sequence hole
 		for ($j=$SeqNum-1; $j<$NumRows; $j++) {
 			$sql = "UPDATE ".DBRptFields." SET seqnum = ".($j+2)." WHERE id=".$IDList[$j].";";
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 		}
 	}
 	if (!isset($_POST['Visible'])) $Visible = '0'; else $Visible = $_POST['Visible'];
@@ -322,7 +322,7 @@ function InsertSequence($SeqNum, $EntryType) {
 			(reportid, entrytype, seqnum, fieldname, displaydesc, visible, columnbreak, params)
 		VALUES (".$ReportID.",'".$EntryType."',".$SeqNum.",'".DB_escape_string($_POST['FieldName'])."',
 			'".DB_escape_string($_POST['DisplayDesc'])."','".$Visible."','".$ColumnBreak."','".$Params."');";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	return $SeqNum;
 }
 
@@ -332,18 +332,18 @@ function DeleteSequence($SeqNum, $EntryType) {
 	//  delete the sequence number from the list
 	$sql = "DELETE FROM ".DBRptFields."
 		WHERE reportid = ".$ReportID." AND entrytype = '".$EntryType."' AND seqnum = ".$SeqNum.";";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	// read in the remaining sequences and re-number
 	$sql = "SELECT id FROM ".DBRptFields."
 		WHERE reportid = ".$ReportID." AND entrytype = '".$EntryType."'
 		ORDER BY seqnum;";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	while ($FieldID = DB_fetch_array($Result)) { $IDList[] = $FieldID['id']; }
 	$NumRows = DB_num_rows($Result);
 	if ($NumRows >= $SeqNum) {	// then not at end of list re-number sequences
 		for ($j=$SeqNum-1; $j<$NumRows; $j++) {
 			$sql = "UPDATE ".DBRptFields." SET seqnum = ".($j+1)." WHERE id=".$IDList[$j].";";
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 		}
 	}
 	return true;
@@ -436,7 +436,7 @@ function ValidateField($ReportID, $FieldName, $Description) {
 			table5, table5criteria,
 			table6, table6criteria
 		FROM ".DBReports." WHERE id='".$ReportID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$Prefs = DB_fetch_assoc($Result);
 	// Check for a non-blank entry in the field description or fieldname
 	if (mb_strlen($FieldName)<1 OR mb_strlen($Description)<1) return false;
@@ -448,7 +448,7 @@ function ValidateField($ReportID, $FieldName, $Description) {
 	if ($Prefs['table5']) $strTable .= ' INNER JOIN '.$Prefs['table5']. ' ON '.$Prefs['table5criteria'];
 	if ($Prefs['table6']) $strTable .= ' INNER JOIN '.$Prefs['table6']. ' ON '.$Prefs['table6criteria'];
 	$sql = "SELECT ".$FieldName." FROM ".$strTable." LIMIT 1";
-	$Result=DB_query($sql,'','',false,false);
+	$Result = DB_query($sql,'','',false,false);
 	// Try to fetch one row, if we have a row, sql was valid
 	if (DB_num_rows($Result)<1) return false; else return true;
 }
@@ -552,7 +552,7 @@ function ExportReport($ReportID) {
 	$CSVOutput .= 'version:1.0'.$crlf;
 	// Fetch the core report data from table reports
 	$sql = "SELECT * FROM ".DBReports." WHERE id = ".$ReportID.";";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$myrow = DB_fetch_assoc($Result);
 	// Fetch the language dependent db entries
 	$ReportName = $myrow['reportname'];
@@ -570,7 +570,7 @@ function ExportReport($ReportID) {
 	// Now add the report fields
 	$CSVOutput .= $crlf.'/* Report Field Description Information: */'.$crlf;
 	$sql = "SELECT * FROM ".DBRptFields." WHERE reportid = ".$ReportID." ORDER BY entrytype, seqnum;";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$i=0;
 	while ($FieldRows = DB_fetch_assoc($Result)) {
 		if ($FieldRows['entrytype']<>'dateselect' AND $FieldRows['entrytype']<>'trunclong') {
@@ -643,7 +643,7 @@ function ImportReport($RptName) {
 	// check for valid file, duplicate report name
 	if ($RptName=='') $RptName = $ReportName; // then no report was entered use reportname from file
 	$sql= "SELECT id FROM ".DBReports." WHERE reportname='".DB_escape_string($RptName)."';";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	if (DB_num_rows($Result)>0) { // the report name already exists, error
 		$Rtn['result'] = 'error';
 		$Rtn['message'] = RPT_REPDUP;
@@ -654,7 +654,7 @@ function ImportReport($RptName) {
 	foreach ($arrSQL as $sql) { // find the main reports sql statement, language and execute it
 		if (mb_strpos($sql,'ReportData:')===0) {
 			$sql="INSERT INTO ".DBReports." SET ".mb_substr(trim($sql),11);
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 			$ValidReportSQL = true;
 		}
 	}
@@ -671,7 +671,7 @@ function ImportReport($RptName) {
 			title1desc = '".$Title1Desc."',
 			title2desc = '".$Title2Desc."'
 		WHERE id = ".$ReportID.";";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	foreach ($arrSQL as $sql) { // fetch the translations for the field descriptions
 		if (mb_strpos($sql,'FieldDesc')===0) { // then it's a field description, find the index and save
 			$sql = trim($sql);
@@ -684,14 +684,14 @@ function ImportReport($RptName) {
 			$sql = trim($sql);
 			$FldIndex = mb_substr($sql,9,mb_strpos($sql,':')-9);
 			$sql="INSERT INTO ".DBRptFields." SET ".mb_substr($sql,mb_strpos($sql,':')+1);
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 			$FieldID = DB_Last_Insert_ID(DBRptFields, 'id');
 			if ($FieldID<>0) { // A field was successfully written update the report id
 				if (isset($Language[$FldIndex])) $DispSQL = "displaydesc='".$Language[$FldIndex]."', ";
 					else $DispSQL = '';
 				$tsql = "UPDATE ".DBRptFields." SET ".$DispSQL." reportid='".$ReportID."'
 					WHERE id=".$FieldID.";";
-				$Result=DB_query($tsql,'','',false,true);
+				$Result = DB_query($tsql,'','',false,true);
 			}
 		}
 	}
@@ -702,7 +702,7 @@ function ImportReport($RptName) {
 
 function CreateTableList($ReportID,$Table) {
 	$sql = "SELECT table".$Table." FROM ".DBReports." WHERE id='".$ReportID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$myrow = DB_fetch_row($Result);
 
 	$TableList = '';
@@ -720,14 +720,14 @@ function CreateTableList($ReportID,$Table) {
 function CreateLinkList($ReportID,$Table) {
 	$sql = "SELECT table1, table2, table3, table4, table5, table6
 		FROM ".DBReports." WHERE id='".$ReportID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$myrow = DB_fetch_row($Result);
 	$LinkList = ''; $j = 0;
 
 	/* Get list of link tables from foreign keys */
 	for ($i = 0; $i < $Table; $i++) {
 		$sql = "SELECT table1, table2 FROM reportlinks WHERE table1 = '" . $myrow[$i] . "'";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		while($mytable=DB_fetch_row($Result)) {
 			if ($myrow[$Table]) {
 				if ($myrow[$Table] == $mytable[1]){
@@ -759,14 +759,14 @@ function CreateLinkEqList($ReportID,$Table) {
 		table5, table5criteria,
 		table6, table6criteria
 		FROM ".DBReports." WHERE id='".$ReportID."'";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	$myrow = DB_fetch_row($Result);
 	$LinkEqList = ''; $j = 0;
 
 	/* Get list of foreign key constraints */
 	for ($i = 0; $i < $Table; $i++) {
 		$sql = "SELECT table1, table2, equation FROM reportlinks WHERE table1 = '" . $myrow[$i] . "'";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		while($mytable=DB_fetch_row($Result)) {
 			if ($myrow[$Table+3]) {
 				if ($myrow[$Table+3] == $mytable[2]){
@@ -796,7 +796,7 @@ function CreateFieldList($ReportID,$FName,$Type) {
 	} else { // pull from user selected tables for this report
 		$sql = "SELECT table1, table2, table3, table4, table5, table6
 			FROM " . DBReports . " WHERE id='" . $ReportID . "'";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		$myrow = DB_fetch_row($Result);
 	}
 	$FieldList = '';

--- a/reportwriter/admin/ReportCreator.php
+++ b/reportwriter/admin/ReportCreator.php
@@ -47,7 +47,7 @@ if (!isset($_POST['ReportID'])) { // entered for the first time or created new r
 		$Type=$_POST['Type'];
 	} else { // we only have a reportid, we need to retrieve the type from thge db to set up the forms correctly
 		$sql = "SELECT reporttype FROM ".DBReports." WHERE id='".$ReportID."'";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		$myrow = DB_fetch_array($Result);
 		$Type = $myrow[0];
 	}
@@ -70,13 +70,13 @@ switch ($_GET['action']) {
 				break;
 			case RPT_BTN_EDIT: // fetch the report information and go to the page setup screen
 				$sql = "SELECT * FROM ".DBReports." WHERE id='".$ReportID."'";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$myrow = DB_fetch_array($Result);
 				$FormParams = PrepStep('3');
 				break;
 			case RPT_BTN_RENAME: // Rename a report was selected, fetch the report name and show rename form
 				$sql = "SELECT reportname FROM ".DBReports." WHERE id='".$ReportID."'";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$myrow = DB_fetch_array($Result);
 				$_POST['ReportName'] = $myrow['reportname'];
 				// continue like copy was pushed
@@ -85,9 +85,9 @@ switch ($_GET['action']) {
 				break;
 			case RPT_BTN_DEL: // after confirmation, delete the report and go to the main report admin menu
 				$sql= "DELETE FROM ".DBReports." WHERE id = ".$ReportID.";";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$sql= "DELETE FROM ".DBRptFields." WHERE reportid = ".$ReportID.";";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				// reload main entry form
 			default:
 				$DropDownString = RetrieveReports();
@@ -108,9 +108,9 @@ switch ($_GET['action']) {
 			case RPT_BTN_REPLACE: // Erase the default report and copy a new one with the same name
 				if (isset($_POST['ReplaceReportID'])) { // then we need to delete the report to replace
 					$sql= "DELETE FROM ".DBReports." WHERE id = ".$_POST['ReplaceReportID'].";";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					$sql= "DELETE FROM ".DBRptFields." WHERE reportid = ".$_POST['ReplaceReportID'].";";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 				}
 				// report has been deleted, continue to create or copy (in case 'Continue' below)
 			case RPT_BTN_CONT: // fetch the report information and go to the page setup screen
@@ -122,7 +122,7 @@ switch ($_GET['action']) {
 				}
 				// check for duplicate report name
 				$sql = "SELECT id FROM ".DBReports." WHERE reportname='".addslashes($_POST['ReportName'])."';";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				if (DB_num_rows($Result)>0) { // then we have a duplicate report name, error and reload
 					$myrow = DB_fetch_array($Result);
 					$ReplaceReportID = $myrow['id']; // save the duplicate report id
@@ -146,41 +146,41 @@ switch ($_GET['action']) {
 					$Type = $_POST['NewType'];
 					$sql = "INSERT INTO ".DBReports." (reportname, reporttype, groupname, defaultreport)
 						VALUES ('".addslashes($_POST['ReportName'])."', '".$Type."', '".$GroupName."', '1')";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					$ReportID = DB_Last_Insert_ID(DBReports,'id');
 					// Set some default report information: date display default choices to 'ALL'
 					if ($Type<>'frm') { // set the truncate long descriptions default
 						$sql = "INSERT INTO ".DBRptFields." (reportid, entrytype, params, displaydesc)
 							VALUES (".$ReportID.", 'trunclong', '0', '');";
-						$Result=DB_query($sql,'','',false,true);
+						$Result = DB_query($sql,'','',false,true);
 					} else { // it's a form so write a default form break record
 						$sql = "INSERT INTO ".DBRptFields." (reportid, entrytype, params, displaydesc)
 							VALUES (".$ReportID.", 'grouplist', '', '');";
-						$Result=DB_query($sql,'','',false,true);
+						$Result = DB_query($sql,'','',false,true);
 					}
 					$sql = "INSERT INTO ".DBRptFields." (reportid, entrytype, fieldname, displaydesc)
 						VALUES (".$ReportID.", 'dateselect', '', 'a');";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 				} else { // copy the report and all fields to the new report name
 					$OrigID = $ReportID;
 					// Set the report id to 0 to prepare to copy
 					$sql = "UPDATE ".DBReports." SET id=0 WHERE id=".$ReportID.";";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					$sql = "INSERT INTO ".DBReports." SELECT * FROM ".DBReports." WHERE id = 0;";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					// Fetch the id entered
 					$ReportID = DB_Last_Insert_ID(DBReports,'id');
 					// Restore original report ID from 0
 					$sql = "UPDATE ".DBReports." SET id=".$OrigID." WHERE id=0;";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					// Set the report name and group name per the form
 					$sql = "UPDATE ".DBReports." SET
 							reportname = '" . DB_escape_string($_POST['ReportName']) . "'
 						WHERE id =".$ReportID.";";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					// fetch the fields and duplicate
 					$sql = "SELECT * FROM ".DBRptFields." WHERE reportid=".$OrigID.";";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					while ($temp = DB_fetch_array($Result)) $field[] = $temp;
 					foreach ($field as $row) {
 						$sql = "INSERT INTO ".DBRptFields." (reportid, entrytype, seqnum, fieldname,
@@ -188,12 +188,12 @@ switch ($_GET['action']) {
 							VALUES (".$ReportID.", '".$row['entrytype']."', ".$row['seqnum'].",
 								'".$row['fieldname']."', '".$row['displaydesc']."', '".$row['visible']."',
 								'".$row['columnbreak']."', '".$row['params']."');";
-						$Result=DB_query($sql,'','',false,true);
+						$Result = DB_query($sql,'','',false,true);
 					}
 				}
 				// read back in new data for next screen (will set defaults as defined in the db)
 				$sql = "SELECT * FROM ".DBReports." WHERE id='".$ReportID."'";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$myrow = DB_fetch_array($Result);
 				$FormParams = PrepStep('3');
 				break;
@@ -207,7 +207,7 @@ switch ($_GET['action']) {
 				}
 				// check for duplicate report name
 				$sql = "SELECT id FROM ".DBReports." WHERE reportname='".addslashes($_POST['ReportName'])."';";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				if (DB_num_rows($Result)>0) { // then we have a duplicate report name, error and reload
 					$myrow = DB_fetch_array($Result);
 					if ($myrow['id']<>$ReportID) { // then the report has a duplicate name to something other than itself, error
@@ -217,7 +217,7 @@ switch ($_GET['action']) {
 					}
 				}
 				$sql = "UPDATE ".DBReports." SET reportname='".addslashes($_POST['ReportName'])."' WHERE id=".$ReportID.";";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$usrMsg[] = array('message'=>RPT_UPDATED, 'level'=>'success');
 				// continue with default to return to reports home
 			case RPT_BTN_BACK:
@@ -233,7 +233,7 @@ switch ($_GET['action']) {
 				$success = UpdatePageFields($ReportID);
 				// read back in new data for next screen (will set defaults as defined in the db)
 				$sql = "SELECT * FROM ".DBReports." WHERE id='".$ReportID."'";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$myrow = DB_fetch_array($Result);
 				$FormParams = PrepStep('3');
 				break;
@@ -248,7 +248,7 @@ switch ($_GET['action']) {
 						table6, table6criteria,
 						reportname
 					FROM " . DBReports . " WHERE id='".$ReportID."'";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$myrow = DB_fetch_array($Result);
 				$numrows = DB_num_rows($Result);
 				$FormParams = PrepStep('4');
@@ -264,7 +264,7 @@ switch ($_GET['action']) {
 		switch ($_POST['todo']) {
 			case RPT_BTN_BACK:
 				$sql = "SELECT * FROM ".DBReports." WHERE id='".$ReportID."'";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$myrow = DB_fetch_array($Result);
 				$FormParams = PrepStep('3');
 				break;
@@ -272,7 +272,7 @@ switch ($_GET['action']) {
 			case RPT_BTN_CONT: // fetch the report information and go to the page setup screen
 				if ($_POST['Table1']) {
 					$sql = "SELECT table1 FROM ".DBReports." WHERE id='".$ReportID."'";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					$myrow = DB_fetch_row($Result);
 					if ($myrow[0] != $_POST['Table1']) {
 						unset($_POST['Table2']); unset($_POST['Table2Criteria']);
@@ -295,7 +295,7 @@ switch ($_GET['action']) {
 							table6, table6criteria,
 							reportname
 						FROM ".DBReports." WHERE id='".$ReportID."'";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					$myrow = DB_fetch_array($Result);
 					$FormParams = PrepStep('4');
 					break;
@@ -319,7 +319,7 @@ switch ($_GET['action']) {
 				$FieldListings = RetrieveFields('fieldlist');
 			} elseif (isset($_POST['dn_x'])) { // the shift down button was pushed
 				$sql = "SELECT seqnum FROM ".DBRptFields." WHERE reportid = ".$ReportID." AND entrytype = 'fieldlist';";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				if ($SeqNum<DB_num_rows($Result)) $success = ChangeSequence($SeqNum, 'fieldlist', 'down');
 				$FieldListings = RetrieveFields('fieldlist');
 			} elseif (isset($_POST['ed_x'])) { // the sequence edit button was pushed
@@ -327,7 +327,7 @@ switch ($_GET['action']) {
 				$FieldListings = RetrieveFields('fieldlist');
 				$sql = "SELECT * FROM ".DBRptFields."
 					WHERE reportid = ".$ReportID." AND entrytype = 'fieldlist' AND seqnum=".$SeqNum.";";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$FieldListings['defaults'] = DB_fetch_array($Result);
 				$FieldListings['defaults']['buttonvalue'] = RPT_BTN_CHANGE;
 			} elseif (isset($_POST['rm_x'])) { // the sequence remove button was pushed
@@ -347,7 +347,7 @@ switch ($_GET['action']) {
 							table6, table6criteria,
 							reportname
 						FROM ".DBReports." WHERE id='".$ReportID."'";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					$myrow = DB_fetch_array($Result);
 					$FormParams = PrepStep('4');
 					break;
@@ -435,7 +435,7 @@ switch ($_GET['action']) {
 				$usrMsg[] = array('message'=>RPT_BADDATA, 'level'=>'error');
 			} else { // update the database
 				$sql = "UPDATE ".DBRptFields." SET params='".serialize($Params)."' WHERE id = ".$_POST['ID'].";";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				if ($success=='edit') { // then the edit button was pressed, change button name from Add New to Change
 					$ButtonValue = RPT_BTN_CHANGE;
 				}
@@ -471,7 +471,7 @@ switch ($_GET['action']) {
 					}
 					// Update field properties
 					$sql = "UPDATE ".DBRptFields." SET params='".serialize($Params)."' WHERE id = ".$_POST['ID'].";";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					$Params['TotalField']='';
 					$FormParams = PrepStep('prop');
 					$FormParams['id'] = $myrow['id'];
@@ -515,7 +515,7 @@ switch ($_GET['action']) {
 					}
 					// Update field properties
 					$sql = "UPDATE ".DBRptFields." SET params='".serialize($Params)."' WHERE id = ".$_POST['ID'].";";
-					$Result=DB_query($sql,'','',false,true);
+					$Result = DB_query($sql,'','',false,true);
 					// check for update errors and reload
 					if ($_POST['todo']==RPT_BTN_FINISH) { // no errors and finished so return to field setup
 						$FieldListings = RetrieveFields('fieldlist');
@@ -543,14 +543,14 @@ switch ($_GET['action']) {
 				if ($SeqNum<>1) $success = ChangeSequence($_POST['SeqNum'], $EntryType, 'up');
 			} elseif (isset($_POST['dn_x'])) { // the shift down button was pushed
 				$sql = "SELECT seqnum FROM ".DBRptFields." WHERE reportid = ".$ReportID." AND entrytype = '".$EntryType."';";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				if ($SeqNum<DB_num_rows($Result)) $success = ChangeSequence($_POST['SeqNum'], $EntryType, 'down');
 			} elseif (isset($_POST['ed_x'])) { // the sequence edit button was pushed
 				$OverrideDefaults = true;
 				// pre fill form with the field to edit and change button name
 				$sql = "SELECT * FROM ".DBRptFields."
 					WHERE reportid = ".$ReportID." AND entrytype = '".$EntryType."' AND seqnum=".$SeqNum.";";
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$NewDefaults['defaults'] = DB_fetch_array($Result);
 				$NewDefaults['defaults']['buttonvalue'] = RPT_BTN_CHANGE;
 			} elseif (isset($_POST['rm_x'])) { // the sequence remove button was pushed

--- a/reportwriter/includes/WriteForm.php
+++ b/reportwriter/includes/WriteForm.php
@@ -297,7 +297,7 @@ function BuildPDF($ReportID, $Prefs) {
 	$sql = "SELECT seqnum, params FROM ".DBRptFields."
 		WHERE reportid=".$ReportID." AND entrytype='fieldlist' AND visible=1
 		ORDER BY seqnum";
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	while ($FieldValues = DB_fetch_assoc($Result)) {
 		$FieldValues['params'] = unserialize($FieldValues['params']);
 		$FieldListings[] = $FieldValues;
@@ -459,7 +459,7 @@ function BuildPDF($ReportID, $Prefs) {
 	if ($sqlCrit) $sql .=' WHERE '.$sqlCrit;
 	$sql .=" GROUP BY ".$PageBreakField;
 	// execute sql to see if we have data
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	if (DB_num_rows($Result)==0) {
 		$usrMsg['message'] = RPT_NOROWS;
 		$usrMsg['level'] = 'error';
@@ -484,7 +484,7 @@ function BuildPDF($ReportID, $Prefs) {
 	if ($strTxtBlk<>'') { // then we have data, fill in TextField value with data
 		$strTxtBlk = mb_substr($strTxtBlk,0,-2);
 		$sql = "SELECT ".$strTxtBlk." FROM ".CompanyDataBase." LIMIT 1;";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		$CoyData = DB_fetch_row($Result);
 		$i=0;
 		foreach ($FieldListings as $key=>$SingleObject) {
@@ -506,7 +506,7 @@ function BuildPDF($ReportID, $Prefs) {
 			foreach ($SingleObject['params']['Seq'] as $OneField) $strTxtBlk .= $OneField['TblField'].', ';
 			$strTxtBlk = mb_substr($strTxtBlk,0,-2);
 			$sql = "SELECT ".$strTxtBlk." FROM ".CompanyDataBase." LIMIT 1;";
-			$Result=DB_query($sql,'','',false,true);
+			$Result = DB_query($sql,'','',false,true);
 			$TxtBlkValues = DB_fetch_row($Result);
 			$TextField = '';
 			foreach($TxtBlkValues as $t=>$Temp) $TextField .= $Temp.AddSep($SingleObject['params']['Seq'][$t]['Processing']);
@@ -520,7 +520,7 @@ function BuildPDF($ReportID, $Prefs) {
 		if ($sqlCrit) $TrailingSQL=" FROM ".$sqlTable." WHERE ".$sqlCrit." AND ".$PageBreakField."='".$Fvalue."'";
 			else $TrailingSQL =" FROM ".$sqlTable." WHERE ".$PageBreakField."='".$Fvalue."'";
 		$sql = "SELECT " . $strField . $TrailingSQL;
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		$FieldValues = DB_fetch_row($Result);
 		// Build the text block strings
 		foreach ($FieldListings as $key=>$SingleObject) {
@@ -534,7 +534,7 @@ function BuildPDF($ReportID, $Prefs) {
 				foreach ($SingleObject['params']['Seq'] as $OneField) $strTxtBlk .= $OneField['TblField'].', ';
 				$strTxtBlk = mb_substr($strTxtBlk,0,-2);
 				$sql = "SELECT ".$strTxtBlk.$TrailingSQL;
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$TxtBlkValues = DB_fetch_row($Result);
 				$TextField = '';
 				foreach($TxtBlkValues as $t=>$Temp) $TextField .= $Temp.AddSep($SingleObject['params']['Seq'][$t]['Processing']);
@@ -566,7 +566,7 @@ function BuildPDF($ReportID, $Prefs) {
 				$tblField = mb_substr($tblField,0,-2); // remove the last two chars (comma and space)
 				$SingleObject['params']['Data'] = [$tblHeading]; // set the first data element to the headings
 				$sql = "SELECT ".$tblField.$TrailingSQL;
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				while ($Temp = DB_fetch_assoc($Result)){
                     $SingleObject['params']['Data'][] = $Temp;
                 }
@@ -584,7 +584,7 @@ function BuildPDF($ReportID, $Prefs) {
 				$ttlField = '';
 				foreach ($SingleObject['params']['Seq'] as $Temp) $ttlField .= $Temp.'+';
 				$sql = "SELECT SUM(".mb_substr($ttlField,0,-1).")".$TrailingSQL;
-				$Result=DB_query($sql,'','',false,true);
+				$Result = DB_query($sql,'','',false,true);
 				$Temp = DB_fetch_row($Result);
 				$FieldListings[$key]['params']['TextField'] = $Temp[0];
 			}

--- a/reportwriter/includes/WriteReport.php
+++ b/reportwriter/includes/WriteReport.php
@@ -584,7 +584,7 @@ function BuildSQL($Prefs) {
 function BuildDataArray($ReportID, $sql, $Prefs) {
 	global $Heading, $Seq;
 	// first see if we have data
-	$Result=DB_query($sql,'','',false,true);
+	$Result = DB_query($sql,'','',false,true);
 	if (DB_num_rows($Result)==0) return false; // No data so bail now
 
 	// See if we need to group, fetch the group fieldname

--- a/reportwriter/install/ReportListForm.php
+++ b/reportwriter/install/ReportListForm.php
@@ -20,7 +20,7 @@ function GetReports($GroupID) {
 		$sql= "SELECT id, reportname FROM reports
 			WHERE defaultreport='".$Def."' AND groupname='".$GroupID."'
 			ORDER BY reportname";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		if (DB_num_rows($Result)>0) {
 			$RptForm .= '<tr><td><select name="ReportID" size="10" onchange="submit()">';
 			while ($Temp = DB_fetch_array($Result)) {

--- a/reportwriter/install/ReportListLinks.php
+++ b/reportwriter/install/ReportListLinks.php
@@ -18,7 +18,7 @@ function GetRptLinks($GroupID) {
 		$sql= "SELECT id, reportname FROM reports
 			WHERE defaultreport='".$Def."' AND groupname='".$GroupID."'
 			ORDER BY reportname";
-		$Result=DB_query($sql,'','',false,true);
+		$Result = DB_query($sql,'','',false,true);
 		if (DB_num_rows($Result)>0) {
 			while ($Temp = DB_fetch_array($Result)) {
 				$RptLinks .= '<tr><td class="menu_group_item">';


### PR DESCRIPTION
As mentioned in comment https://github.com/timschofield/webERP/commit/9decfebdf9a62388f71117341e370287b19750ff#commitcomment-163569726

Side notes:

* this should reduce the size of the translation files quite a bit, once we get around to updating them
* this kind of refactoring exercise really makes me question the choice of not having a database-abstraction layer which would deduplicate the huge number of queries found in almost every php file