### PR TITLE
Clean up of $Debug instances, and repeated code about managing error codes from DB. 

### DIFF
--- a/AgedDebtors.php
+++ b/AgedDebtors.php
@@ -242,20 +242,8 @@ if(isset($_POST['PrintPDF']) or isset($_POST['View'])
 				holdreasons.reasondescription
 				HAVING ABS(SUM(debtortrans.balance)) >0.005";
 	}
-	$CustomerResult = DB_query($SQL,'','',False,False); /*dont trap errors handled below*/
-
-	if(DB_error_no() !=0) {
-		$Title = _('Aged Customer Account Analysis') . ' - ' . _('Problem Report') . '.... ';
-		include('includes/header.php');
-		prnMsg(_('The customer details could not be retrieved by the SQL because') . ' ' . DB_error_msg(),'error');
-		echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if($Debug==1) {
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
-
+	$ErrMsg = _('The customer details could not be retrieved');
+	$CustomerResult = DB_query($SQL, $ErrMsg , '', false);
 
 	$HTML = '';
 
@@ -374,18 +362,8 @@ if(isset($_POST['PrintPDF']) or isset($_POST['View'])
 				$SQL .= " AND debtortrans.salesperson='" . $_SESSION['SalesmanLogin'] . "'";
 			}
 
-			$DetailResult = DB_query($SQL,'','',False,False); /*Dont trap errors */
-			if(DB_error_no() !=0) {
-				$Title = _('Aged Customer Account Analysis') . ' - ' . _('Problem Report') . '....';
-				include('includes/header.php');
-				prnMsg(_('The details of outstanding transactions for customer') . ' - ' . $AgedAnalysis['debtorno'] . ' ' . _('could not be retrieved because') . ' - ' . DB_error_msg(),'error');
-				echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-				if($Debug==1) {
-					echo '<br />' . _('The SQL that failed was') . '<br />' . $SQL;
-				}
-				include('includes/footer.php');
-				exit();
-			}
+			$ErrMsg = _('The details of outstanding transactions for customer') . ' - ' . $AgedAnalysis['debtorno'] . ' ' . _('could not be retrieved');
+			$DetailResult = DB_query($SQL, $ErrMsg, '', false);
 
 			$HTML .= '<tr>
 						<td colspan="6">

--- a/BOMExtendedQty.php
+++ b/BOMExtendedQty.php
@@ -141,18 +141,6 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 
 	} // End of while $ComponentCounter > 0
 
-	if (DB_error_no() !=0) {
-		$Title = _('Quantity Extended BOM Listing') . ' - ' . _('Problem Report');
-		include('includes/header.php');
-		prnMsg( _('The Quantiy Extended BOM Listing could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
-
 	$Tot_Val=0;
 	$SQL = "SELECT tempbom.component,
 				   SUM(tempbom.quantity) as quantity,

--- a/BOMIndented.php
+++ b/BOMIndented.php
@@ -142,19 +142,6 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 		} // End of while $ComponentCounter > 0
 	} // End of if $_POST['Levels']
 
-	if (DB_error_no() !=0) {
-	  $Title = _('Indented BOM Listing') . ' - ' . _('Problem Report');
-	  include('includes/header.php');
-	   prnMsg( _('The Indented BOM Listing could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-	   echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   if ($Debug==1){
-		  echo '<br />' . $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
-	}
-
-
 	$SQL = "SELECT stockmaster.stockid,
 				   stockmaster.description
 			  FROM stockmaster

--- a/BOMIndentedReverse.php
+++ b/BOMIndentedReverse.php
@@ -128,20 +128,6 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 
 	} // End of while $ComponentCounter > 0
 
-	if (DB_error_no() !=0) {
-	  $Title = _('Indented BOM Listing') . ' - ' . _('Problem Report');
-	  include('includes/header.php');
-	   prnMsg( _('The Indented BOM Listing could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-	   echo '<br />
-			<a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   if ($Debug==1){
-		  echo '<br />' . $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
-	}
-
-
 	$SQL = "SELECT stockmaster.stockid,
 				   stockmaster.description
 			  FROM stockmaster

--- a/BOMListing.php
+++ b/BOMListing.php
@@ -26,19 +26,9 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 			ORDER BY bom.parent,
 					bom.component";
 
-	$BOMResult = DB_query($SQL,'','',false,false); //dont do error trapping inside DB_query
+	$ErrMsg = ('The Bill of Material listing could not be retrieved');
+	$BOMResult = DB_query($SQL, $ErrMsg, '', false);
 
-	if (DB_error_no() !=0) {
-	   $Title = _('Bill of Materials Listing') . ' - ' . _('Problem Report');
-	   include('includes/header.php');
-	   prnMsg(_('The Bill of Material listing could not be retrieved by the SQL because'),'error');
-	   echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   if ($Debug==1){
-		  echo '<br />' . $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
-	}
 	if (DB_num_rows($BOMResult)==0){
 	   $Title = _('Bill of Materials Listing') . ' - ' . _('Problem Report');
 	   include('includes/header.php');

--- a/ConfirmDispatch_Invoice.php
+++ b/ConfirmDispatch_Invoice.php
@@ -721,12 +721,6 @@ if (isset($_POST['ProcessInvoice']) and $_POST['ProcessInvoice'] != '') {
 
 		/*there should be the same number of items returned from this query as there are lines on the invoice - if not 	then someone has already invoiced or credited some lines */
 
-		if ($Debug == 1) {
-			echo '<br />' . $SQL;
-			echo '<br />' . _('Number of rows returned by SQL') . ':' . DB_num_rows($Result);
-			echo '<br />' . _('Count of items in the session') . ' ' . count($_SESSION['Items' . $identifier]->LineItems);
-		}
-
 		echo '<br />';
 		prnMsg(_('This order has been changed or invoiced since this delivery was started to be confirmed') . '. ' . _('Processing halted') . '. ' . _('To enter and confirm this dispatch') . '/' . _('invoice the order must be re-selected and re-read again to update the changes made by the other user'), 'error');
 

--- a/ContractBOM.php
+++ b/ContractBOM.php
@@ -142,7 +142,7 @@ if (isset($_POST['Search'])){  /*ie seach for stock items */
 	$ErrMsg = _('There is a problem selecting the part records to display because');
 	$SearchResult = DB_query($SQL, $ErrMsg);
 
-	if (DB_num_rows($SearchResult)==0 AND $Debug==1){
+	if (DB_num_rows($SearchResult)==0){
 		prnMsg( _('There are no products to display matching the criteria provided'),'warn');
 	}
 	if (DB_num_rows($SearchResult)==1){
@@ -203,9 +203,6 @@ if (isset($_POST['NewItem'])){ /* NewItem is set from the part selection list as
 																			$MyRow['decimalplaces']);
 				} else {
 					prnMsg (_('The item code') . ' ' . trim($_POST['StockID'.$i]) . ' ' . _('does not exist in the database and therefore cannot be added to the contract BOM'),'error');
-					if ($Debug==1){
-						echo '<br />' . $SQL;
-					}
 					include('includes/footer.php');
 					exit();
 				}

--- a/Contracts.php
+++ b/Contracts.php
@@ -719,9 +719,6 @@ if (isset($_POST['SelectedCustomer'])) {
 	$MyRow = DB_fetch_array($Result);
 	if (DB_num_rows($Result)==0){
 		prnMsg(_('The customer details were unable to be retrieved'),'error');
-		if ($Debug==1){
-			prnMsg(_('The SQL used that failed to get the customer details was:') . '<br />' . $SQL,'error');
-		}
 	} else {
 		$_SESSION['Contract'.$identifier]->BranchName = $MyRow['brname'];
 		$_SESSION['RequireCustomerSelection'] = 0;

--- a/CounterReturns.php
+++ b/CounterReturns.php
@@ -150,9 +150,6 @@ if (!isset($_SESSION['Items' . $identifier])) {
 
 			prnMsg(_('The branch details for branch code') . ': ' . $_SESSION['Items' . $identifier]->Branch . ' ' . _('against customer code') . ': ' . $_SESSION['Items' . $identifier]->DebtorNo . ' ' . _('could not be retrieved') . '. ' . _('Check the set up of the customer and branch'),'error');
 
-			if ($Debug==1) {
-				echo '<br />' . _('The SQL that failed to get the branch details was') . ':<br />' . $SQL;
-			}
 			include('includes/footer.php');
 			exit();
 		}

--- a/CounterSales.php
+++ b/CounterSales.php
@@ -161,9 +161,6 @@ if (!isset($_SESSION['Items'.$identifier])) {
 
 				prnMsg(_('The branch details for branch code') . ': ' . $_SESSION['Items'.$identifier]->Branch . ' ' . _('against customer code') . ': ' . $_SESSION['Items'.$identifier]->DebtorNo . ' ' . _('could not be retrieved') . '. ' . _('Check the set up of the customer and branch'),'error');
 
-				if ($Debug==1) {
-					echo '<br />' . _('The SQL that failed to get the branch details was') . ':<br />' . $SQL;
-				}
 				include('includes/footer.php');
 				exit();
 			}

--- a/CustomerReceipt.php
+++ b/CustomerReceipt.php
@@ -643,14 +643,10 @@ if (isset($_POST['Search'])){
 						WHERE 	custbranch.debtorno = debtorsmaster.debtorno
 							AND custbranch.salesman='" . $_SESSION['SalesmanLogin'] . "')";
 		}
-
-		$CustomerSearchResult = DB_query($SQL,'','',false,false);
-		if (DB_error_no() !=0) {
-			prnMsg(_('The searched customer records requested cannot be retrieved because') . ' - ' . DB_error_msg(),'error');
-			if ($Debug==1){
-				prnMsg(_('SQL used to retrieve the customer details was') . '<br />' . $SQL,'error');
-			}
-		} elseif (DB_num_rows($CustomerSearchResult)==1){
+		$ErrMsg = _('The searched customer records requested cannot be retrieved');
+		$CustomerSearchResult = DB_query($SQL, $ErrMsg, '', false);
+		
+		if (DB_num_rows($CustomerSearchResult)==1){
 			$MyRow=DB_fetch_array($CustomerSearchResult);
 			$Select = $MyRow['debtorno'];
 			unset($CustomerSearchResult);

--- a/DebtorsAtPeriodEnd.php
+++ b/DebtorsAtPeriodEnd.php
@@ -35,19 +35,8 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				currencies.currency,
 				currencies.decimalplaces";
 
-	$CustomerResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Customer Balances') . ' - ' . _('Problem Report');
-		include('includes/header.php');
-		prnMsg(_('The customer details could not be retrieved by the SQL because') . DB_error_msg(),'error');
-		echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = ('The customer details could not be retrieved');
+	$CustomerResult = DB_query($SQL, $ErrMsg, '', false);
 
 	if (DB_num_rows($CustomerResult) == 0) {
 		$Title = _('Customer Balances') . ' - ' . _('Problem Report');

--- a/DeliveryDetails.php
+++ b/DeliveryDetails.php
@@ -168,9 +168,6 @@ if(isset($_POST['Update'])
 
 			prnMsg(_('The branch details for branch code') . ': ' . $_SESSION['Items'.$identifier]->Branch . ' ' . _('against customer code') . ': ' . $_POST['Select'] . ' ' . _('could not be retrieved') . '. ' . _('Check the set up of the customer and branch'),'error');
 
-			if($Debug==1) {
-				echo '<br />' . _('The SQL that failed to get the branch details was') . ':<br />' . $SQL;
-			}
 			include('includes/footer.php');
 			exit();
 		}

--- a/GoodsReceived.php
+++ b/GoodsReceived.php
@@ -367,45 +367,6 @@ if ($_SESSION['PO'.$identifier]->SomethingReceived()==0 AND isset($_POST['Proces
 
 			prnMsg(_('This order has been changed or invoiced since this delivery was started to be actioned') . '. ' . _('Processing halted') . '. ' . _('To enter a delivery against this purchase order') . ', ' . _('it must be re-selected and re-read again to update the changes made by the other user'),'warn');
 
-			if ($Debug==1) {
-				echo '<table class="selection">
-					<tr>
-						<td>' . _('GL Code of the Line Item') . ':</td>
-						<td>' . $_SESSION['PO'.$identifier]->LineItems[$LineNo]->GLCode . '</td>
-						<td>' . $MyRow['glcode'] . '</td>
-					</tr>
-					<tr>
-						<td>' . _('ShiptRef of the Line Item') . ':</td>
-						<td>' . $_SESSION['PO'.$identifier]->LineItems[$LineNo]->ShiptRef . '</td>
-						<td>' . $MyRow['shiptref'] . '</td>
-					</tr>
-					<tr>
-						<td>' . _('Contract Reference of the Line Item') . ':</td>
-						<td>' . $_SESSION['PO'.$identifier]->LineItems[$LineNo]->JobRef . '</td>
-						<td>' . $MyRow['jobref'] . '</td>
-					</tr>
-					<tr>
-						<td>' . _('Quantity Invoiced of the Line Item') . ':</td>
-						<td>' . locale_number_format($_SESSION['PO'.$identifier]->LineItems[$LineNo]->QtyInv,$_SESSION['PO'.$identifier]->LineItems[$LineNo]->DecimalPlaces) . '</td>
-						<td>' . $MyRow['qtyinvoiced'] . '</td>
-					</tr>
-					<tr>
-						<td>' . _('Stock Code of the Line Item') . ':</td>
-						<td>' .  $_SESSION['PO'.$identifier]->LineItems[$LineNo]->StockID . '</td>
-						<td>' . $MyRow['itemcode'] . '</td>
-					</tr>
-					<tr>
-						<td>' . _('Order Quantity of the Line Item') . ':</td>
-						<td>' . locale_number_format($_SESSION['PO'.$identifier]->LineItems[$LineNo]->Quantity,$_SESSION['PO'.$identifier]->LineItems[$LineNo]->DecimalPlaces) . '</td>
-						<td>' . $MyRow['quantityord'] . '</td>
-					</tr>
-					<tr>
-						<td>' . _('Quantity of the Line Item Already Received') . ':</td>
-						<td>' . locale_number_format($_SESSION['PO'.$identifier]->LineItems[$LineNo]->QtyReceived,$_SESSION['PO'.$identifier]->LineItems[$LineNo]->DecimalPlaces) . '</td>
-						<td>' . locale_number_format($MyRow['quantityrecd'],$_SESSION['PO'.$identifier]->LineItems[$LineNo]->DecimalPlaces) . '</td>
-					</tr>
-					</table>';
-			}
 			echo '<div class="centre"><a href="' . $RootPath . '/PO_SelectOSPurchOrder.php">' .
 				_('Select a different purchase order for receiving goods against') . '</a></div>';
 			echo '<div class="centre"><a href="' . $RootPath . '/GoodsReceived.php?PONumber=' . $_SESSION['PO'.$identifier]->OrderNo . '">' .  _('Re-read the updated purchase order for receiving goods against'). '</a></div>';

--- a/InventoryPlanning.php
+++ b/InventoryPlanning.php
@@ -56,19 +56,8 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])){
 					stockmaster.stockid";
 
 	}
-	$InventoryResult = DB_query($SQL, '', '', false, false);
-
-	if (DB_error_no() !=0) {
-	  $Title = _('Inventory Planning') . ' - ' . _('Problem Report') . '....';
-	  include('includes/header.php');
-	   prnMsg(_('The inventory quantities could not be retrieved by the SQL because') . ' - ' . DB_error_msg(),'error');
-	   echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   if ($Debug==1){
-	      echo '<br />' . $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
-	}
+	$ErrMsg = _('The inventory quantities could not be retrieved');
+	$InventoryResult = DB_query($SQL, $ErrMsg, '', false);
 
 	$HTML = '';
 
@@ -167,21 +156,8 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])){
 					AND stockmoves.hidemovt=0";
 		}
 
-		$SalesResult = DB_query($SQL,'','', false, false);
-
-		if (DB_error_no() !=0) {
-	 		 $Title = _('Inventory Planning') . ' - ' . _('Problem Report') . '....';
-	  		include('includes/header.php');
-	   		prnMsg( _('The sales quantities could not be retrieved by the SQL because') . ' - ' . DB_error_msg(),'error');
-	   		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   		if ($Debug==1){
-	      		echo '<br />' .$SQL;
-	   		}
-
-	   		include('includes/footer.php');
-	   		exit();
-		}
-
+		$ErrMsg = _('The sales quantities could not be retrieved');
+		$SalesResult = DB_query($SQL, $ErrMsg, '', false);
 		$ListCount = DB_num_rows($SalesResult);
 		$SalesRow = DB_fetch_array($SalesResult);
 

--- a/InventoryPlanningPrefSupplier.php
+++ b/InventoryPlanningPrefSupplier.php
@@ -175,20 +175,9 @@ if (isset($_POST['PrintPDF'])){
 				ORDER BY purchdata.supplierno,
 				stockmaster.stockid";
 	}
-	$InventoryResult = DB_query($SQL, '', '', false, false);
+	$ErrMsg = _('The inventory quantities could not be retrieved');
+	$InventoryResult = DB_query($SQL, $ErrMsg, '', false);
 	$ListCount = DB_num_rows($InventoryResult);
-
-	if (DB_error_no() !=0) {
-	  $Title = _('Inventory Planning') . ' - ' . _('Problem Report') . '....';
-	  include('includes/header.php');
-	   prnMsg(_('The inventory quantities could not be retrieved by the SQL because') . ' - ' . DB_error_msg(),'error');
-	   echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   if ($Debug==1){
-	      echo '<br />' . $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
-	}
 
 	NewPageHeader();
 
@@ -234,19 +223,8 @@ if (isset($_POST['PrintPDF'])){
    		   $SQL .= "	AND stockmoves.loccode ='" . $_POST['Location'] . "'";
 		}
 
-		$SalesResult = DB_query($SQL,'','',FALSE,FALSE);
-
-		if (DB_error_no() !=0) {
-	 		 $Title = _('Inventory Planning') . ' - ' . _('Problem Report') . '....';
-	  		include('includes/header.php');
-	   		prnMsg( _('The sales quantities could not be retrieved by the SQL because') . ' - ' . DB_error_msg(),'error');
-	   		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   		if ($Debug==1){
-	      			echo '<br />' .  $SQL;
-	   		}
-	   		include('includes/footer.php');
-	   		exit();
-		}
+		$ErrMsg = _('The sales quantities could not be retrieved');
+		$SalesResult = DB_query($SQL, $ErrMsg, '', false);
 
 		$SalesRow = DB_fetch_array($SalesResult);
 

--- a/InventoryQuantities.php
+++ b/InventoryQuantities.php
@@ -99,20 +99,9 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 						locstock.loccode";
 	}
 
+	$ErrMsg = _('The Inventory Quantity report could not be retrieved');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
 
-	$Result = DB_query($SQL,'','',false,true);
-
-	if (DB_error_no() !=0) {
-	  $Title = _('Inventory Quantities') . ' - ' . _('Problem Report');
-	  include('includes/header.php');
-	   prnMsg( _('The Inventory Quantity report could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-	   echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   if ($Debug==1){
-		  echo '<br />' . $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
-	}
 	if (DB_num_rows($Result)==0){
 			$Title = _('Print Inventory Quantities Report');
 			include('includes/header.php');

--- a/InventoryValuation.php
+++ b/InventoryValuation.php
@@ -57,19 +57,8 @@ if (isset($_POST['PrintPDF']) or isset($_POST['Spreadsheet']) or isset($_POST['V
 				ORDER BY stockcategory.categorydescription,
 					stockmaster.stockid";
 	}
-	$InventoryResult = DB_query($SQL,'','',false,true);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Inventory Valuation') . ' - ' . _('Problem Report');
-		include('includes/header.php');
-		prnMsg( _('The inventory valuation could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg =  _('The inventory valuation could not be retrieved');
+	$InventoryResult = DB_query($SQL, $ErrMsg, '', false);
 
 	if (DB_num_rows($InventoryResult)==0){
 		$Title = _('Print Inventory Valuation Error');

--- a/MRPPlannedPurchaseOrders.php
+++ b/MRPPlannedPurchaseOrders.php
@@ -88,19 +88,8 @@ if ( isset($_POST['PrintPDF']) OR isset($_POST['Review']) ) {
 					computedcost
 				ORDER BY mrpplannedorders.part,yearmonth";
 	}
-	$Result = DB_query($SQL,'','',false,true);
-
-	if (DB_error_no() !=0) {
-		$Title = _('MRP Planned Purchase Orders') . ' - ' . _('Problem Report');
-		include('includes/header.php');
-		prnMsg( _('The MRP planned purchase orders could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The MRP planned purchase orders could not be retrieved');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
 
 	if (DB_num_rows($Result)==0){ //then there is nothing to print
 		$Title = _('Print MRP Planned Purchase Orders');

--- a/MRPPlannedWorkOrders.php
+++ b/MRPPlannedWorkOrders.php
@@ -88,19 +88,8 @@ if ( isset($_POST['PrintPDF']) OR isset($_POST['Review']) ) {
 						 computedcost
 				ORDER BY mrpplannedorders.part,yearmonth";
 	}
-	$Result = DB_query($SQL, '', '', false, true);
-
-	if (DB_error_no() !=0) {
-	  $Title = _('MRP Planned Work Orders') . ' - ' . _('Problem Report');
-	  include('includes/header.php');
-	   prnMsg( _('The MRP planned work orders could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-	   echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   if ($Debug==1){
-		  echo '<br />' . $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
-	}
+	$ErrMsg = _('The MRP planned work orders could not be retrieved');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
 
 	if (DB_num_rows($Result)==0){ //then there is nothing to print
 		$Title = _('MRP Planned Work Orders');

--- a/MRPReport.php
+++ b/MRPReport.php
@@ -27,22 +27,16 @@ if (isset($_POST['PrintPDF']) AND $_POST['Part']!='') {
 			WHERE part = '" . $_POST['Part'] ."'
 			ORDER BY daterequired,whererequired";
 
-	$Result = DB_query($SQL, '', '', false, false);
+	$ErrMsg = _('The MRP calculation must be run before this report will have any output. MRP requires set up of many parameters, including, EOQ, lead times, minimums, bills of materials, demand types, master schedule etc');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
 	if (DB_error_no() !=0) {
 		$Errors = 1;
-		$Title = _('Print MRP Report Error');
-		include('includes/header.php');
-		prnMsg(_('The MRP calculation must be run before this report will have any output. MRP requires set up of many parameters, including, EOQ, lead times, minimums, bills of materials, demand types, master schedule etc'),'error');
-		echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		include('includes/footer.php');
-		exit();
 	}
 
 	if (DB_num_rows($Result) == 0) {
 		$Errors = 1;
 		$Title = _('Print MRP Report Warning');
 		include('includes/header.php');
-		prnMsg(_('The MRP calculation must be run before this report will have any output. MRP requires set up of many parameters, including, EOQ, lead times, minimums, bills of materials, demand types, master schedule, etc'), 'warn');
 		echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
 		include('includes/footer.php');
 		exit();
@@ -109,7 +103,7 @@ if (isset($_POST['PrintPDF']) AND $_POST['Part']!='') {
 				   TRUNCATE(((TO_DAYS(duedate) - TO_DAYS(CURRENT_DATE)) / 7),0) AS weekindex,
 				   TO_DAYS(duedate) - TO_DAYS(CURRENT_DATE) AS datediff
 				FROM mrpplannedorders WHERE part = '" . $_POST['Part'] . "' ORDER BY mrpdate";
-	$Result = DB_query($SQL,'','',false,true);
+	$Result = DB_query($SQL,'','',false);
 	if (DB_error_no() !=0) {
 		$Errors = 1;
 	}
@@ -140,11 +134,8 @@ if (isset($_POST['PrintPDF']) AND $_POST['Part']!='') {
 	if (isset($Errors)) {
 		$Title = _('MRP Report') . ' - ' . _('Problem Report');
 		include('includes/header.php');
-		prnMsg( _('The MRP Report could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
+		prnMsg( _('The MRP Report could not be retrieved'), 'error');
 		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' . $SQL;
-		}
 		include('includes/footer.php');
 		exit();
 	}
@@ -168,7 +159,7 @@ if (isset($_POST['PrintPDF']) AND $_POST['Part']!='') {
 			LEFT JOIN stockmaster
 			ON levels.part = stockmaster.stockid
 			WHERE part = '" . $_POST['Part'] . "'";
-	$Result = DB_query($SQL,'','',false,true);
+	$Result = DB_query($SQL,'','',false);
 	$MyRow=DB_fetch_array($Result);
 	$pdf->addTextWrap($Left_Margin,$YPos,35,$FontSize,_('Part:'),'');
 	$pdf->addTextWrap(70,$YPos,100,$FontSize,$MyRow['part'],'');

--- a/MRPReschedules.php
+++ b/MRPReschedules.php
@@ -25,39 +25,26 @@ if (isset($_POST['PrintPDF'])) {
 /*Find mrpsupplies records where the duedate is not the same as the mrpdate */
 	$SelectType = " ";
 	if ($_POST['Selection'] != 'All') {
-		 $SelectType = " AND ordertype = '" . $_POST['Selection'] . "'";
+		$SelectType = " AND ordertype = '" . $_POST['Selection'] . "'";
 	 }
 	$SQL = "SELECT mrpsupplies.*,
 				   stockmaster.description,
 				   stockmaster.decimalplaces
-			  FROM mrpsupplies,stockmaster
-			  WHERE mrpsupplies.part = stockmaster.stockid AND duedate <> mrpdate
-				 $SelectType
-			  ORDER BY mrpsupplies.part";
-	$Result = DB_query($SQL,'','',false,true);
+			FROM mrpsupplies,stockmaster
+			WHERE mrpsupplies.part = stockmaster.stockid AND duedate <> mrpdate
+				$SelectType
+			ORDER BY mrpsupplies.part";
 
-	if (DB_error_no() !=0) {
-	  $Title = _('MRP Reschedules') . ' - ' . _('Problem Report');
-	  include('includes/header.php');
-	   prnMsg( _('The MRP reschedules could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-	   echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   if ($Debug==1){
-		  echo '<br />' . $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
-	}
+	$ErrMsg = _('The MRP reschedules could not be retrieved');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
 
 	if (DB_num_rows($Result) == 0) {
-	  $Title = _('MRP Reschedules') . ' - ' . _('Problem Report');
-	  include('includes/header.php');
-	   prnMsg( _('No MRP reschedule retrieved'), 'warn');
-	   echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-	   if ($Debug==1){
-		echo '<br />' . $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
+		$Title = _('MRP Reschedules') . ' - ' . _('Problem Report');
+		include('includes/header.php');
+		prnMsg( _('No MRP reschedule retrieved'), 'warn');
+		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
+		include('includes/footer.php');
+		exit();
 	}
 
 	PrintHeader($pdf,$YPos,$PageNumber,$Page_Height,$Top_Margin,$Left_Margin,$Page_Width,

--- a/MRPShortages.php
+++ b/MRPShortages.php
@@ -130,28 +130,15 @@ if (isset($_POST['PrintPDF'])) {
 			   stockmaster.actualcost,
 			   supplytotal.supply,
 			   demandtotal.demand " . $SQLHaving . " ORDER BY '" . $_POST['Sort'] . "'";
-	$Result = DB_query($SQL, '', '', false, true);
 
-	if (DB_error_no() != 0) {
-		$Title = _('MRP Shortages and Excesses') . ' - ' . _('Problem Report');
-		include('includes/header.php');
-		prnMsg(_('The MRP shortages and excesses could not be retrieved by the SQL because') . ' ' . DB_error_msg(), 'error');
-		echo '<br/><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug == 1) {
-			echo '<br/>' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The MRP shortages and excesses could not be retrieved');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
 
 	if (DB_num_rows($Result) == 0) {
 		$Title = _('MRP Shortages and Excesses') . ' - ' . _('Problem Report');
 		include('includes/header.php');
 		prnMsg(_('No MRP shortages - Excess retrieved'), 'warn');
 		echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug == 1) {
-			echo '<br />' . $SQL;
-		}
 		include('includes/footer.php');
 		exit();
 	}

--- a/MailInventoryValuation.php
+++ b/MailInventoryValuation.php
@@ -47,21 +47,8 @@ $SQL = "SELECT stockmaster.categoryid,
 			ORDER BY stockmaster.categoryid,
 				stockmaster.stockid";
 
-$InventoryResult = DB_query($SQL, '', '', false, true);
-$ListCount = DB_num_rows($InventoryResult);
-
-if (DB_error_no() != 0) {
-	$Title = _('Inventory Valuation') . ' - ' . _('Problem Report');
-	include('includes/header.php');
-	echo _('The inventory valuation could not be retrieved by the SQL because') . ' - ' . DB_error_msg();
-	echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-	if ($Debug == 1) {
-		echo '<br />' . $SQL;
-	}
-
-	include('includes/footer.php');
-	exit();
-}
+$ErrMsg = _('The inventory valuation could not be retrieved');
+$InventoryResult = DB_query($SQL, $ErrMsg, '', false);
 
 $HTML = '';
 

--- a/PDFBankingSummary.php
+++ b/PDFBankingSummary.php
@@ -57,17 +57,9 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 		WHERE debtortrans.transno='" . $_POST['BatchNo'] . "'
 		AND debtortrans.type=12";
 
-	$CustRecs = DB_query($SQL, '', '', false, false);
-	if (DB_error_no()!=0) {
-		$Title = _('Create PDF Print-out For A Batch Of Receipts');
-		include('includes/header.php');
-	   	prnMsg(_('An error occurred getting the customer receipts for batch number') . ' ' . $_POST['BatchNo'],'error');
-		if ($Debug==1){
-	        	prnMsg(_('The SQL used to get the customer receipt information that failed was') . '<br />' . $SQL,'error');
-	  	}
-		include('includes/footer.php');
-	  	exit();
-	}
+	$ErrMsg = _('An error occurred getting the customer receipts for batch number') . ' ' . $_POST['BatchNo'];
+	$CustRecs = DB_query($SQL, $ErrMsg, '', false);
+	
 	$SQL = "SELECT narrative,
 			amount
 		FROM gltrans
@@ -76,17 +68,8 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 		AND gltrans.account !='" . $MyRow['bankact'] . "'
 		AND gltrans.account !='" . $_SESSION['CompanyRecord']['debtorsact'] . "'";
 
-	$GLRecs = DB_query($SQL, '', '', false, false);
-	if (DB_error_no() != 0){
-		$Title = _('Create PDF Print-out For A Batch Of Receipts');
-		include('includes/header.php');
-		prnMsg(_('An error occurred getting the GL receipts for batch number') . ' ' . $_POST['BatchNo'],'error');
-		if ($Debug==1){
-			prnMsg(_('The SQL used to get the GL receipt information that failed was') . ':<br />' . $SQL,'error');
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('An error occurred getting the GL receipts for batch number') . ' ' . $_POST['BatchNo'];
+	$GLRecs = DB_query($SQL, $ErrMsg, '', false);
 
 	$HTML = '';
 

--- a/PDFChequeListing.php
+++ b/PDFChequeListing.php
@@ -45,17 +45,10 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				AND transdate >='" . FormatDateForSQL($_POST['FromDate']) . "'
 				AND transdate <='" . FormatDateForSQL($_POST['ToDate']) . "'";
 
-	$Result = DB_query($SQL,'','',false,false);
-	if (DB_error_no()!=0){
-		$Title = _('Payment Listing');
-		include('includes/header.php');
-		prnMsg(_('An error occurred getting the payments'),'error');
-		if ($Debug==1){
-			prnMsg(_('The SQL used to get the receipt header information that failed was') . ':<br />' . $SQL,'error');
-		}
-		include('includes/footer.php');
-		exit();
-	} elseif (DB_num_rows($Result) == 0){
+	$ErrMsg = _('An error occurred getting the payments');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
+	
+	if (DB_num_rows($Result) == 0){
 		$Title = _('Payment Listing');
 		include('includes/header.php');
 		prnMsg (_('There were no bank transactions found in the database within the period from') . ' ' . $_POST['FromDate'] . ' ' . _('to') . ' ' . $_POST['ToDate'] . '. ' ._('Please try again selecting a different date range or account'), 'error');
@@ -106,25 +99,18 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				</tr>';
 
 		$SQL = "SELECT accountname,
-						accountcode,
-						amount,
-						narrative
-					FROM gltrans INNER JOIN chartmaster
+					accountcode,
+					amount,
+					narrative
+				FROM gltrans
+				INNER JOIN chartmaster
 					ON gltrans.account=chartmaster.accountcode
-					WHERE gltrans.typeno ='" . $MyRow['transno'] . "'
-						AND gltrans.type='" . $MyRow['type'] . "'";
+				WHERE gltrans.typeno ='" . $MyRow['transno'] . "'
+					AND gltrans.type='" . $MyRow['type'] . "'";
 
-		$GLTransResult = DB_query($SQL,'','',false,false);
-		if (DB_error_no()!=0){
-			$Title = _('Payment Listing');
-			include('includes/header.php');
-			prnMsg(_('An error occurred getting the GL transactions'),'error');
-			if ($Debug==1){
-				prnMsg( _('The SQL used to get the receipt header information that failed was') . ':<br />' . $SQL, 'error');
-			}
-			include('includes/footer.php');
-			exit();
-		}
+		$ErrMsg = _('An error occurred getting the GL transactions');
+		$GLTransResult = DB_query($SQL, $ErrMsg, '', false);
+
 		while ($GLRow=DB_fetch_array($GLTransResult)){
 			// if user is allowed to see the account we show it, other wise we show "OTHERS ACCOUNTS"
 			$CheckSql = "SELECT count(*)

--- a/PDFCustTransListing.php
+++ b/PDFCustTransListing.php
@@ -29,18 +29,10 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 			WHERE type='" . $_POST['TransType'] . "'
 			AND date_format(inputdate, '%Y-%m-%d')='".FormatDateForSQL($_POST['Date'])."'";
 
-	$Result = DB_query($SQL,'','',false,false);
+	$ErrMsg = _('An error occurred getting the transactions');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
 
-	if (DB_error_no()!=0){
-		$Title = _('Payment Listing');
-		include('includes/header.php');
-		prnMsg(_('An error occurred getting the transactions'),'error');
-		if ($Debug==1){
-			prnMsg(_('The SQL used to get the transaction information that failed was') . ':<br />' . $SQL,'error');
-		}
-		include('includes/footer.php');
-		exit();
-	} elseif (DB_num_rows($Result) == 0){
+	if (DB_num_rows($Result) == 0){
 		$Title = _('Payment Listing');
 		include('includes/header.php');
 		echo '<br />';

--- a/PDFCustomerList.php
+++ b/PDFCustomerList.php
@@ -222,19 +222,8 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 
 	} /* end if not all sales areas was selected */
 
-	$CustomersResult = DB_query($SQL);
-
-	if(DB_error_no() !=0) {
-	  $Title = _('Customer List') . ' - ' . _('Problem Report') . '....';
-	  include('includes/header.php');
-	   prnMsg( _('The customer List could not be retrieved by the SQL because') . ' - ' . DB_error_msg() );
-	   echo '<br /><a href="' .$RootPath .'/index.php">' .  _('Back to the menu'). '</a>';
-	   if($Debug==1) {
-	      echo '<br />' .  $SQL;
-	   }
-	   include('includes/footer.php');
-	   exit();
-	}
+	$ErrMsg = _('The customer List could not be retrieved');
+	$CustomersResult = DB_query($SQL, $ErrMsg);
 
 	if(DB_num_rows($CustomersResult) == 0) {
 	  $Title = _('Customer List') . ' - ' . _('Problem Report') . '....';

--- a/PDFDIFOT.php
+++ b/PDFDIFOT.php
@@ -108,23 +108,13 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 
 	}
 
-	$Result = DB_query($SQL, '', '', false, false); //dont error check - see below
-	if (DB_error_no() != 0) {
-		$Title = _('DIFOT Report Error');
-		include('includes/header.php');
-		prnMsg(_('An error occurred getting the days between delivery requested and actual invoice') , 'error');
-		if ($Debug == 1) {
-			prnMsg(_('The SQL used to get the days between requested delivery and actual invoice dates was') . "<br />$SQL", 'error');
-		}
-		include('includes/footer.php');
-		exit();
-	} elseif (DB_num_rows($Result) == 0) {
+	$ErrMsg = _('An error occurred getting the days between delivery requested and actual invoice');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
+	
+	if (DB_num_rows($Result) == 0) {
 		$Title = _('DIFOT Report Error');
 		include('includes/header.php');
 		prnMsg(_('There were no variances between deliveries and orders found in the database within the period from') . ' ' . $_POST['FromDate'] . ' ' . _('to') . ' ' . $_POST['ToDate'] . '. ' . _('Please try again selecting a different date range') , 'info');
-		if ($Debug == 1) {
-			prnMsg(_('The SQL that returned no rows was') . '<br />' . $SQL, 'error');
-		}
 		include('includes/footer.php');
 		exit();
 	}

--- a/PDFDeliveryDifferences.php
+++ b/PDFDeliveryDifferences.php
@@ -133,26 +133,15 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 		$SQL .= " AND debtortrans.salesperson='" . $_SESSION['SalesmanLogin'] . "'";
 	}
 
-	$Result = DB_query($SQL, '', '', false, false); //dont error check - see below
-	if (DB_error_no() != 0) {
-		$Title = _('Delivery Differences Log Report Error');
-		include('includes/header.php');
-		prnMsg(_('An error occurred getting the variances between deliveries and orders'), 'error');
-		if ($Debug == 1) {
-			prnMsg(_('The SQL used to get the variances between deliveries and orders that failed was') . '<br />' . $SQL, 'error');
-		}
-		include('includes/footer.php');
-		exit();
-	}
-	elseif (DB_num_rows($Result) == 0) {
+	$ErrMsg = _('An error occurred getting the variances between deliveries and orders');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
+
+	if (DB_num_rows($Result) == 0) {
 		$Title = _('Delivery Differences Log Report Error');
 		include('includes/header.php');
 		prnMsg(_('There were no variances between deliveries and orders found in the database within the period from') . ' ' .
 			$_POST['FromDate'] . ' ' . _('to') . ' ' . $_POST['ToDate'] . '. ' .
 			_('Please try again selecting a different date range'), 'info');
-		if ($Debug == 1) {
-			prnMsg(_('The SQL that returned no rows was') . '<br />' . $SQL, 'error');
-		}
 		include('includes/footer.php');
 		exit();
 	}

--- a/PDFLowGP.php
+++ b/PDFLowGP.php
@@ -9,7 +9,7 @@ if (isset($_POST['ToDate'])) {$_POST['ToDate'] = ConvertSQLDate($_POST['ToDate']
 if (!isset($_POST['FromCat'])  OR $_POST['FromCat']=='') {
 	$Title=_('Low Gross Profit Sales');
 }
-$Debug=0;
+
 if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 
 	$HTML = '';
@@ -64,31 +64,17 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				AND ((stockmoves.price*(1-stockmoves.discountpercent)) - (stockmaster.actualcost))/(stockmoves.price*(1-stockmoves.discountpercent)) <=" . $_POST['GPMin']/100 . "
 				ORDER BY stockmaster.stockid";
 
-	$LowGPSalesResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-
-		include('includes/header.php');
-		prnMsg(_('The low GP items could not be retrieved by the SQL because') . ' - ' . DB_error_msg(),'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The low GP items could not be retrieved');
+	$LowGPSalesResult = DB_query($SQL, $ErrMsg, '', false);
 
 	if (DB_num_rows($LowGPSalesResult) == 0) {
-
 		include('includes/header.php');
 		prnMsg(_('No low GP items retrieved'), 'warn');
 		echo '<br /><a href="'  . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' .  $SQL;
-		}
 		include('includes/footer.php');
 		exit();
 	}
+	
 	$HTML .= '<table>
 				<tr>
 					<th>' . _('Trans') . '</th>

--- a/PDFOrderStatus.php
+++ b/PDFOrderStatus.php
@@ -166,17 +166,10 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 
 	$SQL .= " ORDER BY salesorders.orderno";
 
-	$Result = DB_query($SQL,'','',false,false); //dont trap errors here
+	$ErrMsg = _('An error occurred getting the orders details');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
 
-	if (DB_error_no()!=0){
-		include('includes/header.php');
-		echo '<br />' . _('An error occurred getting the orders details');
-		if ($Debug==1){
-			echo '<br />' . _('The SQL used to get the orders that failed was') . '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	} elseif (DB_num_rows($Result)==0){
+	if (DB_num_rows($Result)==0){
 		$Title=_('Order Status Report - No Data');
 		include('includes/header.php');
 		prnMsg(_('There were no orders found in the database within the period from') . ' ' . $_POST['FromDate'] . ' ' . _('to') . ' '. $_POST['ToDate'] . '. ' . _('Please try again selecting a different date range'),'info');

--- a/PDFPriceList.php
+++ b/PDFPriceList.php
@@ -193,19 +193,9 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 					stockcategory.categorydescription," .
 					$ItemOrder;
 	}
-	$PricesResult = DB_query($SQL,'','',false,false);
+	$ErrMsg = _('The Price List could not be retrieved');
+	$PricesResult = DB_query($SQL, $ErrMsg, '', false);
 
-	if (DB_error_no() !=0) {
-		$Title = _('Price List') . ' - ' . _('Problem Report....');
-		include('includes/header.php');
-		prnMsg( _('The Price List could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu'). '</a>';
-		if ($Debug==1) {
-			prnMsg(_('For debugging purposes the SQL used was:') . $SQL,'error');
-		}
-		include('includes/footer.php');
-		exit();
-	}
 	if (DB_num_rows($PricesResult)==0) {
 		$Title = _('Print Price List Error');
 		include('includes/header.php');

--- a/PDFPrintLabel.php
+++ b/PDFPrintLabel.php
@@ -34,17 +34,9 @@ if ((isset($_POST['ShowLabels']) OR isset($_POST['SelectAll']))
 				stockmaster.stockid,
 				prices.startdate";
 
-	$LabelsResult = DB_query($SQL,'','',false,false);
+	$ErrMsg = _('The Price Labels could not be retrieved');
+	$LabelsResult = DB_query($SQL, $ErrMsg, '', false);
 
-	if (DB_error_no() !=0) {
-		prnMsg( _('The Price Labels could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' .   _('Back to the menu'). '</a>';
-		if ($Debug==1){
-			prnMsg(_('For debugging purposes the SQL used was:') . $SQL,'error');
-		}
-		include('includes/footer.php');
-		exit();
-	}
 	if (DB_num_rows($LabelsResult)==0){
 		prnMsg(_('There were no price labels to print out for the category specified'),'warn');
 		echo '<br /><a href="'.htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UTF-8') . '">' .  _('Back') . '</a>';

--- a/PDFRemittanceAdvice.php
+++ b/PDFRemittanceAdvice.php
@@ -74,20 +74,8 @@ If ((isset($_POST['PrintPDF']))
 				ORDER BY supptrans.type,
 						 supptrans.transno";
 
-
-		$TransResult = DB_query($SQL,'','',false,false);
-		if (DB_error_no() !=0) {
-			$Title = _('Remittance Advice Problem Report');
-			include('includes/header.php');
-			prnMsg(_('The details of the payment to the supplier could not be retrieved because') . ' - ' . DB_error_msg(),'error');
-			echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-			if ($Debug==1){
-				echo '<br />' . _('The SQL that failed was') . ' ' . $SQL;
-			}
-			include('includes/footer.php');
-			exit();
-		}
-
+		$ErrMsg = _('The details of the payment to the supplier could not be retrieved');
+		$TransResult = DB_query($SQL, $ErrMsg, '', false);
 
 		while ($DetailTrans = DB_fetch_array($TransResult)){
 

--- a/PDFSellThroughSupportClaim.php
+++ b/PDFSellThroughSupportClaim.php
@@ -80,19 +80,8 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 				ORDER BY sellthroughsupport.supplierno,
 					stockmaster.stockid";
 
-	$ClaimsResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-
-	  include('includes/header.php');
-		prnMsg(_('The sell through support items to claim could not be retrieved by the SQL because') . ' - ' . DB_error_msg(),'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-		  echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The sell through support items to claim could not be retrieved');
+	$ClaimsResult = DB_query($SQL, $ErrMsg , '', false);
 
 	if (DB_num_rows($ClaimsResult) == 0) {
 

--- a/PDFStockCheckComparison.php
+++ b/PDFStockCheckComparison.php
@@ -27,19 +27,8 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['ReportOrClose'])){
 				ORDER BY stockcheckfreeze.loccode,
 						stockcheckfreeze.stockid";
 
-		$StockChecks = DB_query($SQL,'','',false,false);
-		if (DB_error_no() !=0) {
-			$Title = _('Stock Freeze') . ' - ' . _('Problem Report') . '....';
-			include('includes/header.php');
-			echo '<br />';
-			prnMsg( _('The inventory check file could not be retrieved because'). ' - ' . DB_error_msg(),'error');
-			echo '<br /><a href="' .$RootPath .'/index.php">' .  _('Back to the menu') . '</a>';
-			if ($Debug==1){
-	      			echo '<br />' . $SQL;
-			}
-			include('includes/footer.php');
-			exit();
-		}
+		$ErrMsg = _('The inventory check file could not be retrieved');
+		$StockChecks = DB_query($SQL, $ErrMsg, '', false);
 
 		$PeriodNo = GetPeriod (Date($_SESSION['DefaultDateFormat']));
 		$SQLAdjustmentDate = FormatDateForSQL(Date($_SESSION['DefaultDateFormat']));
@@ -53,19 +42,8 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['ReportOrClose'])){
 					WHERE stockcounts.stockid='" . $MyRow['stockid'] . "'
 					AND stockcounts.loccode='" . $MyRow['loccode'] . "'";
 
-			$StockCounts = DB_query($SQL);
-			if (DB_error_no() !=0) {
-				$Title = _('Stock Count Comparison') . ' - ' . _('Problem Report') . '....';
-				include('includes/header.php');
-				echo '<br />';
-				prnMsg( _('The inventory counts file could not be retrieved because'). ' - ' . DB_error_msg(). 'error');
-				echo '<br /><a href="' .$RootPath .'/index.php">' .  _('Back to the menu') . '</a>';
-				if ($Debug==1){
-					echo '<br />' .  $SQL;
-				}
-				include('includes/footer.php');
-				exit();
-			}
+			$ErrMsg = _('The inventory counts file could not be retrieved');
+			$StockCounts = DB_query($SQL, $ErrMsg);
 
 			$StkCountResult = DB_query($SQL);
 			$StkCountRow = DB_fetch_array($StkCountResult);
@@ -257,20 +235,9 @@ if (isset($_POST['PrintPDF']) AND isset($_POST['ReportOrClose'])){
 				WHERE loccode ='" . $Location . "'
 				AND stockid = '" . $CheckItemRow['stockid'] . "'";
 
-		$Counts = DB_query($SQL,'','',false,false);
+		$ErrMsg = _('The inventory counts could not be retrieved');
+		$Counts = DB_query($SQL, $ErrMsg, '', false);
 
-		if (DB_error_no() !=0) {
-	 		$Title = _('Inventory Comparison') . ' - ' . _('Problem Report') . '.... ';
-	  		include('includes/header.php');
-	   		echo '<br />';
-			prnMsg( _('The inventory counts could not be retrieved by the SQL because').' - ' . DB_error_msg(), 'error');
-	   		echo '<br /><a href="' .$RootPath .'/index.php">' .  _('Back to the menu'). '</a>';
-	   		if ($Debug==1){
-	      			echo '<br />' .  $SQL;
-	   		}
-	   		include('includes/footer.php');
-	   		exit();
-		}
 		if ($CheckItemRow['qoh']!=0 OR DB_num_rows($Counts)>0) {
 			$YPos -=$LineHeight;
 			$FontSize=8;

--- a/PDFSuppTransListing.php
+++ b/PDFSuppTransListing.php
@@ -73,18 +73,10 @@ $SQL= "SELECT type,
 		WHERE type='" . $_POST['TransType'] . "'
 		AND trandate='" . FormatDateForSQL($_POST['Date']) . "'";
 
-$Result = DB_query($SQL,'','',false,false);
+$ErrMsg = _('An error occurred getting the payments');
+$Result = DB_query($SQL, $ErrMsg, '', false);
 
-if (DB_error_no()!=0){
-	$Title = _('Payment Listing');
-	include('includes/header.php');
-	prnMsg(_('An error occurred getting the payments'),'error');
-	if ($Debug==1){
-			prnMsg(_('The SQL used to get the receipt header information that failed was') . ':<br />' . $SQL,'error');
-	}
-	include('includes/footer.php');
-  	exit();
-} elseif (DB_num_rows($Result) == 0){
+if (DB_num_rows($Result) == 0){
 	$Title = _('Payment Listing');
 	include('includes/header.php');
 	echo '<br />';

--- a/PDFWeeklyOrders.php
+++ b/PDFWeeklyOrders.php
@@ -46,17 +46,9 @@ $SQL= "SELECT salesorders.orderno,
 		 AND salesorders.quotation=0
 		 ORDER BY salesorders.orderno";
 
-$Result = DB_query($SQL,'','',false,false); //dont trap errors here
+$ErrMsg = _('An error occurred getting the orders details');
+$Result = DB_query($SQL, $ErrMsg , '', false);
 
-if (DB_error_no()!=0){
-	include('includes/header.php');
-	echo '<br />' . _('An error occurred getting the orders details');
-	if ($Debug==1){
-		echo '<br />' . _('The SQL used to get the orders that failed was') . '<br />' . $SQL;
-	}
-	include('includes/footer.php');
-	exit();
-}
 $PaperSize="Letter_Landscape";
 include('includes/PDFStarter.php');
 $pdf->addInfo('Title',_('Weekly Orders Report'));

--- a/PO_Items.php
+++ b/PO_Items.php
@@ -436,17 +436,8 @@ if (isset($_POST['EnterLine'])){ /*Inputs from the form directly without selecti
 		$SQL = "SELECT accountname
 				FROM chartmaster
 				WHERE accountcode ='" . $_POST['GLCode'] . "'";
-		$ErrMsg =  _('The account details for') . ' ' . $_POST['GLCode'] . ' ' . _('could not be retrieved because');
-		$GLValidResult = DB_query($SQL, $ErrMsg,'',false,false);
-		if (DB_error_no() !=0) {
-			$AllowUpdate = false;
-			prnMsg( _('The validation process for the GL Code entered could not be executed because') . ' ' . DB_error_msg(), 'error');
-			if ($Debug==1){
-				prnMsg (_('The SQL used to validate the code entered was') . ' ' . $SQL,'error');
-			}
-			include('includes/footer.php');
-			exit();
-		}
+		$ErrMsg =  _('The account details for') . ' ' . $_POST['GLCode'] . ' ' . _('could not be retrieved');
+		$GLValidResult = DB_query($SQL, $ErrMsg, '', false);
 		if (DB_num_rows($GLValidResult) == 0) { /*The GLCode entered does not exist */
 			$AllowUpdate = false;
 			prnMsg( _('Cannot enter this order line') . ':<br />' . _('The general ledger code') . ' - ' . $_POST['GLCode'] . ' ' . _('is not a general ledger code that is defined in the chart of accounts') . ' . ' . _('Please use a code that is already defined') . '. ' . _('See the Chart list from the link below'),'error');
@@ -671,9 +662,6 @@ if (isset($_POST['NewItem'])
 															$SuppliersPartNo);
 				} else { //no rows returned by the SQL to get the item
 					prnMsg (_('The item code') . ' ' . $ItemCode . ' ' . _('does not exist in the database and therefore cannot be added to the order'),'error');
-					if ($Debug==1){
-						echo '<br />' . $SQL;
-					}
 					include('includes/footer.php');
 					exit();
 				}
@@ -833,9 +821,6 @@ if (isset($_POST['UploadFile'])) {
 						++$InsertNum;
 					} else { //no rows returned by the SQL to get the item
 						prnMsg (_('The item code') . ' ' . $ItemCode . ' ' . _('does not exist in the database and therefore cannot be added to the order'),'error');
-						if ($Debug==1){
-							echo '<br />' . $SQL;
-						}
 					}
 				} /* end of if not already on the order */
 			} /* end if the $_POST has NewQty in the variable name */
@@ -1259,7 +1244,7 @@ if (isset($_POST['Search']) OR isset($_POST['Prev']) OR isset($_POST['Next'])){ 
 	$ErrMsg = _('There is a problem selecting the part records to display because');
 	$SearchResult = DB_query($SQL, $ErrMsg);
 
-	if (DB_num_rows($SearchResult)==0 AND $Debug==1){
+	if (DB_num_rows($SearchResult)==0){
 		prnMsg( _('There are no products to display matching the criteria provided'),'warn');
 	}
 	if (DB_num_rows($SearchResult)==1){

--- a/PickingLists.php
+++ b/PickingLists.php
@@ -506,12 +506,6 @@ if (isset($_POST['ProcessPickList']) and $_POST['ProcessPickList'] != '') {
 	if (DB_num_rows($Result) != count($_SESSION['Items' . $identifier]->LineItems)) {
 		/*there should be the same number of items returned from this query as there are lines on the invoice - if  not 	then someone has already invoiced or credited some lines */
 
-		if ($Debug == 1) {
-			echo '<br />' . $SQL;
-			echo '<br />' . _('Number of rows returned by SQL') . ':' . DB_num_rows($Result);
-			echo '<br />' . _('Count of items in the session') . ' ' . count($_SESSION['Items' . $identifier]->LineItems);
-		}
-
 		echo '<br />';
 		prnMsg(_('This order has been changed or invoiced since this delivery was started to be confirmed') . '. ' . _('Processing halted') . '. ' . _('To enter and confirm this dispatch') . _(' the order must be re-selected and re-read again to update the changes made by the other user'), 'error');
 

--- a/PrintCustTrans.php
+++ b/PrintCustTrans.php
@@ -219,18 +219,9 @@ if (isset($PrintPDF)
 			}
 		} // end else
 
-		$Result = DB_query($SQL,'','',false, false);
+		$ErrMsg = _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $InvoiceToPrint;
+		$Result = DB_query($SQL, $ErrMsg, '', false);
 
-		if (DB_error_no()!=0) {
-			$Title = _('Transaction Print Error Report');
-			include('includes/header.php');
-			prnMsg( _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $InvoiceToPrint . ' ' . _('from the database') . '. ' . _('To print an invoice, the sales order record, the customer transaction record and the branch record for the customer must not have been purged') . '. ' . _('To print a credit note only requires the customer, transaction, salesman and branch records be available'),'error');
-			if ($Debug==1) {
-				prnMsg (_('The SQL used to get this information that failed was') . '<br />' . $SQL,'error');
-			}
-			include('includes/footer.php');
-			exit();
-		}
 		if (DB_num_rows($Result)==1) {
 			$MyRow = DB_fetch_array($Result);
 
@@ -296,19 +287,9 @@ if (isset($PrintPDF)
 							AND stockmoves.show_on_inv_crds=1";
 			} // end else
 
-			$Result = DB_query($SQL);
-			if(DB_error_no()!=0) {
-
-				$Title = _('Transaction Print Error Report');
-				include('includes/header.php');
-				echo '<br />' . _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo . ' ' . _('from the database');
-				if ($Debug==1) {
-					echo '<br />' . _('The SQL used to get this information that failed was') . '<br />' . $SQL;
-				}
-				include('includes/footer.php');
-				exit();
-			}
-
+			$ErrMsg = _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo;
+			$Result = DB_query($SQL, $ErrMsg);
+			
 			if ($InvOrCredit=='Invoice') {
 				/* Calculate Due Date info. This reference is used in the PDFTransPageHeader.php file. */
 				$DisplayDueDate = CalcDueDate(ConvertSQLDate($MyRow['trandate']), $MyRow['dayinfollowingmonth'], $MyRow['daysbeforedue']);
@@ -742,12 +723,10 @@ if (isset($PrintPDF)
 							AND debtortrans.transno='" . $FromTransNo . "'";
 			}
 
-			$Result = DB_query($SQL);
-			if(DB_num_rows($Result)==0 OR DB_error_no()!=0) {
-				echo '<p>' . _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $FromTransNo . ' ' . _('from the database') . '. ' . _('To print an invoice, the sales order record, the customer transaction record and the branch record for the customer must not have been purged') . '. ' . _('To print a credit note only requires the customer, transaction, salesman and branch records be available');
-				if ($Debug==1) {
-					prnMsg( _('The SQL used to get this information that failed was') . '<br />' . $SQL, 'warn');
-				}
+			$ErrMsg = _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $FromTransNo;
+			$Result = DB_query($SQL, $ErrMsg);
+			if(DB_num_rows($Result)==0) {
+				echo '<p>' . $ErrMsg . ' ' . _('from the database') . '. ' . _('To print an invoice, the sales order record, the customer transaction record and the branch record for the customer must not have been purged') . '. ' . _('To print a credit note only requires the customer, transaction, salesman and branch records be available');
 				break;
 				include('includes/footer.php');
 				exit();
@@ -952,14 +931,8 @@ if (isset($PrintPDF)
 				echo '<hr />';
 				echo '<div class="centre"><h4>' . _('All amounts stated in') . ' ' . $MyRow['currcode'] . '</h4></div>';
 
-				$Result = DB_query($SQL);
-				if (DB_error_no()!=0) {
-					echo '<br />' . _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo . ' ' . _('from the database');
-					if ($Debug==1){
-						 echo '<br />' . _('The SQL used to get this information that failed was') . '<br />' .$SQL;
-					}
-					exit();
-				}
+				$ErrMsg = _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo ;
+				$Result = DB_query($SQL, $ErrMsg);
 
 				if (DB_num_rows($Result)>0){
 	/* Table for stock details */

--- a/PrintCustTransPortrait.php
+++ b/PrintCustTransPortrait.php
@@ -220,20 +220,9 @@ if(isset($PrintPDF)
 			}
 		}
 
-		$Result = DB_query($SQL,'','',false,false);
+		$ErrMsg = _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $InvoiceToPrint;
+		$Result = DB_query($SQL, $ErrMsg, '', false);
 
-		if(DB_error_no()!=0) {
-
-			$Title = _('Transaction Print Error Report');
-			include('includes/header.php');
-
-			prnMsg( _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $InvoiceToPrint . ' ' . _('from the database') . '. ' . _('To print an invoice, the sales order record, the customer transaction record and the branch record for the customer must not have been purged') . '. ' . _('To print a credit note only requires the customer, transaction, salesman and branch records be available'),'error');
-			if($Debug==1) {
-				prnMsg (_('The SQL used to get this information that failed was') . '<br />' . $SQL,'error');
-			}
-			include('includes/footer.php');
-			exit();
-		}
 		if(DB_num_rows($Result)==1) {
 			$MyRow = DB_fetch_array($Result);
 
@@ -298,17 +287,8 @@ if(isset($PrintPDF)
 					AND stockmoves.show_on_inv_crds=1";
 			} // end else
 
-		$Result = DB_query($SQL);
-		if(DB_error_no()!=0) {
-			$Title = _('Transaction Print Error Report');
-			include('includes/header.php');
-			echo '<br />' . _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo . ' ' . _('from the database');
-			if($Debug==1) {
-				echo '<br />' . _('The SQL used to get this information that failed was') . '<br />' . $SQL;
-			}
-			include('includes/footer.php');
-			exit();
-		}
+		$ErrMsg = _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo;
+		$Result = DB_query($SQL, $ErrMsg);
 
 		if ($InvOrCredit=='Invoice') {
 			/* Calculate Due Date info. This reference is used in the PDFTransPageHeaderPortrait.php file. */
@@ -749,12 +729,10 @@ if(isset($PrintPDF)
 
 			}
 
-			$Result = DB_query($SQL);
-			if(DB_num_rows($Result)==0 OR DB_error_no()!=0) {
-				echo '<p>' . _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $InvoiceToPrint . ' ' . _('from the database') . '. ' . _('To print an invoice, the sales order record, the customer transaction record and the branch record for the customer must not have been purged') . '. ' . _('To print a credit note only requires the customer, transaction, salesman and branch records be available');
-				if($Debug==1) {
-					prnMsg( _('The SQL used to get this information that failed was') . '<br />' . $SQL,'warn');
-				}
+			$ErrMsg = _('There was a problem retrieving the invoice or credit note details for note number') . ' ' . $InvoiceToPrint;
+			$Result = DB_query($SQL, $ErrMsg);
+			if(DB_num_rows($Result)==0) {
+				echo '<p>' . $ErrMsg . ' ' . _('from the database') . '. ' . _('To print an invoice, the sales order record, the customer transaction record and the branch record for the customer must not have been purged') . '. ' . _('To print a credit note only requires the customer, transaction, salesman and branch records be available');
 				break;
 				include('includes/footer.php');
 				exit();
@@ -960,14 +938,8 @@ if(isset($PrintPDF)
 				echo '<hr />';
 				echo '<div class="centre"><h4>' . _('All amounts stated in') . ' ' . $MyRow['currcode'] . '</h4></div>';
 
-				$Result = DB_query($SQL);
-				if(DB_error_no()!=0) {
-					echo '<br />' . _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo . ' ' . _('from the database');
-					if($Debug==1) {
-						 echo '<br />' . _('The SQL used to get this information that failed was') . '<br />' . $SQL;
-					}
-					exit();
-				}
+				$ErrMsg = _('There was a problem retrieving the invoice or credit note stock movement details for invoice number') . ' ' . $FromTransNo ;
+				$Result = DB_query($SQL, $ErrMsg);
 
 				if(DB_num_rows($Result)>0) {
 	/* Table for stock details */

--- a/SalesCategories.php
+++ b/SalesCategories.php
@@ -136,10 +136,6 @@ if (isset($_POST['Search']) or isset($_POST['Prev']) or isset($_POST['Next'])) {
 
 	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('There are no products available meeting the criteria specified'), 'info');
-
-		if ($Debug == 1) {
-			prnMsg(_('The SQL statement used was') . ':<br />' . $SQL, 'info');
-		}
 	}
 
 } //end of if search

--- a/SelectCreditItems.php
+++ b/SelectCreditItems.php
@@ -376,15 +376,12 @@ if ($_SESSION['RequireCustomerSelection'] ==1
 		$SearchResult = DB_query($SQL, $ErrMsg);
 
 		if (DB_num_rows($SearchResult)==0){
-			   prnMsg(_('There are no products available that match the criteria specified'),'info');
-			   if ($Debug==1){
-				    prnMsg(_('The SQL statement used was') . ':<br />' . $SQL,'info');
-			   }
+			prnMsg(_('There are no products available that match the criteria specified'),'info');
 		}
 		if (DB_num_rows($SearchResult)==1){
-			   $MyRow=DB_fetch_array($SearchResult);
-			   $_POST['NewItem'] = $MyRow['stockid'];
-			   DB_data_seek($SearchResult,0);
+			$MyRow=DB_fetch_array($SearchResult);
+			$_POST['NewItem'] = $MyRow['stockid'];
+			DB_data_seek($SearchResult,0);
 		}
 
 	 } //end of if search for parts to add to the credit note

--- a/SelectOrderItems.php
+++ b/SelectOrderItems.php
@@ -460,9 +460,6 @@ if (isset($SelectedCustomer)) {
 
 			prnMsg(_('The branch details for branch code') . ': ' . $_SESSION['Items'.$identifier]->Branch . ' ' . _('against customer code') . ': ' . $_SESSION['Items'.$identifier]->DebtorNo . ' ' . _('could not be retrieved') . '. ' . _('Check the set up of the customer and branch'),'error');
 
-			if ($Debug==1){
-				prnMsg( _('The SQL that failed to get the branch details was') . ':<br />' . $SQL . 'warning');
-			}
 			include('includes/footer.php');
 			exit();
 		}

--- a/StockCheck.php
+++ b/StockCheck.php
@@ -32,18 +32,8 @@ if (isset($_POST['PrintPDF'])){
 					   AND stockmaster.mbflag!='K'
 					   AND stockmaster.mbflag!='D'";
 
-		$Result = DB_query($SQL,'','',false,false);
-		if (DB_error_no() !=0) {
-			$Title = _('Stock Count Sheets - Problem Report');
-			include('includes/header.php');
-			prnMsg(_('The inventory quantities could not be added to the freeze file because') . ' ' . DB_error_msg(),'error');
-			echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-			if ($Debug==1){
-		  			echo '<br />' . $SQL;
-			}
-			include('includes/footer.php');
-			exit();
-		}
+		$ErrMsg = _('The inventory quantities could not be added to the freeze file');
+		$Result = DB_query($SQL, $ErrMsg, '', false);
 	}
 
 	if ($_POST['MakeStkChkData']=='AddUpdate'){
@@ -53,18 +43,8 @@ if (isset($_POST['PrintPDF'])){
 				WHERE stockmaster.categoryid IN ('". implode("','",$_POST['Categories'])."')
 				AND stockcheckfreeze.loccode='" . $_POST['Location'] . "'";
 
-		$Result = DB_query($SQL,'','',false,false);
-		if (DB_error_no() !=0) {
-			$Title = _('Stock Freeze') . ' - ' . _('Problem Report') . '.... ';
-			include('includes/header.php');
-			prnMsg(_('The old quantities could not be deleted from the freeze file because') . ' ' . DB_error_msg(),'error');
-			echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-			if ($Debug==1){
-		  			echo '<br />' . $SQL;
-			}
-			include('includes/footer.php');
-			exit();
-		}
+		$ErrMsg = _('The old quantities could not be deleted from the freeze file');
+		$Result = DB_query($SQL, $ErrMsg, '', false);
 
 		$SQL = "INSERT INTO stockcheckfreeze (stockid,
 										  loccode,
@@ -83,25 +63,15 @@ if (isset($_POST['PrintPDF'])){
 				AND stockmaster.mbflag!='G'
 				AND stockmaster.mbflag!='D'";
 
-		$Result = DB_query($SQL,'','',false,false);
-		if (DB_error_no() !=0) {
-			$Title = _('Stock Freeze - Problem Report');
-			include('includes/header.php');
-			prnMsg(_('The inventory quantities could not be added to the freeze file because') . ' ' . DB_error_msg(),'error');
-			echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-			if ($Debug==1){
-		  			echo '<br />' . $SQL;
-			}
-			include('includes/footer.php');
-			exit();
-		} else {
-			$Title = _('Stock Check Freeze Update');
-			include('includes/header.php');
-			echo '<p><a href="' . htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UTF-8') . '">' . _('Print Check Sheets') . '</a>';
-			prnMsg( _('Added to the stock check file successfully'),'success');
-			include('includes/footer.php');
-			exit();
-		}
+		$ErrMsg = _('The inventory quantities could not be added to the freeze file');
+		$Result = DB_query($SQL, $ErrMsg, '', false);
+
+		$Title = _('Stock Check Freeze Update');
+		include('includes/header.php');
+		echo '<p><a href="' . htmlspecialchars($_SERVER['PHP_SELF'],ENT_QUOTES,'UTF-8') . '">' . _('Print Check Sheets') . '</a>';
+		prnMsg( _('Added to the stock check file successfully'),'success');
+		include('includes/footer.php');
+		exit();
 	}
 
 
@@ -124,19 +94,9 @@ if (isset($_POST['PrintPDF'])){
 
 	$SQL .=  " ORDER BY stockmaster.categoryid, stockmaster.stockid";
 
-	$InventoryResult = DB_query($SQL,'','',false,false);
+	$ErrMsg = _('The inventory quantities could not be retrieved');
+	$InventoryResult = DB_query($SQL, $ErrMsg, '', false);
 
-	if (DB_error_no() !=0) {
-		$Title = _('Stock Sheets') . ' - ' . _('Problem Report') . '.... ';
-		include('includes/header.php');
-		prnMsg( _('The inventory quantities could not be retrieved by the SQL because') . ' ' . DB_error_msg(),'error');
-		echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-		  	echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
 	if (DB_num_rows($InventoryResult) ==0) {
 		$Title = _('Stock Count Sheets - Problem Report');
 		include('includes/header.php');

--- a/StockDispatch.php
+++ b/StockDispatch.php
@@ -117,20 +117,9 @@ if (isset($_POST['PrintPDF'])) {
 			AND (stockmaster.mbflag='B' OR stockmaster.mbflag='M') " .
 			$WhereCategory . " ORDER BY locstock.loccode,locstock.stockid";
 
-	$Result = DB_query($SQL,'','',false,true);
+	$ErrMsg = _('The Stock Dispatch report could not be retrieved');
+	$Result = DB_query($SQL, $ErrMsg, '', false);
 
-	if (DB_error_no() !=0) {
-		$Title = _('Stock Dispatch - Problem Report');
-		include('includes/header.php');
-		prnMsg( _('The Stock Dispatch report could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-		echo '<br />
-				<a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
 	if (DB_num_rows($Result) ==0) {
 		$Title = _('Stock Dispatch - Problem Report');
 		include('includes/header.php');

--- a/StockUsage.php
+++ b/StockUsage.php
@@ -141,14 +141,8 @@ if (isset($_POST['ShowUsage'])){
 				ORDER BY periodno DESC LIMIT " . $_SESSION['NumberOfPeriodsOfStockUsage'];
 
 	}
-	$MovtsResult = DB_query($SQL);
-	if (DB_error_no() !=0) {
-		echo _('The stock usage for the selected criteria could not be retrieved because') . ' - ' . DB_error_msg();
-		if ($Debug==1){
-		echo '<br />' . _('The SQL that failed was') . $SQL;
-		}
-		exit();
-	}
+	$ErrMsg = _('The stock usage for the selected criteria could not be retrieved');
+	$MovtsResult = DB_query($SQL, $ErrMsg);
 
 	echo '<table class="selection">
 			<thead>

--- a/StockUsageGraph.php
+++ b/StockUsageGraph.php
@@ -95,18 +95,8 @@ if($_GET['StockLocation'] == 'All') {
     }
 }
 
-$MovtsResult = DB_query($SQL);
-
-if (DB_error_no() != 0) {
-    $Title = _('Stock Usage Graph Problem');
-    include('includes/header.php');
-    echo _('The stock usage for the selected criteria could not be retrieved because') . ' - ' . DB_error_msg();
-    if ($Debug == 1) {
-        echo '<br />' . _('The SQL that failed was') . $SQL;
-    }
-    include('includes/footer.php');
-    exit();
-}
+$ErrMsg = _('The stock usage for the selected criteria could not be retrieved');
+$MovtsResult = DB_query($SQL, $ErrMsg);
 
 if (DB_num_rows($MovtsResult) == 0) {
     $Title = _('Stock Usage Graph Problem');

--- a/SuppPaymentRun.php
+++ b/SuppPaymentRun.php
@@ -104,18 +104,8 @@ if ((isset($_POST['PrintPDF']) OR isset($_POST['PrintPDFAndProcess']))
 					supptrans.type,
 					supptrans.transno";
 
-		$TransResult = DB_query($SQL,'','',false,false);
-		if (DB_error_no() !=0) {
-			$Title = _('Payment Run - Problem Report');
-			include('includes/header.php');
-			prnMsg(_('The details of supplier invoices due could not be retrieved because') . ' - ' . DB_error_msg(),'error');
-			echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-			if ($Debug==1){
-				echo '<br />' . _('The SQL that failed was') . ' ' . $SQL;
-			}
-			include('includes/footer.php');
-			exit();
-		}
+		$ErrMsg = _('The details of supplier invoices due could not be retrieved');
+		$TransResult = DB_query($SQL, $ErrMsg , '', false);
 		if (DB_num_rows($TransResult)==0) {
 			include('includes/header.php');
 			prnMsg(_('There are no outstanding supplier invoices to pay'),'info');
@@ -178,19 +168,8 @@ if ((isset($_POST['PrintPDF']) OR isset($_POST['PrintPDFAndProcess']))
 							WHERE type = '" . $DetailTrans['type'] . "'
 							AND transno = '" . $DetailTrans['transno'] . "'";
 
-				$ProcessResult = DB_query($SQL,'','',false,false);
-				if (DB_error_no() !=0) {
-					$Title = _('Payment Processing - Problem Report') . '.... ';
-					include('includes/header.php');
-					prnMsg(_('None of the payments will be processed since updates to the transaction records for') . ' ' .$SupplierName . ' ' . _('could not be processed because') . ' - ' . DB_error_msg(),'error');
-					echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-					if ($Debug==1){
-						echo '<br />' . _('The SQL that failed was') . $SQL;
-					}
-					DB_Txn_Rollback();
-					include('includes/footer.php');
-					exit();
-				}
+				$ErrMsg = ('None of the payments will be processed since updates to the transaction records for') . ' ' .$SupplierName . ' ' . _('could not be processed');
+				$ProcessResult = DB_query($SQL, $ErrMsg, '', true);
 			}
 
 			$LeftOvers = $PDF->addTextWrap(340, $YPos,60,$FontSize,locale_number_format($DetailTrans['balance'],$CurrDecimalPlaces), 'right');
@@ -215,9 +194,6 @@ if ((isset($_POST['PrintPDF']) OR isset($_POST['PrintPDFAndProcess']))
 			include('includes/header.php');
 			prnMsg(_('None of the payments will be processed. Unfortunately, there was a problem committing the changes to the database because') . ' - ' . DB_error_msg(),'error');
 			echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-			if ($Debug==1){
-				prnMsg(_('The SQL that failed was') . '<br />' . $SQL,'error');
-			}
 			DB_Txn_Rollback();
 			include('includes/footer.php');
 			exit();
@@ -315,17 +291,9 @@ if ((isset($_POST['PrintPDF']) OR isset($_POST['PrintPDFAndProcess']))
 			<input type="date" name="AmountsDueBy" maxlength="10" size="11" value="' . $DefaultDate . '" />
 		  </field>';
 
+	$ErrMsg = _('The bank accounts could not be retrieved');
 	$SQL = "SELECT bankaccountname, accountcode FROM bankaccounts";
-
-	$AccountsResults = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-		 echo '<br />' . _('The bank accounts could not be retrieved by the SQL because') . ' - ' . DB_error_msg();
-		 if ($Debug==1){
-			echo '<br />' . _('The SQL used to retrieve the bank accounts was') . ':<br />' . $SQL;
-		 }
-		 exit();
-	}
+	$AccountsResults = DB_query($SQL, $ErrMsg, '', false);
 
 	echo '<field>
 			<label for="BankAccount">' . _('Pay From Account') . ':</label>

--- a/SuppPriceList.php
+++ b/SuppPriceList.php
@@ -122,19 +122,8 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View']) or isset($_POST['Email'])
 			}
 		}
 	}
-	$PricesResult = DB_query($SQL,'','',false,true);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Price List') . ' - ' . _('Problem Report');
-		include('includes/header.php');
-		prnMsg( _('The Price List could not be retrieved by the SQL because') . ' '  . DB_error_msg(),'error');
-		echo '<a href="' .$RootPath .'/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg =  _('The Price List could not be retrieved');
+	$PricesResult = DB_query($SQL, $ErrMsg, '', false);
 
 	if (DB_num_rows($PricesResult)==0) {
 

--- a/SupplierAllocations.php
+++ b/SupplierAllocations.php
@@ -308,9 +308,6 @@ if (isset($_GET['AllocTrans'])){
 	$Result = DB_query($SQL);
 	if (DB_num_rows($Result) != 1){
 		prnMsg(_('There was a problem retrieving the information relating the transaction selected') . '. ' . _('Allocations are unable to proceed'), 'error');
-		if ($Debug == 1){
-			echo '<br />' . _('The SQL that was used to retrieve the transaction information was') . ' :<br />'  . $SQL;
-		}
 		exit();
 	}
 

--- a/SupplierBalsAtPeriodEnd.php
+++ b/SupplierBalsAtPeriodEnd.php
@@ -43,19 +43,9 @@ if (isset($_POST['PrintPDF'])
 				currencies.currency,
 				currencies.decimalplaces";
 
-	$SupplierResult = DB_query($SQL);
+	$ErrMsg = _('The Supplier details could not be retrieved');
+	$SupplierResult = DB_query($SQL, $ErrMsg);
 
-	if (DB_error_no() !=0) {
-		$Title = _('Supplier Balances - Problem Report');
-		include('includes/header.php');
-		prnMsg(_('The Supplier details could not be retrieved by the SQL because') . ' ' . DB_error_msg(),'error');
-		echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
 	if (DB_num_rows($SupplierResult) ==0) {
 		$Title = _('Supplier Balances - Problem Report');
 		include('includes/header.php');

--- a/SupplierCredit.php
+++ b/SupplierCredit.php
@@ -1036,10 +1036,6 @@ then do the updates and inserts to process the credit note entered */
 
 			} /* end of GRN postings */
 
-			if ($Debug == 1 AND abs(($_SESSION['SuppTrans']->OvAmount/ $_SESSION['SuppTrans']->ExRate) - $LocalTotal)>0.004){
-				prnMsg(_('The total posted to the credit accounts is') . ' ' . $LocalTotal . ' ' . _('but the sum of OvAmount converted at ExRate') . ' = ' . ($_SESSION['SuppTrans']->OvAmount / $_SESSION['SuppTrans']->ExRate),'error');
-			}
-
 			foreach ($_SESSION['SuppTrans']->Taxes as $Tax){
 				/* Now the TAX account */
 				if ($Tax->TaxOvAmount/ $_SESSION['SuppTrans']->ExRate !=0){

--- a/SupplierInvoice.php
+++ b/SupplierInvoice.php
@@ -1400,11 +1400,6 @@ else { // $_POST['PostInvoice'] is set so do the postings -and dont show the but
 				$LocalTotal += ($EnteredGRN->ChgPrice * $EnteredGRN->This_QuantityInv) / $_SESSION['SuppTrans']->ExRate;
 			} /* end of GRN postings */
 
-			if ($Debug == 1 AND (abs($_SESSION['SuppTrans']->OvAmount / $_SESSION['SuppTrans']->ExRate) - $LocalTotal) > 0.009999) {
-
-				echo '<p>' . _('The total posted to the debit accounts is') . ' ' . $LocalTotal . ' ' . _('but the sum of OvAmount converted at ExRate') . ' = ' . ($_SESSION['SuppTrans']->OvAmount / $_SESSION['SuppTrans']->ExRate);
-			}
-
 			foreach ($_SESSION['SuppTrans']->Taxes as $Tax) {
 				/* Now the TAX account */
 				if ($Tax->TaxOvAmount <> 0) {

--- a/SupplierTenderCreate.php
+++ b/SupplierTenderCreate.php
@@ -806,7 +806,7 @@ if (isset($_POST['Search'])) { /*ie seach for stock items */
 	$ErrMsg = _('There is a problem selecting the part records to display because');
 	$SearchResult = DB_query($SQL, $ErrMsg);
 
-	if (DB_num_rows($SearchResult) == 0 and $Debug == 1) {
+	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('There are no products to display matching the criteria provided'), 'warn');
 	}
 	if (DB_num_rows($SearchResult) == 1) {

--- a/SupplierTenders.php
+++ b/SupplierTenders.php
@@ -660,7 +660,7 @@ if (isset($_POST['Search'])){  /*ie seach for stock items */
 	$ErrMsg = _('There is a problem selecting the part records to display because');
 	$SearchResult = DB_query($SQL, $ErrMsg);
 
-	if (DB_num_rows($SearchResult)==0 AND $Debug==1){
+	if (DB_num_rows($SearchResult)==0){
 		prnMsg( _('There are no products to display matching the criteria provided'),'warn');
 	}
 	if (DB_num_rows($SearchResult)==1){

--- a/Tax.php
+++ b/Tax.php
@@ -34,18 +34,10 @@ if (isset($_POST['TaxAuthority']) and isset($_POST['PrintPDF']) and isset($_POST
 					AND (debtortrans.type=10 OR debtortrans.type=11)
 					AND debtortranstaxes.taxauthid = '" . $_POST['TaxAuthority'] . "'
 				ORDER BY debtortrans.id";
-	$DebtorTransResult = DB_query($SQL, '', '', false, false); //don't trap errors in DB_query
-	if (DB_error_no() != 0) {
-		$Title = _('Taxation Reporting Error');
-		include('includes/header.php');
-		prnMsg(_('The accounts receivable transaction details could not be retrieved because') . ' ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug == 1) {
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+
+	$ErrMsg = _('The accounts receivable transaction details could not be retrieved');
+	$DebtorTransResult = DB_query($SQL, $ErrMsg, '', false);
+
 	$SalesCount = 0;
 	$SalesNet = 0;
 	$SalesTax = 0;
@@ -139,18 +131,10 @@ if (isset($_POST['TaxAuthority']) and isset($_POST['PrintPDF']) and isset($_POST
 					AND (supptrans.type=20 OR supptrans.type=21)
 					AND supptranstaxes.taxauthid = '" . $_POST['TaxAuthority'] . "'
 				ORDER BY supptrans.id"; // ORDER BY supptrans.recno ?
-	$SuppTransResult = DB_query($SQL, '', '', false, false); //doint trap errors in DB_query
-	if (DB_error_no() != 0) {
-		$Title = _('Taxation Reporting Error');
-		include('includes/header.php');
-		echo _('The accounts payable transaction details could not be retrieved because') . ' ' . DB_error_msg();
-		echo '<br /><a href="' . $RootPath . '/index.php?">' . _('Back to the menu') . '</a>';
-		if ($Debug == 1) {
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+
+	$ErrMsg = _('The accounts payable transaction details could not be retrieved');
+	$SuppTransResult = DB_query($SQL, $ErrMsg, '', false);
+
 	$PettyCashSQL = "SELECT pcashdetails.date AS trandate,
 							pcashdetailtaxes.pccashdetail AS transno,
 							pcashdetailtaxes.description AS suppreference,
@@ -168,18 +152,10 @@ if (isset($_POST['TaxAuthority']) and isset($_POST['PrintPDF']) and isset($_POST
 							AND pcashdetails.date <= '" . FormatDateForSQL($PeriodEnd) . "'
 							AND pcashdetailtaxes.taxauthid = '" . $_POST['TaxAuthority'] . "'
 						ORDER BY pcashdetailtaxes.counterindex";
-	$PettyCashResult = DB_query($PettyCashSQL, '', '', false, false); //doint trap errors in DB_query
-	if (DB_error_no() != 0) {
-		$Title = _('Taxation Reporting Error');
-		include('includes/header.php');
-		echo _('The petty cash transaction details could not be retrieved because') . ' ' . DB_error_msg();
-		echo '<br /><a href="' . $RootPath . '/index.php?">' . _('Back to the menu') . '</a>';
-		if ($Debug == 1) {
-			echo '<br />' . $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+
+	$ErrMsg = _('The petty cash transaction details could not be retrieved');
+	$PettyCashResult = DB_query($PettyCashSQL, $ErrMsg, '', false); 
+
 	$PurchasesCount = 0;
 	$PurchasesNet = 0;
 	$PurchasesTax = 0;

--- a/WorkOrderIssue.php
+++ b/WorkOrderIssue.php
@@ -695,10 +695,6 @@ if (isset($_POST['Search'])) {
 
 	if (DB_num_rows($SearchResult) == 0) {
 		prnMsg(_('There are no products available meeting the criteria specified'), 'info');
-
-		if ($Debug == 1) {
-			prnMsg(_('The SQL statement used was') . ':<br />' . $SQL, 'info');
-		}
 	}
 	if (DB_num_rows($SearchResult) == 1) {
 		$MyRow = DB_fetch_array($SearchResult);

--- a/Z_DataExport.php
+++ b/Z_DataExport.php
@@ -60,19 +60,9 @@ if ( isset($_POST['pricelist']) ) {
 			ORDER BY prices.currabrev,
 				stockmaster.categoryid,
 				stockmaster.stockid";
-	$PricesResult = DB_query($SQL,'','',false,false);
 
-	if (DB_error_no() !=0) {
-		$Title = _('Price List Export Problem ....');
-		include('includes/header.php');
-		prnMsg( _('The Price List could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' .   _('Back to the menu'). '</a>';
-		if ($Debug==1){
-			echo '<br />' .  $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The Price List could not be retrieved');
+	$PricesResult = DB_query($SQL, $ErrMsg, '', false);
 
 	$CSVContent = stripcomma('stockid') . ',' .
 			stripcomma('description') . ',' .
@@ -156,19 +146,8 @@ if ( isset($_POST['pricelist']) ) {
 		WHERE debtorsmaster.debtorno=custbranch.debtorno
 		AND ((defaultlocation = '".$_POST['Location']."') OR (defaultlocation = '') OR (defaultlocation IS NULL))";
 
-	$CustResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Customer List Export Problem ....');
-		include('includes/header.php');
-		prnMsg( _('The Customer List could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' .   _('Back to the menu'). '</a>';
-		if ($Debug==1){
-			echo '<br />' .  $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The Customer List could not be retrieved by the SQL');
+	$CustResult = DB_query($SQL, $ErrMsg , '', false);
 
 	$CSVContent = stripcomma('debtorno') . ',' .
 			stripcomma('branchcode') . ',' .
@@ -247,19 +226,8 @@ if ( isset($_POST['pricelist']) ) {
 			commissionrate2
 		FROM salesman";
 
-	$SalesManResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Salesman List Export Problem ....');
-		include('includes/header.php');
-		prnMsg( _('The Salesman List could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' .   _('Back to the menu'). '</a>';
-		if ($Debug==1){
-			echo '<br />' .  $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The Salesman List could not be retrieved');
+	$SalesManResult = DB_query($SQL, $ErrMsg, '', false);
 
 	$CSVContent = stripcomma('salesmancode') . ',' .
 			stripcomma('salesmanname') . ',' .
@@ -268,7 +236,6 @@ if ( isset($_POST['pricelist']) ) {
 			stripcomma('commissionrate1') . ',' .
 			stripcomma('breakpoint') . ',' .
 			stripcomma('commissionrate2') . "\n";
-
 
 	while ($SalesManList = DB_fetch_array($SalesManResult)){
 
@@ -296,19 +263,8 @@ if ( isset($_POST['pricelist']) ) {
 	$SQL = "SELECT stockid
 		FROM stockmaster
 		ORDER BY stockid";
-	$ImageResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Security Token List Export Problem ....');
-		include('includes/header.php');
-		prnMsg( _('The Image List could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' .   _('Back to the menu'). '</a>';
-		if ($Debug==1){
-			echo '<br />' .  $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The Image List could not be retrieved');
+	$ImageResult = DB_query($SQL, $ErrMsg, '', false);
 
 	$CSVContent = stripcomma('stockid') . ','.
 				  stripcomma('filename') . ','.
@@ -335,23 +291,11 @@ if ( isset($_POST['pricelist']) ) {
 			tokenname
 		FROM securitytokens";
 
-	$SecTokenResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Security Token List Export Problem ....');
-		include('includes/header.php');
-		prnMsg( _('The Security Token List could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' .   _('Back to the menu'). '</a>';
-		if ($Debug==1){
-			echo '<br />' .  $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The Security Token List could not be retrieved');
+	$SecTokenResult = DB_query($SQL, $ErrMsg, '', false);
 
 	$CSVContent = stripcomma('tokenid') . ',' .
 			stripcomma('tokenname') . "\n";
-
 
 	while ($SecTokenList = DB_fetch_array($SecTokenResult)){
 
@@ -371,23 +315,11 @@ if ( isset($_POST['pricelist']) ) {
 			secrolename
 		FROM securityroles";
 
-	$SecRoleResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Security Role List Export Problem ....');
-		include('includes/header.php');
-		prnMsg( _('The Security Role List could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' .   _('Back to the menu'). '</a>';
-		if ($Debug==1){
-			echo '<br />' .  $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The Security Role List could not be retrieved');
+	$SecRoleResult = DB_query($SQL, $ErrMsg, '', false);
 
 	$CSVContent = stripcomma('secroleid') . ',' .
 			stripcomma('secrolename') . "\n";
-
 
 	while ($SecRoleList = DB_fetch_array($SecRoleResult)){
 
@@ -407,23 +339,11 @@ if ( isset($_POST['pricelist']) ) {
 			tokenid
 		FROM securitygroups";
 
-	$SecGroupResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Security Group List Export Problem ....');
-		include('includes/header.php');
-		prnMsg( _('The Security Group List could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' .   _('Back to the menu'). '</a>';
-		if ($Debug==1){
-			echo '<br />' .  $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The Security Group List could not be retrieved');
+	$SecGroupResult = DB_query($SQL, $ErrMsg, '', false);
 
 	$CSVContent = stripcomma('secroleid') . ',' .
 			stripcomma('tokenid') . "\n";
-
 
 	while ($SecGroupList = DB_fetch_array($SecGroupResult)){
 
@@ -459,19 +379,8 @@ if ( isset($_POST['pricelist']) ) {
 		WHERE (customerid <> '') OR
 			(NOT customerid IS NULL)";
 
-	$SecUserResult = DB_query($SQL,'','',false,false);
-
-	if (DB_error_no() !=0) {
-		$Title = _('Security User List Export Problem ....');
-		include('includes/header.php');
-		prnMsg( _('The Security User List could not be retrieved by the SQL because'). ' - ' . DB_error_msg(), 'error');
-		echo '<br /><a href="' .$RootPath .'/index.php">' .   _('Back to the menu'). '</a>';
-		if ($Debug==1){
-			echo '<br />' .  $SQL;
-		}
-		include('includes/footer.php');
-		exit();
-	}
+	$ErrMsg = _('The Security User List could not be retrieved');
+	$SecUserResult = DB_query($SQL, $ErrMsg, '', false);
 
 	$CSVContent = stripcomma('userid') . ',' .
 			stripcomma('password') . ','.

--- a/includes/ConnectDB_postgres.php
+++ b/includes/ConnectDB_postgres.php
@@ -23,7 +23,7 @@ global $db;		// Make sure it IS global, regardless of our context
 $db = pg_connect( $PgConnStr );
 
 if ( !$db ) {
-	if ($Debug==1) {
+	if ($Debug >= 1) {
 		echo '<br>' . $PgConnStr . '<br>';
 	}
 	echo '<br>' . _('The company name entered together with the configuration in the file config.php for the database user name and password do not provide the information required to connect to the database.') . '<br><br>' . _(' Try logging in with an alternative company name.');

--- a/includes/PDFPaymentRun_PymtFooter.php
+++ b/includes/PDFPaymentRun_PymtFooter.php
@@ -49,20 +49,8 @@ if (isset($_POST['PrintPDFAndProcess'])){
 				'" . -$AccumDiffOnExch . "',
 				'" . -$AccumBalance . "')";
 
-	$ProcessResult = DB_query($SQL,'','',false,false);
-	if (DB_error_no() !=0) {
-		$Title = _('Payment Processing - Problem Report');
-		include('header.php');
-		prnMsg(_('None of the payments will be processed because the payment record for') . ' ' . $SupplierName . ' ' . _('could not be inserted because') . ' - ' . DB_error_msg(),'error');
-		echo '<br>
-				<a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			prnMsg(_('The SQL that failed was') . ' ' . $SQL,'error');
-		}
-		DB_Txn_Rollback();
-		include('footer.php');
-		exit();
-	}
+	$ErrMsg = _('None of the payments will be processed because the payment record for') . ' ' . $SupplierName . ' ' . _('could not be inserted');
+	$ProcessResult = DB_query($SQL, $ErrMsg, '', true);
 
 	$PaymentTransID = DB_Last_Insert_ID('supptrans','id');
 
@@ -80,19 +68,8 @@ if (isset($_POST['PrintPDFAndProcess'])){
 						'" . $PaymentTransID . "',
 						'" . $AllocTrans->TransID . "')";
 
-		$ProcessResult = DB_query($SQL);
-		if (DB_error_no() !=0) {
-			$Title = _('Payment Processing - Problem Report') . '.... ';
-			include('header.php');
-			prnMsg(_('None of the payments will be processed since an allocation record for') . $SupplierName . _('could not be inserted because') . ' - ' . DB_error_msg(),'error');
-			echo '<br><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-			if ($Debug==1){
-				prnMsg(_('The SQL that failed was') . $SQL,'error');
-			}
-			DB_Txn_Rollback();
-			include('footer.php');
-			exit();
-		}
+		$ErrMsg = _('None of the payments will be processed since an allocation record for') . $SupplierName . _('could not be inserted');
+		$ProcessResult = DB_query($SQL, $ErrMsg, '', true);
 	} /*end of the loop to insert the allocation records */
 
 
@@ -109,20 +86,8 @@ if (isset($_POST['PrintPDFAndProcess'])){
 				'" . FormatDateForSQL($_POST['AmountsDueBy']) . "',
 				'" . $_POST['PaytType'] . "',
 				" .  -$AccumBalance . ")";
-	$ProcessResult = DB_query($SQL,'','',false,false);
-	if (DB_error_no() !=0) {
-		$Title = _('Payment Processing - Problem Report');
-		include('header.php');
-		prnMsg(_('None of the payments will be processed because the bank account payment record for') . ' ' . $SupplierName . ' ' . _('could not be inserted because') . ' - ' . DB_error_msg(),'error');
-		echo '<br />
-				<a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-		if ($Debug==1){
-			prnMsg(_('The SQL that failed was') . ' ' . $SQL,'error');
-		}
-		DB_Txn_Rollback();
-		include('footer.php');
-		exit();
-	}
+	$ErrMsg = _('None of the payments will be processed because the bank account payment record for') . ' ' . $SupplierName . ' ' . _('could not be inserted'); 
+	$ProcessResult = DB_query($SQL, $ErrMsg, '', true);
 
 	/*If the General Ledger Link is activated */
 	if ($_SESSION['CompanyRecord']['gllink_creditors']==1){
@@ -146,20 +111,8 @@ if (isset($_POST['PrintPDFAndProcess'])){
 					'" . mb_substr($SupplierID . " - " . $SupplierName . ' ' . _('payment run on') . ' ' . Date($_SESSION['DefaultDateFormat']) . ' - ' . $PaytReference, 0, 200) . "',
 					'" . (-$AccumBalance/ filter_number_format($_POST['ExRate'])) . "')";
 
-		$ProcessResult = DB_query($SQL,'','',false,false);
-		if (DB_error_no() !=0) {
-			$Title = _('Payment Processing') . ' - ' . _('Problem Report') . '.... ';
-			include('header.php');
-			prnMsg(_('None of the payments will be processed since the general ledger posting for the payment to') . ' ' . $SupplierName . ' ' . _('could not be inserted because') . ' - ' . DB_error_msg(),'error');
-			echo '<br />
-					<a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-			if ($Debug==1){
-				prnMsg(_('The SQL that failed was') . ':<br />' . $SQL, 'error');
-			}
-			DB_Txn_Rollback();
-			include('footer.php');
-			exit();
-		}
+		$ErrMsg = _('None of the payments will be processed since the general ledger posting for the payment to') . ' ' . $SupplierName . ' ' . _('could not be inserted');
+		$ProcessResult = DB_query($SQL, $ErrMsg, '', true);
 
 		/*Do the GL trans for the payment DR creditors */
 
@@ -178,19 +131,8 @@ if (isset($_POST['PrintPDFAndProcess'])){
 					'" . mb_substr($SupplierID . ' - ' . $SupplierName . ' ' . _('payment run on') . ' ' . Date($_SESSION['DefaultDateFormat']) . ' - ' . $PaytReference, 0, 200) . "',
 					'" . ($AccumBalance/ filter_number_format($_POST['ExRate'])  + $AccumDiffOnExch) . "')";
 
-		$ProcessResult = DB_query($SQL,'','',false,false);
-		if (DB_error_no() !=0) {
-			$Title = _('Payment Processing - Problem Report');
-			include('header.php');
-			prnMsg(_('None of the payments will be processed since the general ledger posting for the payment to') . ' ' . $SupplierName . ' ' . _('could not be inserted because') . ' - ' . DB_error_msg(),'error');
-			echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-			if ($Debug==1){
-				prnMsg(_('The SQL that failed was') . ':<BR>' . $SQL,'error');
-			}
-			DB_Txn_Rollback();
-			include('footer.php');
-			exit();
-		}
+		$ErrMsg = _('None of the payments will be processed since the general ledger posting for the payment to') . ' ' . $SupplierName . ' ' . _('could not be inserted');
+		$ProcessResult = DB_query($SQL, $ErrMsg, '', true);
 
 		/*Do the GL trans for the exch diff */
 		if ($AccumDiffOnExch != 0){
@@ -208,20 +150,8 @@ if (isset($_POST['PrintPDFAndProcess'])){
 							'" . $_SESSION['CompanyRecord']['purchasesexchangediffact'] . "',
 							'" . mb_substr($SupplierID . ' - ' . $SupplierName . ' ' . _('payment run on') . ' ' . Date($_SESSION['DefaultDateFormat']) . " - " . $PaytReference, 0, 200) . "',
 							'" . (-$AccumDiffOnExch) . "')";
-
-			$ProcessResult = DB_query($SQL,'','',false,false);
-			if (DB_error_no() !=0) {
-				$Title = _('Payment Processing - Problem Report');
-				include('header.php');
-				prnMsg(_('None of the payments will be processed since the general ledger posting for the exchange difference on') . ' ' . $SupplierName . ' ' . _('could not be inserted because') .' - ' . DB_error_msg(),'error');
-				echo '<br /><a href="' . $RootPath . '/index.php">' . _('Back to the menu') . '</a>';
-				if ($Debug==1){
-					prnMsg(_('The SQL that failed was: ') . '<br />' . $SQL,'error');
-				}
-				DB_Txn_Rollback();
-				include('footer.php');
-				exit();
-			}
+			$ErrMsg = _('None of the payments will be processed since the general ledger posting for the exchange difference on') . ' ' . $SupplierName . ' ' . _('could not be inserted');
+			$ProcessResult = DB_query($SQL, $ErrMsg, '', true);
 		}
 		EnsureGLEntriesBalance(22,$SuppPaymentNo);
 	} /*end if GL linked to creditors */

--- a/includes/UserLogin.php
+++ b/includes/UserLogin.php
@@ -15,7 +15,6 @@ define('UL_MAINTENANCE', 5);
  */
 function userLogin($Name, $Password, $SysAdminEmail = '') {
 
-	global $Debug;
 	global $PathPrefix;
 
 	if (!isset($_SESSION['AccessLevel']) OR $_SESSION['AccessLevel'] == '' OR
@@ -43,7 +42,6 @@ function userLogin($Name, $Password, $SysAdminEmail = '') {
 				WHERE www_users.userid='" . $Name . "'";
 
 		$ErrMsg = _('Could not retrieve user details on login because');
-		$Debug = 1;
         $PasswordVerified = false;
 		$Auth_Result = DB_query($SQL, $ErrMsg);
 


### PR DESCRIPTION
 Managing error codes from DB should be done in DB_query() only for consistency.

Some $Debug == 1 were development style messages to verify the SQL, etc. They should not be in a production code. Seem like leftovers from development times.

Some DB_query() used the 5th parameter to false, forcing DB_query fucntion to not execute the error trapping, and executing the error trapping in the script. It produced repeated an inconsistent code. Now DB_query() always does the error trapping. 

Some error trapping in the code contained DB_Txn_Rollback(), even if called with the 4th parameter as false. Simplified to call to DB_query() with 4th parameter as true and let DB_query() handle the rollback properly.

Always Set the DB_query to use error trapping, not using the 5th parameter (default = true). DB_query() should always do the error trapping. Why would we don't want to know an unexpected error occurred? Should we delete the 5th parameter from DB_query()?

In SuppPaymentRun.php, line 190 there is a DB_Txn_Commit() and just after that, we check if (DB_error_no() !=0). 
I am not sure if it is an overkill, or we should really improve function DB_Txn_Commit() and take care of the errors it produces, not only in one random file. Code in SuppPaymentRun.php still not removed. 

R

P.S.: My first PR. Not entirely sure if it's done correctly or not ;-)

