### PR TITLE
Fixes for issues found by ci tests

### DIFF
--- a/GetStockImage.php
+++ b/GetStockImage.php
@@ -269,7 +269,6 @@ if ( $automake AND !isset($FileName) ) {
 		$tmpim = imagecreatetruecolor($resize_new_width, $resize_new_height);
 		imagealphablending ( $tmpim, true);
 		imagecopyresampled($tmpim, $im, 0, 0, 0, 0, $resize_new_width, $resize_new_height, $sw, $sh );
-		imagedestroy($im);
 		$im = $tmpim;
 		unset($tmpim);
 
@@ -355,5 +354,3 @@ header('Content-type: image/'.$style);
 $func = 'image'.$functype;
 // AND send image
 $func($im);
-// Destroy image
-imagedestroy($im);

--- a/build/dump_database.sh
+++ b/build/dump_database.sh
@@ -119,11 +119,10 @@ if [ "$ADD_CREATE_TABLES_STATEMENTS" = true ]; then
 		TARGET_FILE=demo.sql
 	fi
 
-	# @todo review the list of excluded tables
-	echo mysqldump -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" \
-		--skip-set-charset --no-data $ADD_DROP_TABLES_OPTION
+	# the `--column-statistics=0` option is needed when using mysqldump from mysql to access some mariadb versions
 
-	mysqldump -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" \
+	# @todo review the list of excluded tables
+	mysqldump --column-statistics=0 -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" \
 	    --skip-set-charset --no-data $ADD_DROP_TABLES_OPTION \
 		--ignore-table="${MYSQL_DATABASE}.buckets" \
 		--ignore-table="${MYSQL_DATABASE}.levels" \
@@ -144,7 +143,7 @@ fi
 
 if [ "$ACTION" = all ] || [ "$ACTION" = default ]; then
 	# @todo review the list of included tables
-	mysqldump -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" \
+	mysqldump --column-statistics=0 -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" \
 		$MYSQL_DUMP_OPTIONS $SORT_ROWS_OPTION "$MYSQL_DATABASE" \
 		accountgroups \
 		accountsection \
@@ -188,7 +187,7 @@ fi
 
 if [ "$ACTION" = all ] || [ "$ACTION" = demo ]; then
 	# @todo review the list of excluded tables
-	mysqldump -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" \
+	mysqldump --column-statistics=0 -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER" -p"$MYSQL_PASSWORD" \
 		$MYSQL_DUMP_OPTIONS $SORT_ROWS_OPTION \
 		--ignore-table="${MYSQL_DATABASE}.mrpsupplies" \
 		--ignore-table="${MYSQL_DATABASE}.mrpplanedorders" \

--- a/build/dump_database.sh
+++ b/build/dump_database.sh
@@ -88,7 +88,7 @@ if [ "$ADD_CREATE_TABLES_STATEMENTS" != 'true' ] && [ "$ADD_DROP_TABLES_OPTION" 
 	exit 1
 fi
 
-mysql -u"$MYSQL_USER"  -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < "$BASE_DIR/build/TruncateAuditTrail.sql"
+mysql -h"$MYSQL_HOST" -P"$MYSQL_PORT" -u"$MYSQL_USER"  -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE" < "$BASE_DIR/build/TruncateAuditTrail.sql"
 
 if [ "$ADD_CREATE_SCHEMA_STATEMENTS" = true ]; then
 	# @todo add default collation to be utf8mb4

--- a/build/update_translations.sh
+++ b/build/update_translations.sh
@@ -53,7 +53,7 @@ if [ "$ACTION" = all ] || [ "$ACTION" = source_files ]; then
 	# xgettext: Extracts translatable strings from given input file paths
 	# @todo use `find` to avoid having to specify all directories manually
 	echo "Extracting translatable strings from source files..."
-	xgettext --no-wrap --from-code=utf-8 -L PHP --keyword __ -o locale/en_GB.utf8/LC_MESSAGES/messages.pot ./*.php ./api/*.php ./dashboard/*.php \
+	xgettext --no-wrap --from-code=utf-8 -L PHP --keyword=__ -o locale/en_GB.utf8/LC_MESSAGES/messages.pot ./*.php ./api/*.php ./dashboard/*.php \
 		./doc/Manual/*.php ./includes/*.php ./install/*.php ./install/pages/*.php ./reportwriter/*.php ./reportwriter/admin/*.php \
 		./reportwriter/admin/forms/*.php ./reportwriter/forms/*.php ./reportwriter/includes/*.php ./reportwriter/install/*.php \
 		./reportwriter/languages/en_US/*.php

--- a/includes/InstallFunctions.php
+++ b/includes/InstallFunctions.php
@@ -24,7 +24,7 @@ function CreateCompanyLogo($CompanyName, $Path_To_Root, $CompanyDir) {
 		$px = (imagesx($im) - $TextWidth) / 2;
 		$py = (imagesy($im) - ($fh)) / 2;
 		//imagefill($im, 0, 0, $BackgroundColour);
-		imagestring($im, $Font, $px, $py, $CompanyName, $TextColour);
+		imagestring($im, $Font, (int)$px, (int)$py, $CompanyName, $TextColour);
 
 		imagesavealpha($im, true);
 

--- a/includes/InstallFunctions.php
+++ b/includes/InstallFunctions.php
@@ -32,7 +32,6 @@ function CreateCompanyLogo($CompanyName, $Path_To_Root, $CompanyDir) {
 		if (!imagepng($im, $CompanyDir . '/logo.png')) {
 			$Result = copy($Path_To_Root . '/images/default_logo.jpg', $CompanyDir . '/logo.jpg');
 		}
-		imagedestroy($im);
 
 	} else {
 		$Result = copy($Path_To_Root . '/images/default_logo.jpg', $CompanyDir . '/logo.jpg');

--- a/includes/InstallFunctions.php
+++ b/includes/InstallFunctions.php
@@ -511,6 +511,7 @@ function UploadData($Demo, $AdminPassword, $AdminUser, $Email, $Language, $CoA, 
 		echo '<div class="info">' . __('Populating the database with demo data.') . '</div>';
 		flush();
 
+		DB_IgnoreForeignKeys();
 		$Errors = (int)PopulateSQLDataBySQLFile($Path_To_Root. '/install/sql/demo.sql', $DBType);
 
 		/// @todo this could just be pushed into demo.sql - and checked for presence by the scripts in /build
@@ -523,6 +524,7 @@ function UploadData($Demo, $AdminPassword, $AdminUser, $Email, $Language, $CoA, 
 			$Errors++;
 			//echo '<div class="error">' . __('...') . '</div>';
 		}
+		DB_ReinstateForeignKeys();
 
 		/// @todo there is no /companies/default folder atm...
 		$CompanyDir = $Path_To_Root . '/companies/' . $DataBaseName;

--- a/includes/session.php
+++ b/includes/session.php
@@ -176,7 +176,7 @@ if (basename($_SERVER['SCRIPT_NAME']) == 'Logout.php') {
 	$Theme = (isset($_SESSION['Theme'])) ? $_SESSION['Theme'] : $DefaultTheme;
 
 	switch ($rc) {
-		case UL_OK; //user logged in successfully
+		case UL_OK: //user logged in successfully
 			/// @todo shouldn't we only set the cookie if $FirstLogin = true ?
 			setcookie('Login', $_SESSION['DatabaseName']);
 			//include($PathPrefix . 'includes/LanguageSetup.php'); //set up the language


### PR DESCRIPTION
- the recent fix to the `xgettext` call was not done properly
- remove `imagedestroy` calls, as those are a no-op since php 8.0 and give a warning on php 8.5
- fix usage of semicolon in `case`, as it is a warning in php 8.5
- make dump_database.sh work when using mysql 8.0 cli tools against recent mariadb server