### PR TITLE
fix showing item description in BOM heading

### DIFF
--- a/BOMs.php
+++ b/BOMs.php
@@ -828,9 +828,10 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 	$ErrMsg = __('Could not retrieve the description of the parent part because');
 	$Result = DB_query($SQL, $ErrMsg);
 
-	$MyRow = DB_fetch_row($Result);
+	$ParentRow = DB_fetch_array($Result);
 
-	$ParentMBflag = $MyRow[1];
+	$ParentDescription = $ParentRow['description'];
+	$ParentMBflag = $ParentRow['mbflag'];
 
 	switch ($ParentMBflag) {
 		case 'A':
@@ -866,8 +867,8 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 		echo '<table class="selection noPrint">
 				<tr>
 					<th>', __('Manufactured parent items') , ' : ';
-		while ($MyRow = DB_fetch_array($Result)) {
-			echo (($i) ? ', ' : '') , '<a href="', htmlspecialchars(basename(__FILE__) , ENT_QUOTES, 'UTF-8') , '?SelectedParent=', urlencode($MyRow['parent']) , '">', $MyRow['description'], '&nbsp;(', $MyRow['parent'], ')</a>';
+		while ($ParentItemRow = DB_fetch_array($Result)) {
+			echo (($i) ? ', ' : '') , '<a href="', htmlspecialchars(basename(__FILE__) , ENT_QUOTES, 'UTF-8') , '?SelectedParent=', urlencode($ParentItemRow['parent']) , '">', $ParentItemRow['description'], '&nbsp;(', $ParentItemRow['parent'], ')</a>';
 			++$i;
 		} //end while loop
 		echo '</th>
@@ -890,8 +891,8 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 				<tr>
 					<th>', __('Assembly parent items') , ' : ';
 		$i = 0;
-		while ($MyRow = DB_fetch_array($Result)) {
-			echo (($i) ? ', ' : '') , '<a href="', htmlspecialchars(basename(__FILE__) , ENT_QUOTES, 'UTF-8') , '?SelectedParent=', urlencode($MyRow['parent']) , '">', $MyRow['description'], '&nbsp;(', $MyRow['parent'], ')</a>';
+		while ($ParentItemRow = DB_fetch_array($Result)) {
+			echo (($i) ? ', ' : '') , '<a href="', htmlspecialchars(basename(__FILE__) , ENT_QUOTES, 'UTF-8') , '?SelectedParent=', urlencode($ParentItemRow['parent']) , '">', $ParentItemRow['description'], '&nbsp;(', $ParentItemRow['parent'], ')</a>';
 			++$i;
 		} //end while loop
 		echo '</th>
@@ -919,8 +920,8 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 				<tr>
 					<th>', __('Kit sets') , ' : ';
 		$i = 0;
-		while ($MyRow = DB_fetch_array($Result)) {
-			echo (($i) ? ', ' : '') , '<a href="', htmlspecialchars(basename(__FILE__) , ENT_QUOTES, 'UTF-8') , '?SelectedParent=', urlencode($MyRow['parent']) , '">', $MyRow['description'], '&nbsp;(', $MyRow['parent'], ')</a>';
+		while ($ParentItemRow = DB_fetch_array($Result)) {
+			echo (($i) ? ', ' : '') , '<a href="', htmlspecialchars(basename(__FILE__) , ENT_QUOTES, 'UTF-8') , '?SelectedParent=', urlencode($ParentItemRow['parent']) , '">', $ParentItemRow['description'], '&nbsp;(', $ParentItemRow['parent'], ')</a>';
 			++$i;
 		} //end while loop
 		echo '</th>
@@ -948,8 +949,8 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 				<tr>
 					<th>', __('Phantom') , ' : ';
 		$i = 0;
-		while ($MyRow = DB_fetch_array($Result)) {
-			echo (($i) ? ', ' : '') , '<a href="', htmlspecialchars(basename(__FILE__) , ENT_QUOTES, 'UTF-8') , '?SelectedParent=', urlencode($MyRow['parent']) , '">', $MyRow['description'], '&nbsp;(', $MyRow['parent'], ')</a>';
+		while ($ParentItemRow = DB_fetch_array($Result)) {
+			echo (($i) ? ', ' : '') , '<a href="', htmlspecialchars(basename(__FILE__) , ENT_QUOTES, 'UTF-8') , '?SelectedParent=', urlencode($ParentItemRow['parent']) , '">', $ParentItemRow['description'], '&nbsp;(', $ParentItemRow['parent'], ')</a>';
 			++$i;
 		} //end while loop
 		echo '</th>
@@ -964,7 +965,7 @@ if (isset($SelectedParent)) { //Parent Stock Item selected so display BOM or edi
 	echo '<input type="hidden" name="ShowAllLevels" value="', $_POST['ShowAllLevels'], '" />';
 	echo '<table>';
 	echo '<tr>
-			<th colspan="16"><b><a href="', $RootPath, '/SelectProduct.php?StockID=', urlencode($SelectedParent), '">', $SelectedParent, ' - ', $MyRow[0], ' (', $MBdesc, ') </a></b></th>
+			<th colspan="16"><b><a href="', $RootPath, '/SelectProduct.php?StockID=', urlencode($SelectedParent), '">', $SelectedParent, ' - ', $ParentDescription, ' (', $MBdesc, ') </a></b></th>
 		</tr>';
 
 	$BOMTree = array();


### PR DESCRIPTION
Fixes #1009 

The issue was caused by re-use of the MyRow variable. Under some conditions MyRow could be "cleared" resulting in the missing item description in the bom table heading. The fix preserves the selected parent values after the first query.

Following are the same three BOMs from issue report #1009 after the fix.

The top-level remains the same:

<img width="1514" height="591" alt="image" src="https://github.com/user-attachments/assets/7a6c008e-7fdf-40d0-976b-8134b254cbc1" />

but now the lower 2 levels also show the item description.

<img width="1514" height="591" alt="image" src="https://github.com/user-attachments/assets/96ec7f76-3fce-4577-833f-174d75f24d8c" />

<img width="1514" height="591" alt="image" src="https://github.com/user-attachments/assets/93bc05fb-d97c-497d-bb9a-7a69e79e6efe" />
