### PR TITLE
Revised DashboardConfig.php fix for PHP 8.3 (and some housekeeping)

### DIFF
--- a/.github/copilot_instructions.md
+++ b/.github/copilot_instructions.md
@@ -1,0 +1,14 @@
+# webERP Coding Standards
+
+This repository is webERP.
+
+Requirements:
+
+- PHP compatibility consistent with webERP standards.
+- Avoid modern framework assumptions.
+- Use procedural PHP where appropriate.
+- Preserve existing coding style.
+- Use mysqli functions already used by the project.
+- Maintain backwards compatibility.
+- Generate SQL compatible with MariaDB/MySQL.
+- Keep changes small and reviewable.

--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,33 @@
-# Ignore NetBeans project metadata
+# ignore IDE scaffolding
+## NetBeans
 /nbproject/
-# As well as Jetbrains stuff
+
+## Jetbrains
 /.idea/
-# And VSCode
+
+## VSCode
 /.vscode/launch.json
-# And random assorted tooling files
+
+# ignore tooling
+## Windows / WSL
 Thumbs.db
+.DS_Store
+*:Zone.Identifier
 
-# Only config.distrib.php is to be distributed
-/config.php
-
-# Ignore everything in the companies directory...
-/companies/*
-# ...except for weberpdemo
-!/companies/weberpdemo
-
-# the per-developer phpunit config and phpunit cache
+## (per-developer) phpunit config and phpunit cache
 /.phpunit.result.cache
 /phpunit.xml
 
-# And the eventual .git dir from composer-installed projects which are downloaded as git clones instead of zipballs
+## .git/ in composer-installed projects (created by git clone not zipball)
 /vendor/phplot/phplot/.git/
+
+## other
 KLConfig/
+
+# do not ever distribute local config.php (only config.distrib.php is distributed)
+# to avoid accidential disclosure of database or other credentials
+/config.php
+
+# ignore everything in companies/ except weberpdemo/
+/companies/*
+!/companies/weberpdemo

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,10 @@ Thumbs.db
 .DS_Store
 *:Zone.Identifier
 
-## (per-developer) phpunit config and phpunit cache
+## fonts created JIT by DOMPDF
+/vendor/dompdf/dompdf/lib/fonts/*.json
+
+## phpunit config and phpunit cache (per-developer) 
 /.phpunit.result.cache
 /phpunit.xml
 
@@ -24,8 +27,8 @@ Thumbs.db
 ## other
 KLConfig/
 
-# do not ever distribute local config.php (only config.distrib.php is distributed)
-# to avoid accidential disclosure of database or other credentials
+# DO NOT EVER distribute the local config.php to avoid accidential disclosure
+#   of database or other credentials (only config.distrib.php is distributed)
 /config.php
 
 # ignore everything in companies/ except weberpdemo/

--- a/DashboardConfig.php
+++ b/DashboardConfig.php
@@ -36,9 +36,17 @@ if (isset($_POST['Update'])) {
 										description='" . $_POST['Description'] . "'
 									WHERE id='" . $_POST['ID'] . "'";
 	$Result = DB_query($SQL);
-	$SQL = "UPDATE scripts SET pagesecurity='" . $_POST['PageSecurity'] . "',
-								description='" . $_POST['Description'] . "'
-							WHERE script='" . $MyRow['scripts'] . "'";
+	$SQL = "INSERT INTO scripts (script,
+							pagesecurity,
+						description
+						) VALUES (
+							'" . $MyRow['scripts'] . "',
+							'" . $_POST['PageSecurity'] . "',
+							'" . $_POST['Description'] . "'
+						)
+						ON DUPLICATE KEY UPDATE
+							pagesecurity = VALUES(pagesecurity),
+							description = VALUES(description)";
 	$Result = DB_query($SQL);
 	if (DB_error_no() == 0) {
 		prnMsg(__('The script was successfully updated'), 'success');
@@ -62,11 +70,14 @@ if (isset($_POST['Insert'])) {
 	$SQL = "INSERT INTO scripts (script,
 								pagesecurity,
 								description
-							) VALUES (
-								'" . $_POST['Script'] . "',
-								'" . $_POST['PageSecurity'] . "',
-								'" . $_POST['Description'] . "'
-							)";
+								) VALUES (
+									'" . $_POST['Script'] . "',
+									'" . $_POST['PageSecurity'] . "',
+									'" . $_POST['Description'] . "'
+								)
+								ON DUPLICATE KEY UPDATE
+									pagesecurity = VALUES(pagesecurity),
+									description = VALUES(description)";
 	$Result = DB_query($SQL);
 	if (DB_error_no() == 0) {
 		prnMsg(__('The script was successfully inserted'), 'success');
@@ -155,9 +166,11 @@ if (isset($_GET['Edit'])) {
 				<label for="Script">', __('Script Name'), '</label>
 				<select name="Script">';
 	$Scripts = glob('dashboard/*.php');
+	if (!isset($ScriptArray)) {
+		$ScriptArray = array();
+	}
 	foreach ($Scripts as $ScriptName) {
 		$ScriptName = basename($ScriptName);
-		$ScriptArray = array(); // per PHP 8.4, must be defined before use 
 		if ($ScriptName != 'template.php' and !in_array($ScriptName, $ScriptArray)) {
 			if ($_POST['Script'] == $ScriptName) {
 				echo '<option selected="selected" value="', $ScriptName, '">', $ScriptName, '</option>';

--- a/DashboardConfig.php
+++ b/DashboardConfig.php
@@ -23,7 +23,7 @@ if (isset($_GET['Delete'])) {
 	if (DB_error_no() == 0) {
 		prnMsg(__('The script was successfully removed'), 'success');
 	} else {
-		prnMsg(__('There was a peoblem removing the script'), 'error');
+		prnMsg(__('There was a problem removing the script'), 'error');
 	}
 }
 
@@ -43,7 +43,7 @@ if (isset($_POST['Update'])) {
 	if (DB_error_no() == 0) {
 		prnMsg(__('The script was successfully updated'), 'success');
 	} else {
-		prnMsg(__('There was a peoblem updating the script'), 'error');
+		prnMsg(__('There was a problem updating the script'), 'error');
 	}
 }
 
@@ -157,6 +157,7 @@ if (isset($_GET['Edit'])) {
 	$Scripts = glob('dashboard/*.php');
 	foreach ($Scripts as $ScriptName) {
 		$ScriptName = basename($ScriptName);
+		$ScriptArray = array(); // per PHP 8.4, must be defined before use 
 		if ($ScriptName != 'template.php' and !in_array($ScriptName, $ScriptArray)) {
 			if ($_POST['Script'] == $ScriptName) {
 				echo '<option selected="selected" value="', $ScriptName, '">', $ScriptName, '</option>';

--- a/DashboardConfig.php
+++ b/DashboardConfig.php
@@ -71,7 +71,7 @@ if (isset($_POST['Insert'])) {
 	if (DB_error_no() == 0) {
 		prnMsg(__('The script was successfully inserted'), 'success');
 	} else {
-		prnMsg(__('There was a peoblem inserting the script'), 'error');
+		prnMsg(__('There was a problem inserting the script'), 'error');
 	}
 }
 


### PR DESCRIPTION
1. fixes DashboardConfig.php failing on PHP 8.3.6 due to uninitialized array variable "ScriptArray" (fwiw ok with 8.2.32)
2. prevent incorrect 2nd insert being performed resulting in an SQL duplicate key error (hidden using production debug settings)

```
Function Call StackFrame File Line Function Class Arguments
0 /home/dale/weberp/includes/ConnectDB_mariadb.php 82 ShowDebugBackTrace N/A
Array
(
    [0] => The SQL that failed was
    [1] => INSERT INTO scripts (script,
                                pagesecurity,
                                description
                            ) VALUES (
                                'mrp_dashboard.php',
                                '1',
                                'MRP Status'
                            )
)

1/home/dale/weberp/DashboardConfig.php 70 DB_query N/A
Array
(
    [0] => INSERT INTO scripts (script,
                                pagesecurity,
                                description
                            ) VALUES (
                                'mrp_dashboard.php',
                                '1',
                                'MRP Status'
                            )
)
```

3. git ignore Windows/WSL files and fonts created JIT by DOMPDF
4. added Copilot direction file for developing using VS Code on WSL Ubuntu (free plan for GitHub Copilot provides "2,000 completions per month" whatever that means).
