### PR TITLE
remove comments which split php scripts in function/procedure divisions

### DIFF
--- a/AnalysisHorizontalIncome.php
+++ b/AnalysisHorizontalIncome.php
@@ -18,7 +18,6 @@ Parameters:
 	IsIncluded: Parameter to indicate that a script is included within another.
 */
 
-// BEGIN: Procedure division ===================================================
 require(__DIR__ . '/includes/session.php');
 
 $Title = __('Horizontal Analysis of Statement of Comprehensive Income');

--- a/AnalysisHorizontalPosition.php
+++ b/AnalysisHorizontalPosition.php
@@ -18,7 +18,6 @@ Parameters:
 	IsIncluded: Parameter to indicate that a script is included within another.
 */
 
-// BEGIN: Procedure division ===================================================
 require(__DIR__ . '/includes/session.php');
 
 $Title = __('Horizontal Analysis of Statement of Financial Position');

--- a/FormDesigner.php
+++ b/FormDesigner.php
@@ -28,33 +28,37 @@ echo '<p class="page_title_text"><img alt="" src="', $RootPath, '/css/', $Theme,
 __('Form Designer'), '" /> ', // Icon title.
 __('Form Designer'), '</p>'; // Page title.
 
-// BEGIN: Functions division ---------------------------------------------------
 function InputX($keyName, $keyValue) {
 	// Function to input the X coordinate from the left side of the sheet to the left side of the field in points (72 points = 25,4 mm).
 	echo '<td class="number"><label for="', $keyName, 'x">', __('x'), ' = </label></td>', '<td><input class="number" id="', $keyName, 'x" maxlength="4" name="', $keyName, 'x" size="4" title="', __('Distance from the left side of the sheet to the left side of the element in points'), '" type="number" value="', $keyValue, '" /></td>';
 }
+
 function InputY($keyName, $keyValue) {
 	// Function to input the Y coordinate from the lower side of the sheet to the top side of the field in points (72 points = 25,4 mm).
 	echo '<td class="number"><label for="', $keyName, 'y">', __('y'), ' = </label></td>', '<td><input class="number" id="', $keyName, 'y" maxlength="4" name="', $keyName, 'y" size="4" title="', __('Distance from the lower side of the sheet to the top side of the element in points'), '" type="number" value="', $keyValue, '" /></td>';
 }
+
 function InputLength($keyName, $keyValue) {
 	// Function to input the the Length of the field in points (72 points = 25,4 mm).
 	echo '<td class="number"><label for="', $keyName, 'Length">', __('Width'), ' = </label></td>', '<td><input class="number" id="', $keyName, 'Length" maxlength="4" name="', $keyName, 'Length" size="4" title="', __('Width of the element in points'), '" type="number" value="', $keyValue, '" /></td>';
 	// Requires to standardize xml files from "Length" to "Width" before changing the xml name.**********
 
 }
+
 function InputWidth($keyName, $keyValue) {
 	// Function to input the the width of the field in points (72 points = 25,4 mm).
 	echo '<td class="number"><label for="', $keyName, 'width">', __('Width'), ' = </label></td>', '<td><input class="number" id="', $keyName, 'width" maxlength="4" name="', $keyName, 'width" size="4" title="', __('Width of the element in points'), '" type="number" value="', $keyValue, '" /></td>';
 	// Requires to standardize xml files from "width" to "Width" before changing the xml name.**********
 
 }
+
 function InputHeight($keyName, $keyValue) {
 	// Function to input the the height of the field in points (72 points = 25,4 mm).
 	echo '<td class="number"><label for="', $keyName, 'height">', __('Height'), ' = </label></td>', '<td><input class="number" id="', $keyName, 'height" maxlength="4" name="', $keyName, 'height" size="4" title="', __('Height of the element in points'), '" type="number" value="', $keyValue, '" /></td>';
 	// Requires to standardize xml files from "height" to "Height" before changing the xml name.**********
 
 }
+
 function SelectAlignment($keyName, $keyValue) {
 	// Function to select a text alignment.
 	$Alignments = array(); // Possible alignments
@@ -76,10 +80,12 @@ function SelectAlignment($keyName, $keyValue) {
 	}
 	echo '</select></td>';
 }
+
 function InputFontSize($keyName, $keyValue) {
 	// Function to select a text font size.
 	echo '<td class="number"><label for="', $keyName, 'FontSize">', __('Font Size'), ' = </label></td>', '<td><input class="number" id="', $keyName, 'FontSize" maxlength="4" name="', $keyName, 'FontSize" size="4" title="', __('Font size in points'), '" type="number" value="', $keyValue, '" /></td>';
 }
+
 function SelectShowElement($keyName, $keyValue) {
 	// Function to select to show or not an element.
 	$Shows = array(); // Possible alignments
@@ -97,15 +103,9 @@ function SelectShowElement($keyName, $keyValue) {
 	}
 	echo '</select></td>';
 }
-// END: Functions division -----------------------------------------------------
 
-
-// BEGIN: Data division --------------------------------------------------------
 $PaperSizes = array('A3_Portrait', 'A3_Landscape', 'A4_Portrait', 'A4_Landscape', 'A5_Portrait', 'A5_Landscape', 'A6_Portrait', 'A6_Landscape', 'Legal_Portrait', 'Legal_Landscape', 'Letter_Portrait', 'Letter_Landscape'); // Possible paper sizes and orientations.
-// END: Data division ----------------------------------------------------------
 
