### PR TITLE
Use button to Logout/In

### DIFF
--- a/Z_UpgradeDatabase.php
+++ b/Z_UpgradeDatabase.php
@@ -162,11 +162,13 @@ if (!isset($_POST['continue'])) {
 	include(__DIR__ . '/includes/GetConfig.php');
 	$ForceConfigReload = false;
 
+	// use a button here for consistency with the "Continue" button (used to initiate updates)
 	echo '<div class="centre">
 		<a href="' . $RootPath . '/Logout.php" title="' . __('Log out of') . ' ' . 'webERP" alt="">
-			', __('Now click here to logout and then log back in for these changes to take affect'), '
+			<button>', __('Login again for changes to take affect'), '</button>
 		</a>
 	</div>';
+
 }
 
 include(__DIR__ . '/includes/footer.php');


### PR DESCRIPTION
Change the hidden link to "Logout and back in again" after performing updates to an button like the "Continue..." (to install updates) button for consistency and more obvious required user action.