### PR TITLE
fix usage of double quote as string delimiter in sql

### DIFF
--- a/install/sql/tables/sessions.sql
+++ b/install/sql/tables/sessions.sql
@@ -2,7 +2,7 @@ CREATE TABLE `sessions` (
   `sessionid` char(32),
   `logintime` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `userid` varchar(20),
-  `script` varchar(100) NOT NULL DEFAULT "",
+  `script` varchar(100) NOT NULL DEFAULT '',
   `scripttime` TIMESTAMP NULL,
   PRIMARY KEY (`sessionid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;


### PR DESCRIPTION
Double quotes should never be used as string delimiters in sql - unless we want to tie ourselves to mysql-only, in non-ANSI mode.

A good exercise for the reader: add the above bit of info to the coding standard 😝 