### PR TITLE
Add PN Links to BOMIndented.php

### DIFF
--- a/BOMIndented.php
+++ b/BOMIndented.php
@@ -223,7 +223,7 @@ if (isset($_POST['PrintPDF']) or isset($_POST['View'])) {
 		$Symbol = ($Level > 0) ? '|_ ' : '';
 
 		$HTML .= '<tr class="striped_row">
-					<td>' . $Indent . $Symbol . $MyRow['component'] . '</td>
+					<td>' . $Indent . $Symbol . '<a href="' . $RootPath . '/SelectProduct.php?StockID=' . urlencode($MyRow['component']) . '">' . $MyRow['component'] . '</a>' . '</td>
 					<td>' . $MyRow['mbflag'] . '</td>
 					<td>' . $MyRow['description'] . '</td>
 					<td>' . $MyRow['loccode'] . '</td>


### PR DESCRIPTION
Add links from Part Numbers in an Indented Bill of Materials Listing (BOMIndented.php) to SelectProduct.php similar to BOMInquiry.php listing. Discussion https://github.com/timschofield/webERP/discussions/934#discussion-10263974

1. is there a macro or particular structure I should be using to add a link to some string?

2. the links will also appear in a generated PDF, which could be convenient for most users but sometimes night be too much information. It would still be good to support options when generating a PDF but I imagine a PDF could be cleansed after generation if ever needed.