### PR TITLE
Fix sign error

### DIFF
--- a/Credit_Invoice.php
+++ b/Credit_Invoice.php
@@ -554,7 +554,7 @@ if (isset($_POST['ProcessCredit']) and $OKToProcess == true) {
 
 	/*Calculate the allocation and see if it is possible to allocate to the invoice being credited */
 
-	$SQL = "SELECT(ovamount+ovgst+ovfreight-ovdiscount-alloc) AS baltoallocate
+	$SQL = "SELECT(ovamount+ovgst+ovfreight+ovdiscount-alloc) AS baltoallocate
 			FROM debtortrans
 			WHERE transno=" . $_SESSION['ProcessingCredit'] . "
 			AND type=10";


### PR DESCRIPTION
This is the only instance in webERP where debtortrans discount had a - sign, instead of a +. Even the calculated field balance uses a +discount (defined in 8.php).

I consider this a bug, but seems too obvious to have slipped us for so long.

@timschofield could you please double-check this?