### PR TITLE
fix recent commit which was updating $_SESSION[DBVersion] while it should not have, ...

### DIFF
--- a/Z_UpgradeDatabase.php
+++ b/Z_UpgradeDatabase.php
@@ -20,10 +20,11 @@ echo '<link rel="stylesheet" href="' . $RootPath . '/css/dbupgrade.css" type="te
 
 //ob_start(); /* what is this for? */
 
-if (!isset($_SESSION['DBVersion'])) {
+// This is always set in session.php
+/*if (!isset($_SESSION['DBVersion'])) {
 //	header('Location: ' . htmlspecialchars_decode($RootPath) . '/index.php');
 	$_SESSION['DBVersion'] = 0;
-}
+}*/
 
 	// Fix: Check if CompanyRecord['coyname'] is set before using stripslashes
 	$CompanyName = isset($_SESSION['CompanyRecord']['coyname']) ? stripslashes($_SESSION['CompanyRecord']['coyname']) : '';
@@ -130,7 +131,6 @@ if (!isset($_SESSION['DBVersion'])) {
 				$SQL = "SET FOREIGN_KEY_CHECKS=1";
 				$Result = DB_query($SQL);
 
-				$_SESSION['DBVersion'] = $UpdateNumber;
 				/** @todo can we move here the line `UpdateDBNo(basename(__FILE__, '.php')`, and avoid having it in
 				 *        every update file? */
 			}

--- a/includes/GetConfig.php
+++ b/includes/GetConfig.php
@@ -17,9 +17,11 @@ if ((isset($ForceConfigReload) AND $ForceConfigReload==true) OR !isset($_SESSION
 			$_SESSION[$MyRow['confname']] =  $MyRow['confvalue'];
 		}
 	} //end loop through all config variables
+
 	if (!isset($_SESSION['DBUpdateNumber'])) {
 		$_SESSION['DBUpdateNumber'] = -1;
 	}
+
 	$_SESSION['CompanyDefaultsLoaded'] = true;
 
 	DB_free_result($ConfigResult); // no longer needed

--- a/includes/session.php
+++ b/includes/session.php
@@ -157,6 +157,9 @@ if (basename($_SERVER['SCRIPT_NAME']) == 'Logout.php') {
 } else {
 	include($PathPrefix . 'includes/UserLogin.php'); /* Login checking and setup. Includes GetConfig.php on successful logins */
 
+	/// @todo what if the current user is already logged in? We should at least log him/her out before re-logging in...
+	///       (or maybe swallow that event, and log it as suspected hack attempt?)
+
 	if (isset($_POST['UserNameEntryField']) and isset($_POST['Password'])) {
 		$rc = userLogin($_POST['UserNameEntryField'], $_POST['Password'], $SysAdminEmail);
 		$FirstLogin = true;
@@ -171,8 +174,11 @@ if (basename($_SERVER['SCRIPT_NAME']) == 'Logout.php') {
 
 	switch ($rc) {
 		case UL_OK; //user logged in successfully
+			/// @todo shouldn't we only set the cookie if $FirstLogin = true ?
 			setcookie('Login', $_SESSION['DatabaseName']);
-			include($PathPrefix . 'includes/LanguageSetup.php'); //set up the language
+			//include($PathPrefix . 'includes/LanguageSetup.php'); //set up the language
+
+			/// @todo the session table was created in DBUpdateNumber 13, not 11!
 			if ($_SESSION['DBUpdateNumber'] >= 11) {
 				$CheckSQL = "SELECT sessionid
 							FROM sessions
@@ -200,11 +206,14 @@ if (basename($_SERVER['SCRIPT_NAME']) == 'Logout.php') {
 										NOW())";
 						$Result = DB_query($SQL);
 					}
+					/// @todo if if DBUpdateNumber < 22, insert into sessions the sessionid
 				} else {
 					// it is not a new session, update the script name
+					/// @todo if if DBUpdateNumber < 22, do nothing
+					/// @todo if DBUpdateNumber >= 22, check that the known session userID matches $_SESSION['UserID']
+					// no need to escape the session ID - see https://www.php.net/manual/en/function.session-id.php#116836
 					$SQL = "UPDATE sessions
-							SET script = '" . basename($_SERVER['SCRIPT_NAME']) . "',
-								scripttime = NOW()
+							SET script = '" . basename($_SERVER['SCRIPT_NAME']) . "', scripttime = NOW()
 							WHERE sessionid='" . session_id() . "'";
 					$Result = DB_query($SQL);
 				}
@@ -250,6 +259,10 @@ if (basename($_SERVER['SCRIPT_NAME']) == 'Logout.php') {
  */
 if (!isset($_SESSION['DBVersion'])) {
 	$_SESSION['DBVersion'] = HighestFileName($PathPrefix);
+}
+// $_SESSION['DBUpdateNumber'] is normally set by GetConfig.php - but in case we never passed via that code path...
+if (!isset($_SESSION['DBUpdateNumber'])) {
+	$_SESSION['DBUpdateNumber'] = -1;
 }
 if (isset($_SESSION['DBVersion'])
 	and isset($_SESSION['DBUpdateNumber'])

--- a/includes/session.php
+++ b/includes/session.php
@@ -160,6 +160,9 @@ if (basename($_SERVER['SCRIPT_NAME']) == 'Logout.php') {
 	/// @todo what if the current user is already logged in? We should at least log him/her out before re-logging in...
 	///       (or maybe swallow that event, and log it as suspected hack attempt?)
 
+	/// @todo the login form points to /index.php. Should we avoid processing $_POST['UserNameEntryField'] and
+	///       $_POST['Password'] on other pages? We might even go as far as creating a dedicated Login.php...
+
 	if (isset($_POST['UserNameEntryField']) and isset($_POST['Password'])) {
 		$rc = userLogin($_POST['UserNameEntryField'], $_POST['Password'], $SysAdminEmail);
 		$FirstLogin = true;
@@ -222,6 +225,8 @@ if (basename($_SERVER['SCRIPT_NAME']) == 'Logout.php') {
 			break;
 
 		case UL_SHOWLOGIN:
+			/// @todo here, we should store in the sessions table the current session id and the script name. This
+			///       way, when the user logs in, (s)he can be redirected to the original script.
 			include($PathPrefix . 'includes/Login.php');
 			exit();
 


### PR DESCRIPTION
...comments

The only change is in fact removing the line `$_SESSION['DBVersion'] = $UpdateNumber;` from Z_UpgradeDatabase. It was a alogical mistake - $_SESSION['DBVersion'] is always the latest file nr on disk, it is not the version nr stored in the db