### PR TITLE
Add Supplier Notes

### DIFF
--- a/AddSupplierNotes.php
+++ b/AddSupplierNotes.php
@@ -1,0 +1,195 @@
+<?php
+
+require(__DIR__ . '/includes/session.php');
+
+$Title = __('Supplier Notes');
+$ViewTopic = 'AccountsPayable';
+$BookMark = 'SupplierNotes';
+include(__DIR__ . '/includes/header.php');
+
+include(__DIR__ . '/includes/SQL_CommonFunctions.php');
+
+if (isset($_POST['NoteDate'])) {
+	$_POST['NoteDate'] = ConvertSQLDate($_POST['NoteDate']);
+}
+
+if (isset($_GET['Id'])) {
+	$Id = (int)$_GET['Id'];
+} elseif (isset($_POST['Id'])) {
+	$Id = (int)$_POST['Id'];
+}
+if (isset($_POST['SupplierID'])) {
+	$SupplierID = $_POST['SupplierID'];
+} elseif (isset($_GET['SupplierID'])) {
+	$SupplierID = $_GET['SupplierID'];
+}
+
+echo '<a class="toplink" href="' . $RootPath . '/SelectSupplier.php?SupplierID=' . $SupplierID . '">' . __('Back to Select Supplier') . '</a>';
+
+if (isset($_POST['submit'])) {
+
+	//initialise no input errors assumed initially before we test
+	$InputError = 0;
+	/* actions to take once the user has clicked the submit button
+	ie the page has called itself with some user input */
+
+	//first off validate inputs sensible
+	if (trim($_POST['Note']) == '') {
+		$InputError = 1;
+		prnMsg(__('The supplier note may not be empty'), 'error');
+	}
+
+	if (isset($Id) and $InputError != 1) {
+
+		$SQL = "UPDATE suppliernotes SET note='" . $_POST['Note'] . "',
+									date='" . FormatDateForSQL($_POST['NoteDate']) . "'
+				WHERE supplierid ='" . $SupplierID . "'
+				AND noteid='" . $Id . "'";
+		$Msg = __('Supplier Notes') . ' ' . $SupplierID . ' ' . __('has been updated');
+	} elseif ($InputError != 1) {
+
+		$SQL = "INSERT INTO suppliernotes (supplierid,
+										note,
+										date)
+				VALUES ('" . $SupplierID . "',
+						'" . $_POST['Note'] . "',
+						'" . FormatDateForSQL($_POST['NoteDate']) . "')";
+		$Msg = __('The supplier note record has been added');
+	}
+
+	if ($InputError != 1) {
+		$Result = DB_query($SQL);
+
+		echo '<br />';
+		prnMsg($Msg, 'success');
+		unset($Id);
+		unset($_POST['Note']);
+		unset($_POST['Noteid']);
+		unset($_POST['NoteDate']);
+	}
+} elseif (isset($_GET['delete'])) {
+
+	$SQL = "DELETE FROM suppliernotes
+			WHERE noteid='" . $Id . "'
+			AND supplierid='" . $SupplierID . "'";
+	$Result = DB_query($SQL);
+
+	echo '<br />';
+	prnMsg(__('The supplier note record has been deleted'), 'success');
+	unset($Id);
+	unset($_GET['delete']);
+}
+
+if (!isset($Id)) {
+	$SQLname = "SELECT suppname FROM suppliers
+				WHERE supplierid='" . $SupplierID . "'";
+	$Result = DB_query($SQLname);
+	$Row = DB_fetch_array($Result);
+	echo '<p class="page_title_text"><img src="' . $RootPath . '/css/' . $Theme . '/images/maintenance.png" title="' . __('Search') . '" alt="" />' . __('Notes for Supplier') . ': <b>' . $Row['suppname'] . '</b></p>';
+
+	$SQL = "SELECT noteid,
+					supplierid,
+					note,
+					date
+				FROM suppliernotes
+				WHERE supplierid='" . $SupplierID . "'
+				ORDER BY date DESC";
+	$Result = DB_query($SQL);
+
+	if (DB_num_rows($Result) > 0) {
+		echo '<table class="selection">
+			<tr>
+				<th>' . __('Date') . '</th>
+				<th>' . __('Note') . '</th>
+				<th colspan="2">' . __('Action') . '</th>
+			</tr>';
+
+		while ($MyRow = DB_fetch_array($Result)) {
+			echo '<tr class="striped_row">
+					<td>', ConvertSQLDate($MyRow['date']), '</td>
+					<td>', nl2br($MyRow['note']), '</td>
+					<td><a href="', htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8') . '?Id=', $MyRow['noteid'], '&SupplierID=', $MyRow['supplierid'], '">' . __('Edit') . ' </td>
+					<td><a href="', htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8') . '?Id=', $MyRow['noteid'], '&SupplierID=', $MyRow['supplierid'], '&delete=1" onclick="return confirm(\'' . __('Are you sure you wish to delete this supplier note?') . '\');">' . __('Delete') . '</td>
+				</tr>';
+
+		}
+		//END WHILE LIST LOOP
+		echo '</table>';
+	}
+}
+if (isset($Id)) {
+	echo '<div class="centre">
+			<a href="' . htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8') . '?SupplierID=' . $SupplierID . '">' . __('Review all notes for this Supplier') . '</a>
+		</div>';
+}
+
+if (!isset($_GET['delete'])) {
+
+	echo '<form method="post" action="' . htmlspecialchars($_SERVER['PHP_SELF'], ENT_QUOTES, 'UTF-8') . '?SupplierID=' . $SupplierID . '">';
+	echo '<input type="hidden" name="FormID" value="' . $_SESSION['FormID'] . '" />';
+
+	if (isset($Id)) {
+		//editing an existing
+		echo '<p class="page_title_text"><img src="' . $RootPath . '/css/' . $Theme . '/images/maintenance.png" title="' . __('Search') . '" alt="" />' . __('Notes for Supplier') . ': <b>' . $SupplierID . '</b></p>';
+
+		$SQL = "SELECT noteid,
+						supplierid,
+						note,
+						date
+					FROM suppliernotes
+					WHERE noteid='" . $Id . "'
+						AND supplierid='" . $SupplierID . "'";
+
+		$Result = DB_query($SQL);
+
+		$MyRow = DB_fetch_array($Result);
+
+		$_POST['Noteid'] = $MyRow['noteid'];
+		$_POST['Note'] = $MyRow['note'];
+		$_POST['NoteDate'] = $MyRow['date'];
+		$_POST['SupplierID'] = $MyRow['supplierid'];
+		echo '<input type="hidden" name="Id" value="' . $Id . '" />';
+		echo '<input type="hidden" name="SupplierID" value="' . $_POST['SupplierID'] . '" />';
+		echo '<fieldset>
+				<legend>', __('Edit existing supplier note'), '</legend>
+				<field>
+					<label for="Noteid">' . __('Note ID') . ':</label>
+					<fieldtext>' . $_POST['Noteid'] . '</fieldtext>
+				</field>';
+	} else {
+		echo '<fieldset>
+				<legend>', __('Create new supplier note'), '</legend>';
+	}
+
+	echo '<field>
+			<label for="Note">' . __('Supplier Note') . '</label>';
+	if (isset($_POST['Note'])) {
+		echo '<textarea name="Note" autofocus="autofocus" required="required" rows="3" cols="32">' . $_POST['Note'] . '</textarea>
+			<fieldhelp>', __('Write the supplier note here'), '</fieldhelp>
+		</field>';
+	} else {
+		echo '<textarea name="Note" autofocus="autofocus" required="required" rows="3" cols="32"></textarea>
+			<fieldhelp>', __('Write the supplier note here'), '</fieldhelp>
+		</field>';
+	}
+
+	echo '<field>
+			<label for="NoteDate">' . __('Date') . '</label>';
+	if (isset($_POST['NoteDate'])) {
+		echo '<input type="date" required name="NoteDate"  value="' . FormatDateForSQL($_POST['NoteDate']) . '" size="11" maxlength="10" />
+			<fieldhelp>', __('The date of this note'), '</fieldhelp>
+		</field>';
+	} else {
+		echo '<input type="date" required name="NoteDate" value="' . date('Y-m-d') . '" size="11" maxlength="10" />
+			<fieldhelp>', __('The date of this note'), '</fieldhelp>
+		</field>';
+	}
+	echo '</fieldset>';
+	echo '<div class="centre">
+			<input type="submit" name="submit" value="' . __('Enter Information') . '" />
+		</div>
+	</form>';
+
+} //end if record deleted no point displaying form to add record
+
+include(__DIR__ . '/includes/footer.php');

