### PR TITLE
fix validation lengths per schema

### DIFF
--- a/Stocks.php
+++ b/Stocks.php
@@ -142,9 +142,9 @@ if (isset($_POST['submit'])) {
 	//first off validate inputs sensible
 	$i = 1;
 
-	if (!isset($_POST['Description']) or mb_strlen($_POST['Description']) > 50 or mb_strlen($_POST['Description']) == 0) {
+	if (!isset($_POST['Description']) or mb_strlen($_POST['Description']) > 255 or mb_strlen($_POST['Description']) == 0) {
 		$InputError = 1;
-		prnMsg(__('The stock item description must be entered and be fifty characters or less long') . '. ' . __('It cannot be a zero length string either') . ' - ' . __('a description is required'), 'error');
+		prnMsg(__('The stock item description must be entered and be 255 characters or less long') . '. ' . __('It cannot be a zero length string either') . ' - ' . __('a description is required'), 'error');
 		$Errors[$i] = 'Description';
 		$i++;
 	}
@@ -157,6 +157,12 @@ if (isset($_POST['submit'])) {
 	if (mb_strlen($StockID) == 0) {
 		$InputError = 1;
 		prnMsg(__('The Stock Item code cannot be empty'), 'error');
+		$Errors[$i] = 'StockID';
+		$i++;
+	}
+	if (mb_strlen($StockID) > 64) {
+		$InputError = 1;
+		prnMsg(__('The stock item code must be 64 characters or less long'), 'error');
 		$Errors[$i] = 'StockID';
 		$i++;
 	}
@@ -173,9 +179,9 @@ if (isset($_POST['submit'])) {
 		$Errors[$i] = 'Units';
 		$i++;
 	}
-	if (mb_strlen($_POST['BarCode']) > 20) {
+	if (mb_strlen($_POST['BarCode']) > 50) {
 		$InputError = 1;
-		prnMsg(__('The barcode must be 20 characters or less long'), 'error');
+		prnMsg(__('The barcode must be 50 characters or less long'), 'error');
 		$Errors[$i] = 'BarCode';
 		$i++;
 	}
@@ -915,7 +921,7 @@ if (!isset($StockID) or $StockID == '' or isset($_POST['UpdateCategories'])) {
 		echo '<legend>', __('Create Stock Item Details'), '</legend>
 			<field>
 				<label for="StockID">' . __('Item Code') . ':</label>
-				<input type="text" ' . (in_array('StockID', $Errors) ? 'class="inputerror"' : '') . ' data-type="no-illegal-chars" autofocus="autofocus" required="required"  value="' . $StockID . '" name="StockID" size="20" maxlength="20"  title ="' . __('Input the stock code, the following characters are prohibited:') . ' \' &quot; + . &amp; \\ &gt; &lt;" placeholder="' . __('alpha-numeric only') . '" />
+				<input type="text" ' . (in_array('StockID', $Errors) ? 'class="inputerror"' : '') . ' data-type="no-illegal-chars" autofocus="autofocus" required="required"  value="' . $StockID . '" name="StockID" size="20" maxlength="64"  title ="' . __('Input the stock code, the following characters are prohibited:') . ' \' &quot; + . &amp; \\ &gt; &lt;" placeholder="' . __('alpha-numeric only') . '" />
 			</field>';
 	} else {
 		echo '<legend>', __('Edit Stock Item Details'), '</legend>
@@ -1000,7 +1006,7 @@ if (!isset($StockID) or $StockID == '' or isset($_POST['UpdateCategories'])) {
 $Description = $_POST['Description'] ?? '';
 echo '<field>
 		<label for="Description">' . __('Part Description') . ' (' . __('short') . '):</label>
-		<input ' . (in_array('Description', $Errors) ? 'class="inputerror"' : '') . ' type="text" ' . ($New == 0 ? 'autofocus="autofocus"' : '') . ' name="Description" required="required" size="52" maxlength="50" value="' . stripslashes($Description) . '" />
+		<input ' . (in_array('Description', $Errors) ? 'class="inputerror"' : '') . ' type="text" ' . ($New == 0 ? 'autofocus="autofocus"' : '') . ' name="Description" required="required" size="52" maxlength="255" value="' . stripslashes($Description) . '" />
 	</field>';
 
 foreach ($ItemDescriptionLanguagesArray as $LanguageId) {
@@ -1302,7 +1308,7 @@ echo '<field>
 $BarCode = $_POST['BarCode'] ?? '';
 echo '<field>
 		<label for="BarCode">' . __('Bar Code') . ':</label>
-		<input ' . (in_array('BarCode', $Errors) ? 'class="inputerror"' : '') . '  type="text" name="BarCode" size="22" maxlength="20" value="' . $BarCode . '" />
+		<input ' . (in_array('BarCode', $Errors) ? 'class="inputerror"' : '') . '  type="text" name="BarCode" size="22" maxlength="50" value="' . $BarCode . '" />
 	</field>';
 
 $DiscountCategory = $_POST['DiscountCategory'] ?? '';


### PR DESCRIPTION
Attempted to edit imported product and the validation test for the description failed because it was (still) 50 characters.

Requested Copilot verify validation tests vs schema and implemented recommended changes.

## Data validation conflicts in `Stocks.php` vs. `stockmaster` schema

| Field | Code validation | Schema definition | Conflict |
|---|---|---|---|
| `Description` | `Stocks.php:145`: rejects if `mb_strlen() &gt; 50`; HTML `maxlength=&quot;50&quot;` (`Stocks.php:1003`) | `varchar(255)` | Overly restrictive — valid descriptions up to 255 chars (allowed by the schema) are rejected by a hard-coded 50-char limit. |
| `BarCode` | `Stocks.php:176`: rejects if `mb_strlen() &gt; 20`, error message says &quot;20 characters&quot;; HTML `maxlength=&quot;20&quot;` (`Stocks.php:1305`) | `varchar(50)` | Overly restrictive — legitimate barcodes of 21–50 chars (valid per schema, e.g. GS1-128/EAN longer formats) are rejected. |
| `StockID` | `Stocks.php:157-168`: only checks non-empty and `ContainsIllegalCharacters()`; **no max-length check** in PHP. HTML `maxlength=&quot;20&quot;` (`Stocks.php:918`) is the only length limit, and it's client-side only | `varchar(64)` | Under-validated — server-side code never enforces the 64-char schema limit, and the only limit that exists (HTML `maxlength=20`) is far short of what the schema permits and easily bypassed (direct POST). A submitted StockID between 21–64 chars would be silently rejected by the UI, while one &gt; 64 chars sent directly would hit the DB with no PHP-side check. |

Other fields checked and found consistent (no conflict):
- `Units` — code limits to 20 chars, matches `units varchar(20)`.
- `DiscountCategory` — HTML `maxlength=&quot;2&quot;` matches `char(2)`.
- `CategoryID`/`TaxCat` — populated from `&lt;select&gt;` lists sourced directly from `stockcategory`/`taxcategories`, so values are inherently constrained by the FK relationship.
- `EOQ`, `Volume`, `GrossWeight`, `NetWeight`, `Pansize`, `ShrinkFactor` — only numeric/positive checks are needed since the schema columns are `double`/`decimal`, and that's what's tested.

**Recommended fix**: relax the `Description` (50→255) and `BarCode` (20→50) length checks (and their HTML `maxlength`/error text) to match the schema, and add an explicit `mb_strlen($StockID) &gt; 64` check (with matching HTML `maxlength=&quot;64&quot;`) so the PHP validation actually enforces the schema's `stockid varchar(64)` limit. 