### PR TITLE
preserve existing comment when editing BOM line

### DIFF
--- a/BOMs.php
+++ b/BOMs.php
@@ -404,7 +404,7 @@ if (isset($_GET['Add']) or isset($_GET['Edit'])) {
 						workcentreadded,
 						quantity,
 						autoissue,
-						remark
+						remark AS comment
 					FROM bom
 					INNER JOIN locationusers
 						ON locationusers.loccode=bom.loccode


### PR DESCRIPTION
It was intended that when editing a BOM line item the comment box is to be pre-filled with the current comment. However, it does not get pre-filled due to a code mismatch between "comment" and "remark".