### PR TITLE
make start of web pages code more uninform, a-to-c

### DIFF
--- a/AccountGroups.php
+++ b/AccountGroups.php
@@ -1,15 +1,15 @@
 <?php
-/* AccountGroups.php
-Defines the groupings of general ledger accounts */
+
+/* Defines the groupings of general ledger accounts */
 
 include('includes/session.php');
+
 $Title = __('Account Groups');
 $ViewTopic = 'GeneralLedger';
 $BookMark = 'AccountGroups';
 include('includes/header.php');
 
 include('includes/SQL_CommonFunctions.php');
-
 
 function CheckForRecursiveGroup($ParentGroupName, $GroupName) {
 

--- a/AccountSections.php
+++ b/AccountSections.php
@@ -1,7 +1,9 @@
 <?php
+
 /* Defines the sections in the general ledger reports */
 
 include('includes/session.php');
+
 $Title = __('Account Sections');
 $ViewTopic = 'GeneralLedger';
 $BookMark = 'AccountSections';

--- a/AddCustomerContacts.php
+++ b/AddCustomerContacts.php
@@ -1,7 +1,9 @@
 <?php
+
 /* Adds customer contacts */
 
 include('includes/session.php');
+
 $Title = __('Customer Contacts');
 $ViewTopic = 'AccountsReceivable';
 $BookMark = 'AddCustomerContacts';

--- a/AddCustomerNotes.php
+++ b/AddCustomerNotes.php
@@ -1,12 +1,15 @@
 <?php
 
 include('includes/session.php');
-if (isset($_POST['NoteDate'])){$_POST['NoteDate'] = ConvertSQLDate($_POST['NoteDate']);}
+
 $Title = __('Customer Notes');
 $ViewTopic = 'AccountsReceivable';
 $BookMark = 'CustomerNotes';
 include('includes/header.php');
+
 include('includes/SQL_CommonFunctions.php');
+
+if (isset($_POST['NoteDate'])){$_POST['NoteDate'] = ConvertSQLDate($_POST['NoteDate']);}
 
 if (isset($_GET['Id'])){
 	$Id = (int)$_GET['Id'];

--- a/AddCustomerTypeNotes.php
+++ b/AddCustomerTypeNotes.php
@@ -1,10 +1,12 @@
 <?php
 
 include('includes/session.php');
+
 $Title = __('Customer Type (Group) Notes');
 $ViewTopic = 'AccountsReceivable';
 $BookMark = 'CustomerTypeNotes';
 include('includes/header.php');
+
 include('includes/SQL_CommonFunctions.php');
 
 if (isset($_POST['NoteDate'])) {$_POST['NoteDate'] = ConvertSQLDate($_POST['NoteDate']);}

--- a/AgedControlledInventory.php
+++ b/AgedControlledInventory.php
@@ -1,13 +1,13 @@
 <?php
 
 include('includes/session.php');
-$PricesSecurity = 12;//don't show pricing info unless security token 12 available to user
+
+$PricesSecurity = 12; // don't show pricing info unless security token 12 available to user
 
 $Today =  time();
 $Title = __('Aged Controlled Inventory') . ' ' . __('as-of') . ' ' . Date(($_SESSION['DefaultDateFormat']), $Today);
 $ViewTopic = 'Inventory';
 $BookMark = 'AgedControlled';
-
 include('includes/header.php');
 
 echo '<p class="page_title_text">

--- a/AgedDebtors.php
+++ b/AgedDebtors.php
@@ -1,7 +1,9 @@
 <?php
- /* Lists customer account balances in detail or summary in selected currency */
+
+/* Lists customer account balances in detail or summary in selected currency */
 
 include('includes/session.php');
+
 use Dompdf\Dompdf;
 
 if(isset($_POST['PrintPDF']) or isset($_POST['View'])

--- a/AgedSuppliers.php
+++ b/AgedSuppliers.php
@@ -1,7 +1,9 @@
 <?php
 
 include('includes/session.php');
+
 use Dompdf\Dompdf;
+
 $ViewTopic = 'AccountsPayable';
 $BookMark = 'AgedCreditors';
 

--- a/AnalysisHorizontalIncome.php
+++ b/AnalysisHorizontalIncome.php
@@ -1,5 +1,6 @@
 <?php
-/* AnalysisHorizontalIncome.php
+
+/*
 Shows the horizontal analysis of the statement of comprehensive income.
 
 Parameters:

--- a/AnalysisHorizontalPosition.php
+++ b/AnalysisHorizontalPosition.php
@@ -1,5 +1,6 @@
 <?php
-/* AnalysisHorizontalPosition.php
+
+/*
 Shows the horizontal analysis of the statement of financial position.
 
 Parameters:
@@ -19,11 +20,12 @@ Parameters:
 
 // BEGIN: Procedure division ===================================================
 include('includes/session.php');
+
 $Title = __('Horizontal Analysis of Statement of Financial Position');
 $ViewTopic = 'GeneralLedger';
 $BookMark = 'AnalysisHorizontalPosition';
-
 include('includes/header.php');
+
 include('includes/GLFunctions.php');
 
 // Merges gets into posts:

--- a/Areas.php
+++ b/Areas.php
@@ -13,9 +13,6 @@ if (isset($_GET['SelectedArea'])){
 	$SelectedArea = mb_strtoupper($_POST['SelectedArea']);
 }
 
-if (isset($Errors)) {
-	unset($Errors);
-}
 $Errors = array();
 
 if (isset($_POST['submit'])) {

--- a/AuditTrail.php
+++ b/AuditTrail.php
@@ -2,14 +2,13 @@
 
 include('includes/session.php');
 
-if (isset($_POST['FromDate'])){$_POST['FromDate'] = ConvertSQLDate($_POST['FromDate']);}
-if (isset($_POST['ToDate'])){$_POST['ToDate'] = ConvertSQLDate($_POST['ToDate']);}
-
 $Title = __('Audit Trail');
 $ViewTopic = 'Setup';
 $BookMark = 'AuditTrail';
-
 include('includes/header.php');
+
+if (isset($_POST['FromDate'])){$_POST['FromDate'] = ConvertSQLDate($_POST['FromDate']);}
+if (isset($_POST['ToDate'])){$_POST['ToDate'] = ConvertSQLDate($_POST['ToDate']);}
 
 echo '<p class="page_title_text"><img src="'.$RootPath.'/css/'.$Theme.'/images/maintenance.png" title="' . __('Search') . '" alt="" />' . ' ' . $Title . '</p>';
 

--- a/AutomaticTranslationDescriptions.php
+++ b/AutomaticTranslationDescriptions.php
@@ -1,12 +1,13 @@
 <?php
 
 include('includes/session.php');
+
 $Title = __('Translate Item Descriptions');
 $ViewTopic = 'SpecialUtilities'; // Filename in ManualContents.php's TOC.
 $BookMark = 'Z_TranslateItemDescriptions'; // Anchor's id in the manual's html document.
 include('includes/header.php');
 
-if (!function_exists("curl_init")){
+if (!function_exists("curl_init")) {
 	prnMsg("This script requires that the PHP curl module be available to use the Google API. Unfortunately this installation does not have the curl module available","error");
 	include('includes/footer.php');
 	exit();

--- a/BOMExtendedQty.php
+++ b/BOMExtendedQty.php
@@ -1,8 +1,9 @@
 <?php
 
-// BOMExtendedQty.php - Quantity Extended Bill of Materials
+// Quantity Extended Bill of Materials
 
 include('includes/session.php');
+
 use Dompdf\Dompdf;
 
 if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {

--- a/BOMIndented.php
+++ b/BOMIndented.php
@@ -1,9 +1,9 @@
 <?php
+
 /* Shows the bill of material indented for each level */
 
-// BOMIndented.php - Indented Bill of Materials
-
 include('includes/session.php');
+
 use Dompdf\Dompdf;
 
 if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {

--- a/BOMIndentedReverse.php
+++ b/BOMIndentedReverse.php
@@ -1,9 +1,9 @@
 <?php
 
-// BOMIndented.php - Reverse Indented Bill of Materials - From lowest level component to top level
-// assembly
+// Reverse Indented Bill of Materials - From lowest level component to top level assembly
 
 include('includes/session.php');
+
 use Dompdf\Dompdf;
 
 if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {

--- a/BOMInquiry.php
+++ b/BOMInquiry.php
@@ -1,11 +1,10 @@
 <?php
 
 include('includes/session.php');
-$Title = __('Costed Bill Of Material');
 
+$Title = __('Costed Bill Of Material');
 $ViewTopic = 'Manufacturing';
 $BookMark = '';
-
 include('includes/header.php');
 
 if (isset($_GET['StockID'])){

--- a/BOMs.php
+++ b/BOMs.php
@@ -2,15 +2,15 @@
 
 include('includes/session.php');
 
-if (isset($_POST['EffectiveAfter'])){$_POST['EffectiveAfter'] = ConvertSQLDate($_POST['EffectiveAfter']);}
-if (isset($_POST['EffectiveTo'])){$_POST['EffectiveTo'] = ConvertSQLDate($_POST['EffectiveTo']);}
-
 $Title = __('Multi-Level Bill Of Materials Maintenance');
 $ViewTopic = 'Inventory';
 $BookMark = 'BOMMaintenance';
-
 include('includes/header.php');
+
 include('includes/SQL_CommonFunctions.php');
+
+if (isset($_POST['EffectiveAfter'])){$_POST['EffectiveAfter'] = ConvertSQLDate($_POST['EffectiveAfter']);}
+if (isset($_POST['EffectiveTo'])){$_POST['EffectiveTo'] = ConvertSQLDate($_POST['EffectiveTo']);}
 
 function display_children($Parent, $Level, &$BOMTree) {
 	global $i;

--- a/BOMs_SingleLevel.php
+++ b/BOMs_SingleLevel.php
@@ -3,11 +3,10 @@
 include('includes/session.php');
 
 $Title = __('Bill Of Materials Maintenance');
-
 $ViewTopic = 'Manufacturing';
 $BookMark = '';
-
 include('includes/header.php');
+
 include('includes/SQL_CommonFunctions.php');
 
 function display_children($Parent, $Level, &$BOMTree) {

--- a/BackupDatabase.php
+++ b/BackupDatabase.php
@@ -2,10 +2,10 @@
 
 $PageSecurity = 15; //hard coded in case database is old and PageSecurity stuff cannot be retrieved
 
+include('includes/session.php');
+
 $ViewTopic = 'Setup';
 $BookMark = '';
-
-include('includes/session.php');
 $Title = __('Backup webERP Database');
 include('includes/header.php');
 

--- a/BankAccountBalances.php
+++ b/BankAccountBalances.php
@@ -1,8 +1,9 @@
 <?php
-// BankAccountBalances.php
+
 // Shows bank accounts authorised for with balances
 
 include('includes/session.php');
+
 $Title = __('List of bank account balances');
 $ViewTopic = 'GeneralLedger';
 $BookMark = 'BankAccountBalances';

--- a/BankAccountUsers.php
+++ b/BankAccountUsers.php
@@ -1,8 +1,9 @@
 <?php
-// BankAccountUsers.php
+
 // Maintains table bankaccountusers (Authorized users to work with a bank account in webERP).
 
 include('includes/session.php');
+
 $Title = __('Bank Account Users');
 $ViewTopic = 'GeneralLedger';
 $BookMark = 'BankAccountUsers';

--- a/BankAccounts.php
+++ b/BankAccounts.php
@@ -1,12 +1,14 @@
 <?php
-// BankAccounts.php
+
 // This script defines the general ledger code for bank accounts and specifies that bank transactions be created for these accounts for the purposes of reconciliation.
 
 include('includes/session.php');
+
 $Title = __('Bank Accounts');// Screen identificator.
 $ViewTopic = 'GeneralLedger';// Filename's id in ManualContents.php's TOC.
 $BookMark = 'BankAccounts';// Anchor's id in the manual's html document.
 include('includes/header.php');
+
 echo '<p class="page_title_text"><img alt="" src="'.$RootPath.'/css/'.$Theme.
 	'/images/bank.png" title="' .
 	__('Bank') . '" /> ' .// Icon title.

--- a/BankMatching.php
+++ b/BankMatching.php
@@ -1,15 +1,16 @@
 <?php
-// BankMatching.php
+
 // Allows payments and receipts to be matched off against bank statements.
 
 include('includes/session.php');
-if (isset($_POST['AfterDate'])){$_POST['AfterDate'] = ConvertSQLDate($_POST['AfterDate']);}
-if (isset($_POST['BeforeDate'])){$_POST['BeforeDate'] = ConvertSQLDate($_POST['BeforeDate']);}
+
 $Title = __('Bank Matching');
 $ViewTopic = 'GeneralLedger';
 $BookMark = 'BankMatching';
-
 include('includes/header.php');
+
+if (isset($_POST['AfterDate'])){$_POST['AfterDate'] = ConvertSQLDate($_POST['AfterDate']);}
+if (isset($_POST['BeforeDate'])){$_POST['BeforeDate'] = ConvertSQLDate($_POST['BeforeDate']);}
 
 if ((isset($_GET['Type']) AND $_GET['Type']=='Receipts')
 		OR (isset($_POST['Type']) AND $_POST['Type']=='Receipts')) {

--- a/BankReconciliation.php
+++ b/BankReconciliation.php
@@ -1,13 +1,14 @@
 <?php
-// BankReconciliation.php
+
 // Displays the bank reconciliation for a selected bank account.
 
 include('includes/session.php');
+
 $Title = __('Bank Reconciliation');
 $ViewTopic = 'GeneralLedger';
 $BookMark = 'BankAccounts';
-
 include('includes/header.php');
+
 include('includes/GLFunctions.php');
 
 echo '<form method="post" action="' . htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8') . '">';

--- a/COGSGLPostings.php
+++ b/COGSGLPostings.php
@@ -1,7 +1,9 @@
 <?php
+
 /* Defines the general ledger account to be used for cost of sales entries */
 
 include('includes/session.php');
+
 $Title = __('Cost Of Sales GL Postings Set Up');
 $ViewTopic = 'CreatingNewSystem';
 $BookMark = 'COGSGLPostings';

--- a/CollectiveWorkOrderCost.php
+++ b/CollectiveWorkOrderCost.php
@@ -1,15 +1,16 @@
 <?php
+
 /* Multiple work orders cost review */
 
 include('includes/session.php');
-
-if (isset($_POST['DateFrom'])){$_POST['DateFrom'] = ConvertSQLDate($_POST['DateFrom']);}
-if (isset($_POST['DateTo'])){$_POST['DateTo'] = ConvertSQLDate($_POST['DateTo']);}
 
 $Title = __('Search Work Orders');
 $ViewTopic = 'Manufacturing';
 $BookMark = '';
 include('includes/header.php');
+
+if (isset($_POST['DateFrom'])){$_POST['DateFrom'] = ConvertSQLDate($_POST['DateFrom']);}
+if (isset($_POST['DateTo'])){$_POST['DateTo'] = ConvertSQLDate($_POST['DateTo']);}
 
 echo '<p class="page_title_text"><img alt="" src="', $RootPath, '/css/', $Theme,
 	'/images/magnifier.png" title="', // Icon image.

--- a/CompanyPreferences.php
+++ b/CompanyPreferences.php
@@ -1,21 +1,18 @@
 <?php
-// CompanyPreferences.php
+
 // Defines the settings applicable for the company, including name, address, tax authority reference, whether GL integration used etc.
 
 include('includes/session.php');
+
 $ViewTopic = 'CreatingNewSystem';
 $BookMark = 'CompanyParameters';
 $Title = __('Company Preferences');
 include('includes/header.php');
 
-if (isset($Errors)) {
-	unset($Errors);
-}
-
-//initialise no input errors assumed initially before we test
+// initialise no input errors assumed initially before we test
 $InputError = 0;
 $Errors = array();
-$i=1;
+$i = 1;
 
 if (isset($_POST['submit'])) {
 

--- a/ConfirmDispatchControlled_Invoice.php
+++ b/ConfirmDispatchControlled_Invoice.php
@@ -1,16 +1,15 @@
 <?php
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineCartClass.php');
 include('includes/DefineSerialItems.php');
-include('includes/session.php');
-$Title = __('Specify Dispatched Controlled Items');
 
+include('includes/session.php');
+
+$Title = __('Specify Dispatched Controlled Items');
 $ViewTopic = 'ARTransactions';
 $BookMark = 'ConfirmInvoice';
-
-/* Session started in header.php for password checking and authorisation level check */
 include('includes/header.php');
-
 
 if (empty($_GET['identifier'])) {
 	/*unique session identifier to ensure that there is no conflict with other order entry sessions on the same machine  */

--- a/ConfirmDispatch_Invoice.php
+++ b/ConfirmDispatch_Invoice.php
@@ -1,10 +1,13 @@
 <?php
+
 /* Creates sales invoices from entered sales orders based on the quantities dispatched that can be modified */
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineCartClass.php');
 include('includes/DefineSerialItems.php');
 
 include('includes/session.php');
+
 $Title = __('Confirm Dispatches and Invoice An Order');
 $ViewTopic = 'ARTransactions';
 $BookMark = 'ConfirmInvoice';

--- a/ContractBOM.php
+++ b/ContractBOM.php
@@ -1,8 +1,10 @@
 <?php
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineContractClass.php');
 
 include('includes/session.php');
+
 include('includes/ImageFunctions.php');
 
 $identifier = $_GET['identifier'];
@@ -10,7 +12,6 @@ $identifier = $_GET['identifier'];
 /* If a contract header doesn't exist, then go to
  * Contracts.php to create one
  */
-
 if (!isset($_SESSION['Contract'.$identifier])){
 	header('Location:' . htmlspecialchars_decode($RootPath) . '/Contracts.php');
 	exit();
@@ -19,7 +20,6 @@ if (!isset($_SESSION['Contract'.$identifier])){
 $Title = __('Contract Bill of Materials');
 $ViewTopic = 'Contracts';
 $BookMark = 'AddToContract';
-
 include('includes/header.php');
 
 if (isset($_POST['UpdateLines']) OR isset($_POST['BackToHeader'])) {

--- a/ContractCosting.php
+++ b/ContractCosting.php
@@ -1,12 +1,13 @@
 <?php
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineContractClass.php');
-include('includes/session.php');
-$Title = __('Contract Costing');
 
+include('includes/session.php');
+
+$Title = __('Contract Costing');
 $ViewTopic = 'Contracts';
 $BookMark = 'ContractCosting';
-/* Session started in header.php for password checking and authorisation level check */
 include('includes/header.php');
 
 if (empty($_GET['identifier'])) {

--- a/ContractOtherReqts.php
+++ b/ContractOtherReqts.php
@@ -1,5 +1,6 @@
 <?php
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineContractClass.php');
 
 include('includes/session.php');
@@ -9,7 +10,6 @@ $identifier = $_GET['identifier'];
 /* If a contract header doesn't exist, then go to
  * Contracts.php to create one
  */
-
 if (!isset($_SESSION['Contract'.$identifier])){
 	header('Location:' . htmlspecialchars_decode($RootPath) . '/Contracts.php');
 	exit();
@@ -18,7 +18,6 @@ if (!isset($_SESSION['Contract'.$identifier])){
 $Title = __('Contract Other Requirements');
 $ViewTopic = 'Contracts';
 $BookMark = 'AddToContract';
-
 include('includes/header.php');
 
 if (isset($_POST['UpdateLines']) OR isset($_POST['BackToHeader'])) {

--- a/Contracts.php
+++ b/Contracts.php
@@ -1,7 +1,10 @@
 <?php
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineContractClass.php');
+
 include('includes/session.php');
+
 if (isset($_POST['RequiredDate'])){$_POST['RequiredDate'] = ConvertSQLDate($_POST['RequiredDate']);}
 
 if (isset($_GET['ModifyContractNo'])) {
@@ -21,10 +24,11 @@ foreach ($_POST as $FormVariableName=>$FormVariableValue) {
 		$_POST['SelectedBranch']=$_POST['SelectedBranch'.$Index];
 	}
 }
+
 $ViewTopic = 'Contracts';
 $BookMark = 'CreateContract';
-
 include('includes/header.php');
+
 include('includes/SQL_CommonFunctions.php');
 
 /*If the page is called is called without an identifier being set then

--- a/CopyBOM.php
+++ b/CopyBOM.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Author: Ashish Shukla <gmail.com!wahjava>
  *

--- a/CounterReturns.php
+++ b/CounterReturns.php
@@ -2,9 +2,11 @@
 
 // This script allows credits and refunds from the default Counter Sale account for an inventory location.
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineCartClass.php');
 
 include('includes/session.php');
+
 $Title = __('Counter Returns');
 $ViewTopic = 'SalesOrders';
 $BookMark = 'CounterReturns';

--- a/CounterSales.php
+++ b/CounterSales.php
@@ -2,14 +2,16 @@
 
 // Allows sales to be entered against a cash sale customer account defined in the users location record.
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineCartClass.php');
 
 include('includes/session.php');
+
 $Title = __('Counter Sales');
 $ViewTopic = 'SalesOrders';
 $BookMark = 'SalesOrderCounterSales';
-
 include('includes/header.php');
+
 include('includes/GetPrice.php');
 include('includes/SQL_CommonFunctions.php');
 include('includes/StockFunctions.php');

--- a/CreditItemsControlled.php
+++ b/CreditItemsControlled.php
@@ -1,17 +1,15 @@
 <?php
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineCartClass.php');
 include('includes/DefineSerialItems.php');
+
 include('includes/session.php');
 
 $ViewTopic = 'ARTransactions';
 $BookMark = 'CreditNotes';
-
 $Title = __('Specify Credited Controlled Items');
-
-/* Session started in header.php for password checking and authorisation level check */
 include('includes/header.php');
-
 
 if ($_GET['CreditInvoice']=='Yes' OR $_POST['CreditInvoice']=='Yes'){
 	$CreditLink = 'Credit_Invoice.php';

--- a/CreditStatus.php
+++ b/CreditStatus.php
@@ -1,6 +1,7 @@
 <?php
 
 include('includes/session.php');
+
 $Title = __('Credit Status Code Maintenance');
 $ViewTopic = 'CreditStatus';
 $BookMark = 'CreditStatus';
@@ -12,9 +13,6 @@ if (isset($_GET['SelectedReason'])){
 	$SelectedReason = $_POST['SelectedReason'];
 }
 
-if (isset($Errors)) {
-	unset($Errors);
-}
 $Errors = array();
 $InputError = 0;
 echo '<p class="page_title_text">

--- a/Credit_Invoice.php
+++ b/Credit_Invoice.php
@@ -1,16 +1,19 @@
 <?php
-/*Functions to get the GL codes to post the transaction to */
+
+/// @todo move to after session.php inclusion, unless there are side effects
+/* Functions to get the GL codes to post the transaction to */
 include('includes/GetSalesTransGLCodes.php');
-/*defines the structure of the data required to hold the transaction as a session variable */
+/* defines the structure of the data required to hold the transaction as a session variable */
 include('includes/DefineCartClass.php');
 include('includes/DefineSerialItems.php');
-/* Session started in header.php for password checking and authorisation level check */
+
 include('includes/session.php');
+
 $ViewTopic = 'ARTransactions';
 $BookMark = 'CreditNotes';
-
 $Title = __('Credit An Invoice');
 include('includes/header.php');
+
 include('includes/SQL_CommonFunctions.php');
 include('includes/CommissionFunctions.php');
 

--- a/Currencies.php
+++ b/Currencies.php
@@ -1,11 +1,12 @@
 <?php
-//	Currencies.php
+
 //	Defines the currencies available. Each customer and supplier must be defined as transacting in one of the currencies defined here.
 /*
 	The country field is unneeded because the country_code is included inside the currency_code (firsts two letters).
 */
 
 include('includes/session.php');
+
 $ViewTopic = 'Setup';
 $BookMark = 'Currencies';
 $Title = __('Currencies Maintenance');

--- a/CustEDISetup.php
+++ b/CustEDISetup.php
@@ -1,6 +1,7 @@
 <?php
 
 include('includes/session.php');
+
 $ViewTopic = 'EDI';// Filename in ManualContents.php's TOC.
 $BookMark = '';// Anchor's id in the manual's html document.
 $Title = __('Customer EDI Set Up');

--- a/CustItem.php
+++ b/CustItem.php
@@ -4,9 +4,7 @@ include('includes/session.php');
 
 $ViewTopic = 'AccountsReceivable';// Filename in ManualContents.php's TOC.
 $BookMark = '';// Anchor's id in the manual's html document.
-
 $Title = __('Customer Item Data');
-
 include('includes/header.php');
 
 if (isset($_GET['DebtorNo'])) {

--- a/CustLoginSetup.php
+++ b/CustLoginSetup.php
@@ -1,13 +1,14 @@
 <?php
 
 include('includes/session.php');
+
 $Title = __('Customer Login Configuration');
 $ViewTopic = 'Setup';// Filename in ManualContents.php's TOC.
 $BookMark = '';// Anchor's id in the manual's html document.
 include('includes/header.php');
-include('includes/SQL_CommonFunctions.php');
-include('includes/LanguagesArray.php');
 
+include('includes/SQL_CommonFunctions.php');
+//include('includes/LanguagesArray.php');
 
 if (!isset($_SESSION['CustomerID'])){
 	echo '<br />

--- a/CustWhereAlloc.php
+++ b/CustWhereAlloc.php
@@ -1,7 +1,9 @@
 <?php
+
 /* Shows to which invoices a receipt was allocated to */
 
 include('includes/session.php');
+
 $Title = __('Customer How Paid Inquiry');
 $ViewTopic = 'ARInquiries';
 $BookMark = 'WhereAllocated';

--- a/CustomerAccount.php
+++ b/CustomerAccount.php
@@ -1,13 +1,15 @@
 <?php
+
 /* Shows customer account/statement on screen rather than PDF. */
 
 include('includes/session.php');
-if (isset($_POST['TransAfterDate'])) {$_POST['TransAfterDate'] = ConvertSQLDate($_POST['TransAfterDate']);}
 
 $Title = __('Customer Account');// Screen identification.
 $ViewTopic = 'ARInquiries';// Filename in ManualContents.php's TOC.
 $BookMark = 'CustomerAccount';// Anchor's id in the manual's html document.
 include('includes/header.php');
+
+if (isset($_POST['TransAfterDate'])) {$_POST['TransAfterDate'] = ConvertSQLDate($_POST['TransAfterDate']);}
 
 // always figure out the SQL required from the inputs available
 

--- a/CustomerAllocations.php
+++ b/CustomerAllocations.php
@@ -1,13 +1,16 @@
 <?php
+
 /*	Call this page with:
 	1. A TransID to show the make up and to modify existing allocations.
 	2. A DebtorNo to show all outstanding receipts or credits yet to be allocated.
 	3. No parameters to show all outstanding credits and receipts yet to be allocated.
 */
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineCustAllocsClass.php');// Before includes/session.php *******
 
 include('includes/session.php');
+
 $Title = __('Customer Receipt') . '/' . __('Credit Note Allocations');
 $ViewTopic = 'ARTransactions';
 $BookMark = 'CustomerAllocations';

--- a/CustomerBalancesMovement.php
+++ b/CustomerBalancesMovement.php
@@ -5,7 +5,7 @@ include('includes/session.php');
 if (isset($_POST['FromDate'])){$_POST['FromDate'] = ConvertSQLDate($_POST['FromDate']);}
 if (isset($_POST['ToDate'])){$_POST['ToDate'] = ConvertSQLDate($_POST['ToDate']);}
 
-$Title=__('Customer Activity and Balances');
+$Title = __('Customer Activity and Balances');
 /*To do: Info in the manual. RChacon.*/
 $ViewTopic = 'ARInquiries';
 $BookMark = '';

--- a/CustomerBranches.php
+++ b/CustomerBranches.php
@@ -2,10 +2,12 @@
 /* Defines the details of customer branches such as delivery address and contact details - also sales area, representative etc.*/
 
 include('includes/session.php');
+
 $Title = __('Customer Branches');// Screen identification.
 $ViewTopic = 'AccountsReceivable';// Filename's id in ManualContents.php's TOC.
 $BookMark = 'NewCustomerBranch';// Anchor's id in the manual's html document.
 include('includes/header.php');
+
 include('includes/CountriesArray.php');
 
 if (isset($_GET['DebtorNo'])) {

--- a/CustomerInquiry.php
+++ b/CustomerInquiry.php
@@ -1,12 +1,15 @@
 <?php
+
 /* Shows the customers account transactions with balances outstanding, links available to drill down to invoice/credit note or email invoices/credit notes. */
 
 include('includes/session.php');
-if (isset($_POST['TransAfterDate'])){$_POST['TransAfterDate'] = ConvertSQLDate($_POST['TransAfterDate']);}
+
 $Title = __('Customer Inquiry');// Screen identification.
 $ViewTopic = 'ARInquiries';// Filename's id in ManualContents.php's TOC.
 $BookMark = 'CustomerInquiry';// Anchor's id in the manual's html document.
 include('includes/header.php');
+
+if (isset($_POST['TransAfterDate'])){$_POST['TransAfterDate'] = ConvertSQLDate($_POST['TransAfterDate']);}
 
 // always figure out the SQL required from the inputs available
 

--- a/CustomerPurchases.php
+++ b/CustomerPurchases.php
@@ -1,10 +1,12 @@
 <?php
+
 /* This script is to view the items purchased by a customer. */
 
 include('includes/session.php');
+
 $Title = __('Customer Purchases');// Screen identificator.
 $ViewTopic = 'ARInquiries';// Filename's id in ManualContents.php's TOC.
-/* This help needs to be writing...
+/* This help needs to be written...
 $BookMark = 'CustomerPurchases';// Anchor's id in the manual's html document.*/
 include('includes/header.php');
 

--- a/CustomerReceipt.php
+++ b/CustomerReceipt.php
@@ -1,7 +1,10 @@
 <?php
+
 /* Entry of both customer receipts against accounts receivable and also general ledger or nominal receipts */
 
+/// @todo move to after session.php inclusion, unless there are side effects
 include('includes/DefineReceiptClass.php');
+
 include('includes/session.php');
 
 if (isset($_POST['DateBanked'])) {
@@ -21,6 +24,7 @@ if ($_GET['Type']=='GL') {
 }
 
 include('includes/header.php');
+
 include('includes/SQL_CommonFunctions.php');
 include('includes/GLFunctions.php');
 

--- a/CustomerTransInquiry.php
+++ b/CustomerTransInquiry.php
@@ -1,14 +1,14 @@
 <?php
-// CustomerTransInquiry.php
 
 include('includes/session.php');
-if (isset($_POST['FromDate'])){$_POST['FromDate'] = ConvertSQLDate($_POST['FromDate']);}
-if (isset($_POST['ToDate'])){$_POST['ToDate'] = ConvertSQLDate($_POST['ToDate']);}
 
 $Title = __('Customer Transactions Inquiry');
 $ViewTopic = 'ARInquiries';
 $BookMark = 'ARTransInquiry';
 include('includes/header.php');
+
+if (isset($_POST['FromDate'])){$_POST['FromDate'] = ConvertSQLDate($_POST['FromDate']);}
+if (isset($_POST['ToDate'])){$_POST['ToDate'] = ConvertSQLDate($_POST['ToDate']);}
 
 echo '<p class="page_title_text">
 		<img src="'.$RootPath.'/css/'.$Theme.'/images/transactions.png" title="' . __('Transaction Inquiry') . '" alt="" />' . ' ' . __('Transaction Inquiry') . '

--- a/CustomerTypes.php
+++ b/CustomerTypes.php
@@ -1,6 +1,7 @@
 <?php
 
 include('includes/session.php');
+
 $Title = __('Customer Types') . ' / ' . __('Maintenance');
 $ViewTopic = 'Setup';
 $BookMark = 'CustomerTypes';
@@ -10,10 +11,6 @@ if (isset($_POST['SelectedType'])){
 	$SelectedType = mb_strtoupper($_POST['SelectedType']);
 } elseif (isset($_GET['SelectedType'])){
 	$SelectedType = mb_strtoupper($_GET['SelectedType']);
-}
-
-if (isset($Errors)) {
-	unset($Errors);
 }
 
 $Errors = array();

--- a/Customers.php
+++ b/Customers.php
@@ -1,6 +1,7 @@
 <?php
 
 include('includes/session.php');
+
 include('includes/CurrenciesArray.php'); // To get the currency name from the currency code.
 if (isset($_POST['ClientSince'])){$_POST['ClientSince'] = ConvertSQLDate($_POST['ClientSince']);}
 
@@ -17,6 +18,7 @@ $Title = __('Customer Maintenance');
 $ViewTopic = 'AccountsReceivable';
 $BookMark = 'NewCustomer';
 include('includes/header.php');
+
 include('includes/SQL_CommonFunctions.php');
 include('includes/CountriesArray.php');
 


### PR DESCRIPTION
This is kind of a prerequisite to finalising the work on using $PathPrefix everywhere for 'include' calls.

It is similar to the PR which added 'global' statemenet everywhere, without the 'global' lines.

What it does:
- making whitespace more uniform
- pushing inclusion of 'session.php' to the top, if there is visibly no side effect
- push manipulation of $_POST to below display of header, if there is visibly no side effect
- remove useless `unset` calls (those where the unset var is re-defined immediately afterwards)