### PR TITLE
Improve db-dump db script

### DIFF
--- a/build/make_release.sh
+++ b/build/make_release.sh
@@ -38,8 +38,8 @@ echo "Updating translation files..."
 
 echo "Cleaning up and dumping the database..."
 
-"$BASE_DIR/build/dump_database.sh" -d ./install/sql demo
-
+# @todo review the options used - should we not add -t -d ?
+"$BASE_DIR/build/dump_database.sh" -o ./install/sql demo
 
 echo "Creating the final tarball..."
 


### PR DESCRIPTION
It now allows great flexibility in the generation of the sql dumps - in case in the future anyone decides that the "best" format of the sql dump is to include schema-creation statements table-creation statements and/or table-drop statements.

It is also easier to use by the `make_release` script, as it can be told the directory where to save the created file(s), and whether to generate 1 or 2 files.

Last but not least, it tries harder to create a consistent database snapshot (in the unfortunate case anyone is using the db while the dump is being generated)