-
-// BEGIN: Procedure division ---------------------------------------------------
 /* If the user has chosen to either preview the form, or
  * save it then we first have to get the POST values into a
  * simplexml object and then save the file as either a
@@ -351,7 +351,5 @@ echo '</div>
 '</div>';
 
 echo '</div>', '</form>';
-// END: Procedure division ----------------------------------------------------
-
 
 include('includes/footer.php');

--- a/GLAccounts.php
+++ b/GLAccounts.php
@@ -3,7 +3,6 @@
 /* Defines the general ledger accounts */
 /* To delete, insert, or update an account. */
 
-// BEGIN: Functions division ---------------------------------------------------
 function CashFlowsActivityName($Activity) {
 	// Converts the cash flow activity number to an activity text.
 	switch($Activity) {
@@ -16,9 +15,7 @@ function CashFlowsActivityName($Activity) {
 		default: return '<b>' . __('Unknown') . '</b>';
 	}
 }
-// END: Functions division -----------------------------------------------------
 
-// BEGIN: Procedure division ---------------------------------------------------
 require(__DIR__ . '/includes/session.php');
 
 $Title = __('General Ledger Accounts');

--- a/GLBalanceSheet.php
+++ b/GLBalanceSheet.php
@@ -15,10 +15,6 @@ Parameters:
 	IsIncluded: Parameter to indicate that a script is included within another.
 */
 
-// BEGIN: Functions division ===================================================
-// END: Functions division =====================================================
-
-// BEGIN: Procedure division ===================================================
 if (!isset($IsIncluded)) {// Runs normally if this script is NOT included in another.
 	require(__DIR__ . '/includes/session.php');
 }

--- a/GLCashFlowsIndirect.php
+++ b/GLCashFlowsIndirect.php
@@ -17,7 +17,6 @@ Parameters:
 	IsIncluded: Parameter to indicate that a script is included within another.
 */
 
-// BEGIN: Functions division ===================================================
 function CashFlowsActivityName($Activity) {
 	// Converts the cash flow activity number to an activity text.
 	switch($Activity) {
@@ -39,9 +38,7 @@ function colDebitCredit($Amount) {
 		return '<td>&nbsp;</td><td class="number">' . locale_number_format($Amount, $_SESSION['CompanyRecord']['decimalplaces']) . '</td>';// Inflow.
 	}
 }
-// END: Functions division =====================================================
 
-// BEGIN: Procedure division ===================================================
 if (!isset($IsIncluded)) {// Runs normally if this script is NOT included in another.
 	require(__DIR__ . '/includes/session.php');
 }

--- a/GLCashFlowsSetup.php
+++ b/GLCashFlowsSetup.php
@@ -4,7 +4,6 @@
 // This program is under the GNU General Public License, last version. 2016-10-08.
 // This creative work is under the CC BY-NC-SA, last version. 2016-10-08.
 
-// BEGIN: Procedure division ---------------------------------------------------
 require(__DIR__ . '/includes/session.php');
 
 $Title = __('Cash Flows Activities Maintenance');
@@ -220,4 +219,3 @@ echo				'</select>
 	</form>';
 
 include('includes/footer.php');
-// END: Procedure division -----------------------------------------------------

--- a/GLProfit_Loss.php
+++ b/GLProfit_Loss.php
@@ -15,7 +15,6 @@ Parameters:
 	IsIncluded: Parameter to indicate that a script is included within another.
 */
 
-// BEGIN: Procedure division ===================================================
 if (!isset($IsIncluded)) {// Runs normally if this script is NOT included in another.
 	require(__DIR__ . '/includes/session.php');
 }

--- a/GLStatements.php
+++ b/GLStatements.php
@@ -23,10 +23,6 @@ Parameters:
 	IsIncluded: Parameter to indicate that a script is included within another.
 */
 
-// BEGIN: Functions division ===================================================
-// END: Functions division =====================================================
-
-// BEGIN: Procedure division ===================================================
 require(__DIR__ . '/includes/session.php');
 
 $Title = __('Financial Statements');

--- a/ManualContents.php
+++ b/ManualContents.php
@@ -16,7 +16,6 @@ Comments beginning with Help Begin and Help End denote the beginning and end of 
 What section is named after Help Begin: and there can be multiple sections separated with a comma.
 */
 
-// BEGIN: Procedure division ---------------------------------------------------
 $PageSecurity = 0;
 
 // Set the language to show the manual:
@@ -144,4 +143,3 @@ if(file_exists($ManualFooter)) {// Use locale ManualHeader.html if exists. Each 
 }
 
 ob_end_flush();
-// END: Procedure division -----------------------------------------------------

--- a/PDFPriceList.php
+++ b/PDFPriceList.php
@@ -454,4 +454,3 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 
 	include('includes/footer.php');
 } /*end of else not PrintPDF */
-// END: Procedure division -----------------------------------------------------

--- a/PurchasesReport.php
+++ b/PurchasesReport.php
@@ -8,10 +8,6 @@ This creative work is under the CC BY-NC-SA, last version. 2016-12-18.
 This script is "mirror-symmetric" to script SalesReport.php.
 */
 
-// BEGIN: Functions division ===================================================
-// END: Functions division =====================================================
-
-// BEGIN: Procedure division ===================================================
 require(__DIR__ . '/includes/session.php');
 
 $Title = __('Purchases from Suppliers');

--- a/SalesReport.php
+++ b/SalesReport.php
@@ -8,10 +8,6 @@ This creative work is under the CC BY-NC-SA, last version. 2016-12-18.
 This script is "mirror-symmetric" to script PurchasesReport.php.
 */
 
-// BEGIN: Functions division ===================================================
-// END: Functions division =====================================================
-
-// BEGIN: Procedure division ===================================================
 require(__DIR__ . '/includes/session.php');
 
 use Dompdf\Dompdf;


### PR DESCRIPTION
While those are not harming, strictly speaking, given the fact that they are not very widespread, it is just as well to remove them for the sake of fewer lines of code / more uniform coding style