### PR TITLE
Fix immediate redirect happening if session was not loaded

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -8,7 +8,6 @@
 // various $_SESSION items: Theme, DefaultDateFormat, Timeout, ShowPageHelp, ShowFieldHelp, FontSize, UsersRealName, etc...
 
 /// @todo there are any more global variables use in this script than those 3... are we sure it would work if
-
 ///       called within a function?
 global $Language;
 global $Title;
@@ -62,7 +61,10 @@ echo '	<script>
 		localStorage.setItem("DateFormat", "', $_SESSION['DefaultDateFormat'], '");
 		localStorage.setItem("Theme", "', $_SESSION['Theme'], '");
 	</script>' , "\n";
-echo '	<meta http-equiv="refresh" content="' . (60 * $_SESSION['Timeout']) . ';url=Logout.php" />' , "\n";
+
+if (isset($_SESSION['Timeout'])) {
+	echo '	<meta http-equiv="refresh" content="' . (60 * $_SESSION['Timeout']) . ';url=' . $RootPath . '/Logout.php" />', "\n";
+}
 
 if ($_SESSION['ShowPageHelp'] == 0) {
 	echo '	<link href="', $RootPath, '/css/', $_SESSION['Theme'], '/page_help_off.css" rel="stylesheet" type="text/css" media="screen" />' , "\n";


### PR DESCRIPTION
Not 100% sure how to make this happen, but it happened today on my pc - empty db, db down or something similar. Also, not on every page, but at least ContractBOM and other 2 pages.

Also, use the correct absolute path to Logout.php