### PR TITLE
Also show pagination controls on page bottom

### DIFF
--- a/SelectProduct.php
+++ b/SelectProduct.php
@@ -680,8 +680,30 @@ if (isset($SearchResult) AND !isset($_POST['Select'])) {
 			$RowIndex = $RowIndex + 1;
 		}
 		//end of while loop
-		echo '</tbody></table>
-              </div>
+		echo '</tbody></table>';
+		if ($ListPageMax > 1) {
+			echo '<div class="centre"><br />&nbsp;&nbsp;' . $_POST['PageOffset'] . ' ' . __('of') . ' ' . $ListPageMax . ' ' . __('pages') . '. ' . __('Go to Page') . ': ';
+			echo '<select name="PageOffset">';
+			$ListPage = 1;
+			while ($ListPage <= $ListPageMax) {
+				if ($ListPage == $_POST['PageOffset']) {
+					echo '<option value="' . $ListPage . '" selected="selected">' . $ListPage . '</option>';
+				} else {
+					echo '<option value="' . $ListPage . '">' . $ListPage . '</option>';
+				}
+				$ListPage++;
+			}
+			echo '</select>
+				<input type="submit" name="Go" value="' . __('Go') . '" />
+				<input type="submit" name="Previous" value="' . __('Previous') . '" />
+				<input type="submit" name="Next" value="' . __('Next') . '" />
+				<input type="hidden" name="Keywords" value="' . $_POST['Keywords'] . '" />
+				<input type="hidden" name="StockCat" value="' . $_POST['StockCat'] . '" />
+				<input type="hidden" name="StockCode" value="' . $_POST['StockCode'] . '" />
+				<br />
+				</div>';
+		}
+		echo '</div>
               </form>
               <br />';
 	}


### PR DESCRIPTION
As a convenience to the user, also show pagination controls at the bottom of the search results (not only at the top).

I have "Maximum Number of Records to Display" in my personal profile to 50. After I've scrolled down the search results and find I need the next page, it would be convenient if there was a "Next" button at the bottom of the page.

Hopefully this will not cause an issue for those who set "Maximum Number of Records to Display" to a small number (e.g. 20, which is what @pakricard uses iirc).