--- a/SelectSupplier.php
+++ b/SelectSupplier.php
@@ -152,6 +152,7 @@ $TableHead =
 if (isset($_SESSION['SupplierID'])) {
 	// A supplier is selected
 	$SupplierName = '';
+	$SupplierDataTable = '';
 	$SQL = "SELECT suppliers.suppname
 			FROM suppliers
 			WHERE suppliers.supplierid ='" . $_SESSION['SupplierID'] . "'";
@@ -161,11 +162,58 @@ if (isset($_SESSION['SupplierID'])) {
 		$SupplierName = $MyRow[0];
 	}
 
+	if ($_SESSION['Extended_SupplierInfo'] == 1) {
+		$SQL = "SELECT suppliers.suppname,
+						suppliers.lastpaid,
+						suppliers.lastpaiddate,
+						suppliersince,
+						currencies.decimalplaces AS currdecimalplaces
+				FROM suppliers INNER JOIN currencies
+				ON suppliers.currcode=currencies.currabrev
+				WHERE suppliers.supplierid ='" . $_SESSION['SupplierID'] . "'";
+		$DataResult = DB_query($SQL);
+		$MyRow = DB_fetch_array($DataResult);
+
+		$SQL = "SELECT SUM(ovamount) AS total FROM supptrans WHERE supplierno = '" . $_SESSION['SupplierID'] . "' AND (type = '20' OR type='21')";
+		$Total1Result = DB_query($SQL);
+		$Row = DB_fetch_array($Total1Result);
+
+		$SupplierDataTable = '<br />';
+		$SupplierDataTable .= '<table width="45%" cellpadding="4">';
+		$SupplierDataTable .= '<tr><th style="width:33%" colspan="2">' . __('Supplier Data') . '</th></tr>';
+		$SupplierDataTable .= '<tr><td valign="top" class="select">';
+		if ($MyRow['lastpaiddate'] == 0) {
+			$SupplierDataTable .= __('No payments yet to this supplier.') . '</td>';
+			$SupplierDataTable .= '<td valign="top" class="select"></td>';
+			$SupplierDataTable .= '</tr>';
+		} else {
+			$SupplierDataTable .= __('Last Paid:') . '</td>';
+			$SupplierDataTable .= '<td valign="top" class="select"> <b>' . ConvertSQLDate($MyRow['lastpaiddate']) . '</b></td>';
+			$SupplierDataTable .= '</tr>';
+		}
+		$SupplierDataTable .= '<tr>';
+		$SupplierDataTable .= '<td valign="top" class="select">' . __('Last Paid Amount:') . '</td>';
+		$SupplierDataTable .= '<td valign="top" class="select">  <b>' . locale_number_format($MyRow['lastpaid'], $MyRow['currdecimalplaces']) . '</b></td>';
+		$SupplierDataTable .= '</tr>';
+		$SupplierDataTable .= '<tr>';
+		$SupplierDataTable .= '<td valign="top" class="select">' . __('Supplier since:') . '</td>';
+		$SupplierDataTable .= '<td valign="top" class="select"> <b>' . ConvertSQLDate($MyRow['suppliersince']) . '</b></td>';
+		$SupplierDataTable .= '</tr>';
+		$SupplierDataTable .= '<tr>';
+		$SupplierDataTable .= '<td valign="top" class="select">' . __('Total Spend with this Supplier:') . '</td>';
+		$SupplierDataTable .= '<td valign="top" class="select"> <b>' . locale_number_format($Row['total'], $MyRow['currdecimalplaces']) . '</b></td>';
+		$SupplierDataTable .= '</tr>';
+		$SupplierDataTable .= '</table>';
+	}
+
 	echo '<p class="page_title_text"><img alt="" src="', $RootPath, '/css/', $Theme,
 		'/images/supplier.png" title="', // Icon image.
 		__('Supplier'), '" /> ', // Icon title.
-		__('Supplier'), ': ', $_SESSION['SupplierID'], ' - ', $SupplierName, '</p>',// Page title.
-		'<div class="page_help_text">', __('Select a menu option to operate using this supplier.'), '</div>',// Page help text.
+		__('Supplier'), ': ', $_SESSION['SupplierID'], ' - ', $SupplierName, '</p>';// Page title.
+
+	echo $SupplierDataTable;
+
+	echo '<div class="page_help_text">', __('Chose a menu item for the selected supplier.'), '</div>',// Page help text.
 		'<br />',
 		$TableHead,
 			'<tr>
@@ -175,7 +223,7 @@ if (isset($_SESSION['SupplierID'])) {
 		<br />
 		<a href="' . $RootPath . '/SupplierGRNAndInvoiceInquiry.php?SelectedSupplier=' . $_SESSION['SupplierID'] . '&amp;SupplierName='.urlencode($SupplierName).'">' . __('Supplier Delivery Note AND GRN inquiry') . '</a>
 		<br />
-		<br />';
+		';
 
 	echo '<br /><a href="' . $RootPath . '/PO_SelectOSPurchOrder.php?SelectedSupplier=' . $_SESSION['SupplierID'] . '">' . __('Add / Receive / View Outstanding Purchase Orders') . '</a>';
 	echo '<br /><a href="' . $RootPath . '/PO_SelectPurchOrder.php?SelectedSupplier=' . $_SESSION['SupplierID'] . '">' . __('View All Purchase Orders') . '</a><br />';
@@ -194,6 +242,7 @@ if (isset($_SESSION['SupplierID'])) {
 	echo '<a href="' . $RootPath . '/Suppliers.php">' . __('Add a New Supplier') . '</a>
 		<br /><a href="' . $RootPath . '/Suppliers.php?SupplierID=' . $_SESSION['SupplierID'] . '">' . __('Modify Or Delete Supplier Details') . '</a>
 		<br /><a href="' . $RootPath . '/SupplierContacts.php?SupplierID=' . $_SESSION['SupplierID'] . '">' . __('Add/Edit/Delete Supplier Contacts') . '</a>
+		<br /><a href="' . $RootPath . '/AddSupplierNotes.php?SupplierID=' . $_SESSION['SupplierID'] . '">' . __('Add a Supplier Note') . '</a>
 		<br />
 		<br /><a href="' . $RootPath . '/SellThroughSupport.php?SupplierID=' . $_SESSION['SupplierID'] . '">' . __('Set Up Sell Through Support Deals') . '</a>
 		<br /><a href="' . $RootPath . '/Shipments.php?NewShipment=Yes">' . __('Set Up A New Shipment') . '</a>
@@ -201,6 +250,38 @@ if (isset($_SESSION['SupplierID'])) {
 		</td>
 		</tr>
 		<tbody></table>';
+	$SupplierNotesSQL = "SELECT noteid,
+						supplierid,
+						note,
+						date
+				FROM suppliernotes
+				WHERE supplierid='" . $_SESSION['SupplierID'] . "'
+				ORDER BY date DESC";
+	$SupplierNotesResult = DB_query($SupplierNotesSQL);
+	if (DB_num_rows($SupplierNotesResult) <> 0) {
+		echo '<p class="page_title_text">
+				<img src="', $RootPath, '/css/', $Theme, '/images/note_add.png" title="', __('Supplier Notes'), '" alt="" />', ' ', __('Supplier Notes'), '
+			</p>';
+		echo '<table style="width: 45%;">
+				<thead>
+					<tr>
+						<th class="SortedColumn" style="width:10%">', __('Date'), '</th>
+						<th style="width:70%">', __('Note'), '</th>
+						<th colspan="2" style="width:20%">', __('Action'), '</th>
+					</tr>
+				</thead>';
+		echo '<tbody>';
+		while ($SupplierNoteRow = DB_fetch_array($SupplierNotesResult)) {
+			echo '<tr class="striped_row">
+					<td class="date">', ConvertSQLDate($SupplierNoteRow['date']), '</td>
+					<td>', nl2br(htmlspecialchars($SupplierNoteRow['note'], ENT_QUOTES, 'UTF-8', false)), '</td>
+					<td style="text-align:center"><a href="', $RootPath, '/AddSupplierNotes.php?Id=', urlencode($SupplierNoteRow['noteid']), '&amp;SupplierID=', urlencode($SupplierNoteRow['supplierid']), '">', __('Edit'), '</a></td>
+					<td style="text-align:center"><a href="', $RootPath, '/AddSupplierNotes.php?Id=', urlencode($SupplierNoteRow['noteid']), '&amp;SupplierID=', urlencode($SupplierNoteRow['supplierid']), '&amp;delete=1" onclick="return confirm(\'' . __('Are you sure you wish to delete this supplier note?') . '\');">', __('Delete'), '</a></td>
+				</tr>';
+		}
+		echo '</tbody>
+			</table>';
+	}
 } else {
 	// Supplier is not selected yet
 	echo '<p class="page_title_text"><img alt="" src="', $RootPath, '/css/', $Theme,
@@ -376,51 +457,6 @@ if (isset($_SESSION['SupplierID']) and $_SESSION['SupplierID'] != '') {
 				htmlspecialchars($address3, ENT_QUOTES, 'UTF-8') . '<br>' . 
 				htmlspecialchars($address4, ENT_QUOTES, 'UTF-8') . '\').openPopup();
 			</script>';
-		}
-	}
-	// Extended Info only if selected in Configuration
-	if ($_SESSION['Extended_SupplierInfo'] == 1) {
-		if ($_SESSION['SupplierID'] != '') {
-			$SQL = "SELECT suppliers.suppname,
-							suppliers.lastpaid,
-							suppliers.lastpaiddate,
-							suppliersince,
-							currencies.decimalplaces AS currdecimalplaces
-					FROM suppliers INNER JOIN currencies
-					ON suppliers.currcode=currencies.currabrev
-					WHERE suppliers.supplierid ='" . $_SESSION['SupplierID'] . "'";
-			$DataResult = DB_query($SQL);
-			$MyRow = DB_fetch_array($DataResult);
-			// Select some more data about the supplier
-			$SQL = "SELECT SUM(ovamount) AS total FROM supptrans WHERE supplierno = '" . $_SESSION['SupplierID'] . "' AND (type = '20' OR type='21')";
-			$Total1Result = DB_query($SQL);
-			$Row = DB_fetch_array($Total1Result);
-			echo '<br />';
-			echo '<table width="45%" cellpadding="4">';
-			echo '<tr><th style="width:33%" colspan="2">' . __('Supplier Data') . '</th></tr>';
-			echo '<tr><td valign="top" class="select">'; /* Supplier Data */
-			//echo "Distance to this Supplier: <b>TBA</b><br />";
-			if ($MyRow['lastpaiddate'] == 0) {
-				echo __('No payments yet to this supplier.') . '</td>
-					<td valign="top" class="select"></td>
-					</tr>';
-			} else {
-				echo __('Last Paid:') . '</td>
-					<td valign="top" class="select"> <b>' . ConvertSQLDate($MyRow['lastpaiddate']) . '</b></td>
-					</tr>';
-			}
-			echo '<tr>
-					<td valign="top" class="select">' . __('Last Paid Amount:') . '</td>
-					<td valign="top" class="select">  <b>' . locale_number_format($MyRow['lastpaid'], $MyRow['currdecimalplaces']) . '</b></td></tr>';
-			echo '<tr>
-					<td valign="top" class="select">' . __('Supplier since:') . '</td>
-					<td valign="top" class="select"> <b>' . ConvertSQLDate($MyRow['suppliersince']) . '</b></td>
-					</tr>';
-			echo '<tr>
-					<td valign="top" class="select">' . __('Total Spend with this Supplier:') . '</td>
-					<td valign="top" class="select"> <b>' . locale_number_format($Row['total'], $MyRow['currdecimalplaces']) . '</b></td>
-					</tr>';
-			echo '</table>';
 		}
 	}
 }

--- a/sql/updates/45.php
+++ b/sql/updates/45.php
@@ -3,4 +3,4 @@
 ChangeColumnSize('stockact', 'stockcategory', 'VARCHAR(20)', ' NOT NULL ', '', '20');
 ChangeColumnSize('stockact', 'lastcostrollup', 'VARCHAR(20)', ' NOT NULL ', '', '20');
 
-UpdateDBNo(basename(__FILE__, '.php'), __('New table for stock item notes'));
+UpdateDBNo(basename(__FILE__, '.php'), __('Correct stock category GL account code column size to correct over-expanding in update 43'));

--- a/sql/updates/71.php
+++ b/sql/updates/71.php
@@ -1,0 +1,15 @@
+<?php
+
+CreateTable('suppliernotes', "CREATE TABLE IF NOT EXISTS `suppliernotes` (
+  `noteid` int NOT NULL AUTO_INCREMENT,
+  `supplierid` varchar(10) NOT NULL DEFAULT '0',
+  `note` text NOT NULL,
+  `date` date NOT NULL DEFAULT '1000-01-01',
+  PRIMARY KEY (`noteid`)
+)");
+
+AddConstraint('suppliernotes', 'suppliernotes_ibfk_1', 'supplierid', 'suppliers', 'supplierid');
+
+NewScript('AddSupplierNotes.php', 11);
+
+UpdateDBNo(basename(__FILE__, '.php'), __('Add supplier notes table and maintenance script'));


### PR DESCRIPTION
Resolves #989 by re-ordering page including sub-menu maintenance column items and added Supplier Notes to be consistent with Products and Customers.

<img width="1388" height="956" alt="image" src="https://github.com/user-attachments/assets/1d206ead-f66a-430d-a288-d50f8d582656" />

The Supplier Notes section only appears when a note exists.

<img width="1872" height="980" alt="image" src="https://github.com/user-attachments/assets/404fcd2c-a127-41ee-8376-e4df590f3ba3" />

