### PR TITLE
give max timeout in field help

### DIFF
--- a/WWW_Users.php
+++ b/WWW_Users.php
@@ -581,7 +581,7 @@ echo '<field>
 echo '<field>
 		<label for="Timeout">' . __('Timeout after') .':</label>
 		<input type="text" class="number" name="Timeout" required="required" value="' . $_POST['Timeout'] .'" size="4" maxlength="5" title="" />&nbsp;', __('minutes'), '
-		<fieldhelp>'.__('Log the user out after this interval of non-use').'</fieldhelp>
+		<fieldhelp>'.__('Log the user out after this interval of non-use (max 127 minutes)').'</fieldhelp>
 	</field>';
 echo '<field>
 		<label for="Access">' . __('User Role') . ':</label>


### PR DESCRIPTION
Show max timeout as it may be suprising low to the user. 

When investigating an SQL error that occured after attempting to set a user timeout using WWW_Users.php to 600, it was found the max timeout was suprising low - db type type tinyint(4) has range of -128 to +127.
